### PR TITLE
ci(sonar): point analysis and badges at the public project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![GitHub Release](https://img.shields.io/github/v/release/jmrplens/libgen-mcp?style=flat&logo=github&label=Release)](https://github.com/jmrplens/libgen-mcp/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux%20%7C%20macOS-amd64%20%26%20arm64-lightgrey?style=flat&logo=windows-terminal&logoColor=white)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp&metric=coverage)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=coverage)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmrplens/libgen-mcp.svg)](https://pkg.go.dev/github.com/jmrplens/libgen-mcp)
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-1f9cf0?style=flat&logo=cursor&logoColor=white)](https://cursor.directory/plugins/libgen-mcp)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 # SonarCloud configuration for libgen-mcp
 
-sonar.projectKey=jmrplens_libgen-mcp
+sonar.projectKey=jmrplens_libgen-mcp2
 sonar.organization=jmrplens
 sonar.projectName=libgen-mcp
 


### PR DESCRIPTION
The repository is now public, so SonarCloud analysis moved to the public project `jmrplens_libgen-mcp2` (SonarCloud auto-analysis disabled; analysis runs from CI on PRs and main). This repoints `sonar-project.properties` and the README Quality Gate / Coverage badges to the new project key. The old private project was deleted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point SonarCloud analysis and README badges to the public project `jmrplens_libgen-mcp2` so results reflect the public repo. Updated `sonar-project.properties` projectKey and the Quality Gate/Coverage badges; analysis runs via CI on PRs and main (auto-analysis off).

<sup>Written for commit 3d9473222895cc6ba875022d4c4c41c9e2c084b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

