### PR TITLE
ci(release): push server.json pin-back over SSH deploy key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,12 +92,28 @@ jobs:
       - name: Commit pinned server.json back to main
         if: ${{ github.event.repository.private == false }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_DEPLOY_KEY_B64: ${{ secrets.RELEASE_DEPLOY_KEY_B64 }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF#refs/tags/v}"
+
+          # main is protected by a ruleset. Push over SSH with a write-enabled
+          # deploy key, which the ruleset's DeployKey bypass allows.
+          if [ -z "${RELEASE_DEPLOY_KEY_B64:-}" ]; then
+            echo "::warning::RELEASE_DEPLOY_KEY_B64 not set — skipping the server.json pin-back to main."
+            exit 0
+          fi
+          KEY_FILE="${RUNNER_TEMP}/release_deploy_key"
+          KNOWN_HOSTS_FILE="${RUNNER_TEMP}/known_hosts"
+          echo "${RELEASE_DEPLOY_KEY_B64}" | base64 --decode > "${KEY_FILE}"
+          chmod 600 "${KEY_FILE}"
+          ssh-keyscan -H github.com > "${KNOWN_HOSTS_FILE}" 2>/dev/null
+
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          git config core.sshCommand "ssh -i ${KEY_FILE} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=${KNOWN_HOSTS_FILE}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git fetch origin main
           git checkout main
           bash scripts/update-server-json-sha.sh dist/checksums.txt "${VERSION}"
@@ -107,10 +123,7 @@ jobs:
             exit 0
           fi
           git commit -m "chore: pin server.json for v${VERSION}"
-          # main is protected by a ruleset; the github-actions bot is expected to
-          # bypass it. If a push is ever rejected, warn but don't fail the release
-          # (the pinned SHAs can then be applied via a PR).
-          git push origin main || echo "::warning::Could not push pinned server.json to protected main; apply it via a PR."
+          git push origin main
 
   docker:
     name: Docker


### PR DESCRIPTION
main is now protected by the `Protect main` ruleset. The release pipeline's post-release `server.json` pin-back can no longer push with the default `GITHUB_TOKEN`, so it now authenticates with a write-enabled SSH **deploy key** (`RELEASE_DEPLOY_KEY_B64`), which the ruleset's `DeployKey` bypass allows — the same mechanism as gitlab-mcp-server.

- Deploy key added to the repo (write-enabled).
- Private key stored as the `RELEASE_DEPLOY_KEY_B64` secret.
- First PR through the new protected-main + squash-only flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to push the `server.json` pin-back over SSH with a write-enabled deploy key. This satisfies the protected `main` ruleset (DeployKey bypass) and requires the push to succeed.

- **Migration**
  - Add a write-enabled repo deploy key (public key).
  - Store the private key (base64) in `RELEASE_DEPLOY_KEY_B64`.
  - Ensure the branch ruleset allows DeployKey bypass for writes.

<sup>Written for commit a2b756f6c29affd465b5dc0fa1d16249c0c68b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

