### PR TITLE
refactor+test: resolve all SonarCloud issues and raise coverage to 99%

### DIFF
--- a/cmd/format_md_tables/main.go
+++ b/cmd/format_md_tables/main.go
@@ -68,19 +68,34 @@ func run(args []string, stdout io.Writer) error {
 		return err
 	}
 
+	changed, err := formatFiles(rootFS, files, opts.check)
+	if err != nil {
+		return err
+	}
+
+	return reportResults(stdout, changed, opts.check)
+}
+
+// formatFiles formats each file in turn and returns the display paths of those
+// that changed (in check mode, those that would change).
+func formatFiles(rootFS *os.Root, files []string, check bool) ([]string, error) {
 	changed := make([]string, 0)
 	for _, file := range files {
-		var fileChanged bool
-		fileChanged, err = formatMarkdownTableFile(rootFS, file, opts.check)
+		fileChanged, err := formatMarkdownTableFile(rootFS, file, check)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if fileChanged {
 			changed = append(changed, displayPath(file))
 		}
 	}
+	return changed, nil
+}
 
-	if opts.check {
+// reportResults writes the run summary to stdout. In check mode it returns an
+// error when any table is out of date; otherwise it lists the formatted files.
+func reportResults(stdout io.Writer, changed []string, check bool) error {
+	if check {
 		if len(changed) > 0 {
 			return fmt.Errorf("markdown tables are out of date in %d file(s): %s", len(changed), strings.Join(changed, ", "))
 		}

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -194,15 +194,7 @@ func writeLLMSTxt(version string, toolList []*mcp.Tool, checkOnly bool) error {
 
 	b.WriteString("Installing for an AI assistant (headless):\n\n")
 	b.WriteString("If you are an AI assistant setting this up for a user from just this repository URL, write the MCP client configuration directly. No credentials are required. The recommended install is the prebuilt static binary (no dependencies): download the release asset for the user's OS and architecture from the Releases page and point `command` at its absolute path. Cursor, Claude Desktop, and Claude Code use an `mcpServers` key; VS Code and GitHub Copilot use a `servers` key (each entry also sets `\"type\": \"stdio\"`). The `mcpServers` form with the native binary:\n\n")
-	b.WriteString("```json\n")
-	b.WriteString("{\n")
-	b.WriteString("  \"mcpServers\": {\n")
-	b.WriteString("    \"libgen\": {\n")
-	b.WriteString("      \"command\": \"/usr/local/bin/libgen-mcp\"\n")
-	b.WriteString("    }\n")
-	b.WriteString("  }\n")
-	b.WriteString("}\n")
-	b.WriteString("```\n\n")
+	writeMcpServersJSON(&b, "/usr/local/bin/libgen-mcp", nil)
 	b.WriteString("For VS Code / GitHub Copilot, use the `servers` key instead of `mcpServers` and add `\"type\": \"stdio\"` to the `libgen` entry.\n\n")
 	b.WriteString("Docker alternative (no download; pulls the image on first run and runs over stdio) — useful when you cannot determine the user's OS and architecture: set `command` to `docker` and `args` to `[\"run\", \"-i\", \"--rm\", \"ghcr.io/jmrplens/libgen-mcp:latest\"]`.\n\n")
 	b.WriteString("Claude Code (CLI): `claude mcp add libgen -- /usr/local/bin/libgen-mcp` (native binary), or `claude mcp add libgen -- docker run -i --rm ghcr.io/jmrplens/libgen-mcp:latest` (Docker).\n\n")
@@ -456,27 +448,38 @@ func writeLLMSFullInstall(b *strings.Builder) {
 	b.WriteString("## Install (headless)\n\n")
 	b.WriteString("No credentials are required. The recommended install is the prebuilt static binary (no dependencies): download the release asset for the user's OS and architecture from the Releases page and point `command` at its absolute path. Cursor, Claude Desktop, and Claude Code use an `mcpServers` key; VS Code and GitHub Copilot use a `servers` key (each entry also sets `\"type\": \"stdio\"`).\n\n")
 	b.WriteString("Native binary (`mcpServers` form):\n\n")
-	b.WriteString("```json\n")
-	b.WriteString("{\n")
-	b.WriteString("  \"mcpServers\": {\n")
-	b.WriteString("    \"libgen\": {\n")
-	b.WriteString("      \"command\": \"/usr/local/bin/libgen-mcp\"\n")
-	b.WriteString("    }\n")
-	b.WriteString("  }\n")
-	b.WriteString("}\n")
-	b.WriteString("```\n\n")
+	writeMcpServersJSON(b, "/usr/local/bin/libgen-mcp", nil)
 	b.WriteString("Docker alternative (no download; pulls the image on first run and runs over stdio) — useful when you cannot determine the user's OS and architecture:\n\n")
+	writeMcpServersJSON(b, "docker", []string{"run", "-i", "--rm", "ghcr.io/jmrplens/libgen-mcp:latest"})
+	b.WriteString("For VS Code / GitHub Copilot, use the `servers` key instead of `mcpServers` and add `\"type\": \"stdio\"` to the `libgen` entry.\n\n")
+}
+
+// writeMcpServersJSON writes a fenced ```json block holding an `mcpServers`
+// entry for the libgen server, followed by a blank line. When args is empty
+// only a `command` field is emitted; otherwise an `args` array is appended.
+// Centralizing the block keeps the generated files free of duplicated literals.
+func writeMcpServersJSON(b *strings.Builder, command string, args []string) {
 	b.WriteString("```json\n")
 	b.WriteString("{\n")
 	b.WriteString("  \"mcpServers\": {\n")
 	b.WriteString("    \"libgen\": {\n")
-	b.WriteString("      \"command\": \"docker\",\n")
-	b.WriteString("      \"args\": [\"run\", \"-i\", \"--rm\", \"ghcr.io/jmrplens/libgen-mcp:latest\"]\n")
+	if len(args) == 0 {
+		fmt.Fprintf(b, "      \"command\": %q\n", command)
+	} else {
+		fmt.Fprintf(b, "      \"command\": %q,\n", command)
+		b.WriteString("      \"args\": [")
+		for i, arg := range args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(b, "%q", arg)
+		}
+		b.WriteString("]\n")
+	}
 	b.WriteString("    }\n")
 	b.WriteString("  }\n")
 	b.WriteString("}\n")
 	b.WriteString("```\n\n")
-	b.WriteString("For VS Code / GitHub Copilot, use the `servers` key instead of `mcpServers` and add `\"type\": \"stdio\"` to the `libgen` entry.\n\n")
 }
 
 func writeLLMSFullTool(b *strings.Builder, tool *mcp.Tool) {
@@ -530,14 +533,7 @@ func writeInputSchema(b *strings.Builder, schema any) {
 		return
 	}
 
-	required := map[string]bool{}
-	if reqList, isSlice := schemaMap["required"].([]any); isSlice {
-		for _, r := range reqList {
-			if s, isStr := r.(string); isStr {
-				required[s] = true
-			}
-		}
-	}
+	required := schemaRequiredSet(schemaMap)
 
 	b.WriteString("**Parameters:**\n\n")
 	names := make([]string, 0, len(props))
@@ -551,20 +547,43 @@ func writeInputSchema(b *strings.Builder, schema any) {
 		if !isMap {
 			continue
 		}
-		typ := schemaTypeLabel(prop)
-		desc, _ := prop["description"].(string)
-		desc = strings.TrimSuffix(desc, ",required")
-		req := ""
-		if required[name] {
-			req = " (required)"
-		}
-		if desc != "" {
-			fmt.Fprintf(b, "- `%s` (%s)%s: %s\n", name, typ, req, desc)
-		} else {
-			fmt.Fprintf(b, "- `%s` (%s)%s\n", name, typ, req)
-		}
+		writeSchemaProperty(b, name, prop, required[name])
 	}
 	b.WriteString("\n")
+}
+
+// schemaRequiredSet returns the set of property names listed in the schema's
+// "required" array. It returns an empty set when the field is absent or malformed.
+func schemaRequiredSet(schemaMap map[string]any) map[string]bool {
+	required := map[string]bool{}
+	reqList, ok := schemaMap["required"].([]any)
+	if !ok {
+		return required
+	}
+	for _, r := range reqList {
+		if s, isStr := r.(string); isStr {
+			required[s] = true
+		}
+	}
+	return required
+}
+
+// writeSchemaProperty writes one parameter bullet describing a single schema
+// property, marking it "(required)" when required and appending its description
+// when present.
+func writeSchemaProperty(b *strings.Builder, name string, prop map[string]any, required bool) {
+	typ := schemaTypeLabel(prop)
+	desc, _ := prop["description"].(string)
+	desc = strings.TrimSuffix(desc, ",required")
+	req := ""
+	if required {
+		req = " (required)"
+	}
+	if desc != "" {
+		fmt.Fprintf(b, "- `%s` (%s)%s: %s\n", name, typ, req, desc)
+	} else {
+		fmt.Fprintf(b, "- `%s` (%s)%s\n", name, typ, req)
+	}
 }
 
 func schemaTypeLabel(schema map[string]any) string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -131,11 +131,11 @@ func serveHTTP(ctx context.Context, server *mcp.Server, httpAddr string) error {
 		}
 		return err
 	case <-ctx.Done():
-		// ctx is already canceled here, so the shutdown deadline must derive from
-		// a fresh context rather than the (dead) parent.
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
+		// ctx is already canceled here, so derive the shutdown deadline from a
+		// cancellation-stripped copy of ctx (preserving its values) rather than
+		// the dead parent, keeping graceful shutdown bounded by httpShutdownTimeout.
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), httpShutdownTimeout)
 		defer cancel()
-		//nolint:contextcheck // graceful shutdown intentionally uses a fresh, deadline-bounded context.
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			return err
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,6 +182,27 @@ func envFloat(key string, dst *float64) error {
 // Validate checks that the configuration values are within range and that the
 // mirror and download directory are usable.
 func (c *Config) Validate() error {
+	if err := c.validateRanges(); err != nil {
+		return err
+	}
+	if err := validateUnpaywallEmail(c.UnpaywallEmail); err != nil {
+		return err
+	}
+	if err := validateScihubHosts(c.ScihubHosts); err != nil {
+		return err
+	}
+	if err := validateSources(c.Sources); err != nil {
+		return err
+	}
+	if err := validateMirror(c.Mirror); err != nil {
+		return err
+	}
+	return validateDownloadDir(c.DownloadDir)
+}
+
+// validateRanges checks that the numeric configuration fields fall within their
+// allowed bounds, reporting the first out-of-range field in declaration order.
+func (c *Config) validateRanges() error {
 	if c.RateRPS <= 0 || c.RateRPS > 20 {
 		return fmt.Errorf("LIBGEN_MCP_RATE_RPS must be in (0, 20], got %v", c.RateRPS)
 	}
@@ -200,19 +221,7 @@ func (c *Config) Validate() error {
 	if c.Timeout <= 0 || c.Timeout > maxTimeout {
 		return fmt.Errorf("LIBGEN_MCP_TIMEOUT must be in (0, %v], got %v", maxTimeout, c.Timeout)
 	}
-	if err := validateUnpaywallEmail(c.UnpaywallEmail); err != nil {
-		return err
-	}
-	if err := validateScihubHosts(c.ScihubHosts); err != nil {
-		return err
-	}
-	if err := validateSources(c.Sources); err != nil {
-		return err
-	}
-	if err := validateMirror(c.Mirror); err != nil {
-		return err
-	}
-	return validateDownloadDir(c.DownloadDir)
+	return nil
 }
 
 // validateUnpaywallEmail applies a basic sanity check to the Unpaywall contact

--- a/internal/libgen/client_test.go
+++ b/internal/libgen/client_test.go
@@ -315,3 +315,35 @@ func TestCooldownSkip(t *testing.T) {
 		t.Errorf("goodHits = %d, want 2", got)
 	}
 }
+
+// TestDoRequestBuildError covers doRequest's request-construction failure: a mirror
+// base carrying a control character cannot be built into a request.
+func TestDoRequestBuildError(t *testing.T) {
+	c := newTestClient(staticMirrors{"http://\x7f"})
+	if _, _, err := c.get(context.Background(), "/index.php", nil); err == nil {
+		t.Error("get should fail when the request URL is invalid")
+	}
+}
+
+// TestDoRequestBodyReadError covers doRequest's 200-with-read-error branch: a
+// mirror that declares more bytes than it sends, then closes, makes reading the
+// body fail even though the status is 200.
+func TestDoRequestBodyReadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\nshort"))
+		_ = conn.Close()
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	if _, _, err := c.get(context.Background(), "/index.php", nil); err == nil {
+		t.Error("get should fail when a 200 body cannot be fully read")
+	}
+}

--- a/internal/libgen/details_test.go
+++ b/internal/libgen/details_test.go
@@ -107,3 +107,80 @@ func TestDetailsNotFound(t *testing.T) {
 		t.Error("nonexistent md5 should fail")
 	}
 }
+
+// TestDetailsByMD5GetError covers the transport-error branch: when the json.php
+// request cannot be made, DetailsByMD5 surfaces the error.
+func TestDetailsByMD5GetError(t *testing.T) {
+	c := newTestClient(staticMirrors{"http://127.0.0.1:0"})
+	if _, _, err := c.DetailsByMD5(context.Background(), "87a4ebdaf21fa6cc70009a3dd63194ee"); err == nil {
+		t.Error("DetailsByMD5 should fail when the request cannot be made")
+	}
+}
+
+// TestDetailsByMD5DecodeError covers the decode-error branch: a json.php body that
+// is neither an object map nor an empty array surfaces as an error.
+func TestDetailsByMD5DecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json at all"))
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	if _, _, err := c.DetailsByMD5(context.Background(), "87a4ebdaf21fa6cc70009a3dd63194ee"); err == nil {
+		t.Error("DetailsByMD5 should fail on a malformed json.php body")
+	}
+}
+
+// TestDetailsByMD5NonMapEdition covers the editions loop's skip branch: an entry
+// in the editions map that is not an object is ignored, leaving no related edition.
+func TestDetailsByMD5NonMapEdition(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"file123":{"md5":"abc","editions":{"0":"not-an-object"}}}`))
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	file, edition, err := c.DetailsByMD5(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("DetailsByMD5() error = %v", err)
+	}
+	if edition != nil {
+		t.Errorf("edition = %v, want nil (non-object edition skipped)", edition)
+	}
+	if file["md5"] != "abc" {
+		t.Errorf("file.md5 = %v, want abc", file["md5"])
+	}
+}
+
+// TestDetailsByIDFileObject covers the object == "f" branch, which sets addkeys on
+// the query, using the file fixture.
+func TestDetailsByIDFileObject(t *testing.T) {
+	srv := jsonFixtureServer(t)
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	rec, err := c.DetailsByID(context.Background(), "f", "138281637")
+	if err != nil {
+		t.Fatalf("DetailsByID(f) error = %v", err)
+	}
+	if len(rec) == 0 {
+		t.Error("DetailsByID(f) returned an empty record")
+	}
+}
+
+// TestDetailsByIDGetError covers the transport-error branch of DetailsByID.
+func TestDetailsByIDGetError(t *testing.T) {
+	c := newTestClient(staticMirrors{"http://127.0.0.1:0"})
+	if _, err := c.DetailsByID(context.Background(), "e", "1"); err == nil {
+		t.Error("DetailsByID should fail when the request cannot be made")
+	}
+}
+
+// TestDetailsByIDDecodeError covers the decode-error branch of DetailsByID.
+func TestDetailsByIDDecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("garbage"))
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	if _, err := c.DetailsByID(context.Background(), "e", "1"); err == nil {
+		t.Error("DetailsByID should fail on a malformed json.php body")
+	}
+}

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -561,6 +561,33 @@ type streamOpts struct {
 	progress ProgressFunc
 }
 
+// openPartForStream opens (or creates) the partial file at partPath for
+// streaming and reports how many bytes are already present. On a resume it
+// re-hashes the bytes already on disk into digest so the final digest covers the
+// whole file and leaves the file offset at the end, ready to append; on a fresh
+// download it truncates any stale partial and reports a zero starting size. On a
+// rehash failure it keeps the partial so a later call can resume.
+func openPartForStream(partPath string, opts streamOpts, digest io.Writer) (*os.File, int64, error) {
+	flag := os.O_RDWR | os.O_CREATE
+	if !opts.resume {
+		flag |= os.O_TRUNC // restart: discard any stale partial
+	}
+	f, err := os.OpenFile(partPath, flag, 0o600)
+	if err != nil {
+		return nil, 0, err
+	}
+	if !opts.resume {
+		return f, 0, nil
+	}
+	// Re-hash the bytes already on disk so the digest covers the whole file;
+	// io.Copy also leaves the file offset at the end, ready to append.
+	if _, rerr := io.Copy(digest, f); rerr != nil {
+		f.Close()
+		return nil, 0, fmt.Errorf("rehashing partial: %w", rerr) // keep .part for a later resume
+	}
+	return f, opts.existingSize, nil
+}
+
 // streamToPartAndVerify streams body into the stable partial at partPath while
 // computing the MD5 of the whole file, then (when opts.verify) checks the digest
 // against wantMD5 and atomically renames the partial to dest on success. It
@@ -578,26 +605,10 @@ type streamOpts struct {
 // transfer the partial is deleted; on a transient failure (network drop, short
 // read) it is kept so a later call can resume from where it stopped.
 func (c *Client) streamToPartAndVerify(partPath, dest, wantMD5 string, body io.Reader, opts streamOpts) (int64, error) {
-	flag := os.O_RDWR | os.O_CREATE
-	var startSize int64
-	if opts.resume {
-		startSize = opts.existingSize
-	} else {
-		flag |= os.O_TRUNC // restart: discard any stale partial
-	}
-	f, err := os.OpenFile(partPath, flag, 0o600)
+	digest := cryptomd5.New() //nolint:gosec // integrity match against the LibGen-provided md5.
+	f, startSize, err := openPartForStream(partPath, opts, digest)
 	if err != nil {
 		return 0, err
-	}
-
-	digest := cryptomd5.New() //nolint:gosec // integrity match against the LibGen-provided md5.
-	if opts.resume {
-		// Re-hash the bytes already on disk so the digest covers the whole file;
-		// io.Copy also leaves the file offset at the end, ready to append.
-		if _, rerr := io.Copy(digest, f); rerr != nil {
-			f.Close()
-			return 0, fmt.Errorf("rehashing partial: %w", rerr) // keep .part for a later resume
-		}
 	}
 
 	// countingWriter aborts if the total size exceeds the cap; this defends

--- a/internal/libgen/download_coverage_test.go
+++ b/internal/libgen/download_coverage_test.go
@@ -1,0 +1,336 @@
+package libgen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// errReader is an io.Reader that always fails, used to drive the read-error
+// branches of body-consuming helpers.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("simulated read error") }
+
+// failWriter is an io.Writer that always fails, used to drive the write-error
+// branch of the resume re-hash in openPartForStream.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, errors.New("simulated write error") }
+
+// TestParseContentRangeStart covers every branch of the Content-Range parser: a
+// well-formed header, a wrong prefix, a missing dash, an unparseable offset and
+// an empty header.
+func TestParseContentRangeStart(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+		ok   bool
+	}{
+		{"bytes 100-199/200", 100, true},
+		{"bytes 0-0/1", 0, true},
+		{"items 0-1/2", 0, false},    // wrong unit prefix
+		{"bytes 100", 0, false},      // no dash
+		{"bytes abc-9/10", 0, false}, // unparseable start
+		{"", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseContentRangeStart(tc.in)
+		if got != tc.want || ok != tc.ok {
+			t.Errorf("parseContentRangeStart(%q) = (%d, %v), want (%d, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
+// TestFilenameFromDisposition covers the empty header, a valid attachment
+// filename, a malformed media type (ParseMediaType error) and a header with no
+// filename parameter.
+func TestFilenameFromDisposition(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{`attachment; filename="book.pdf"`, "book.pdf"},
+		{"attachment; badparam", ""}, // parameter without '=' is malformed
+		{"attachment", ""},           // no filename parameter
+	}
+	for _, tc := range cases {
+		if got := filenameFromDisposition(tc.in); got != tc.want {
+			t.Errorf("filenameFromDisposition(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestChooseFileName covers the name-selection precedence and, in particular, the
+// fallback-extension branch (appending the source's extension when the chosen
+// name carries none) and its skip when a name already has an extension.
+func TestChooseFileName(t *testing.T) {
+	meta := &FileMeta{Author: "A", Title: "T", Year: "2020", Ext: "epub"}
+	cases := []struct {
+		name        string
+		filename    string
+		disposition string
+		meta        *FileMeta
+		md5         string
+		ext         string
+		want        string
+	}{
+		{"explicit filename wins", "explicit.pdf", "disp.pdf", meta, "md5", "pdf", "explicit.pdf"},
+		{"disposition when no filename", "", "disp.pdf", meta, "md5", "pdf", "disp.pdf"},
+		{"meta when no filename or disposition", "", "", meta, "md5", "pdf", "A - T (2020).epub"},
+		{"md5 with fallback extension", "", "", nil, "abcdef", "pdf", "abcdef.pdf"},
+		{"fallback extension skipped when name has one", "have.mobi", "", nil, "md5", "pdf", "have.mobi"},
+		{"no extension and no fallback", "", "", nil, "deadbeef", "", "deadbeef"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chooseFileName(tc.filename, tc.disposition, tc.meta, tc.md5, tc.ext)
+			if got != tc.want {
+				t.Errorf("chooseFileName() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldEmit covers the elapsed-interval branch, the byte-advance branch, and
+// the throttled (no emit) case of the progress writer.
+func TestShouldEmit(t *testing.T) {
+	if pw := (&progressWriter{lastAt: time.Now().Add(-time.Hour)}); !pw.shouldEmit() {
+		t.Error("shouldEmit() = false after the progress interval elapsed, want true")
+	}
+	if pw := (&progressWriter{lastAt: time.Now(), total: 100, done: 10, lastDone: 0}); !pw.shouldEmit() {
+		t.Error("shouldEmit() = false after advancing a full fraction, want true")
+	}
+	if pw := (&progressWriter{lastAt: time.Now(), total: 100, done: 1, lastDone: 0}); pw.shouldEmit() {
+		t.Error("shouldEmit() = true while recent and barely advanced, want false")
+	}
+}
+
+// expectFetchFileError fails the test if fetchFile unexpectedly succeeded, closing
+// the body if one came back so the check is body-leak clean.
+func expectFetchFileError(t *testing.T, resp *http.Response, err error, msg string) {
+	t.Helper()
+	if err == nil {
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		t.Error(msg)
+	}
+}
+
+// TestFetchFileLimiterError covers fetchFile's rate-limiter guard: a limiter with
+// a zero burst can never grant a token, so Wait fails before any request is built.
+func TestFetchFileLimiterError(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	c.limiter = rate.NewLimiter(rate.Every(time.Hour), 0)
+	resp, err := c.fetchFile(context.Background(), "http://127.0.0.1:0/x", 0, nil)
+	expectFetchFileError(t, resp, err, "fetchFile should fail when the limiter cannot grant a token")
+}
+
+// TestFetchFileRequestErrors covers fetchFile's request-construction failure (an
+// invalid URL) and its transport failure (a dead address).
+func TestFetchFileRequestErrors(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	resp, err := c.fetchFile(context.Background(), "http://\x7f/x", 0, nil)
+	expectFetchFileError(t, resp, err, "fetchFile with an invalid URL should fail at request construction")
+	resp, err = c.fetchFile(context.Background(), "http://127.0.0.1:0/x", 0, nil)
+	expectFetchFileError(t, resp, err, "fetchFile against a dead address should fail at transport")
+}
+
+// TestFetchFileAppliesHeadersAndRange covers the source-header loop and the resume
+// Range header: fetchFile must forward a supplied header and, when resuming, add a
+// bytes= Range for the CDN.
+func TestFetchFileAppliesHeadersAndRange(t *testing.T) {
+	var gotReferer, gotRange string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReferer = r.Header.Get("Referer")
+		gotRange = r.Header.Get("Range")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(staticMirrors{})
+	resp, err := c.fetchFile(context.Background(), srv.URL, 5, http.Header{"Referer": {"http://example.test/"}})
+	if err != nil {
+		t.Fatalf("fetchFile() error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if gotReferer != "http://example.test/" {
+		t.Errorf("Referer = %q, want %q", gotReferer, "http://example.test/")
+	}
+	if gotRange != "bytes=5-" {
+		t.Errorf("Range = %q, want %q", gotRange, "bytes=5-")
+	}
+}
+
+// TestValidateFileResponsePeekError covers validateFileResponse's peek-error
+// branch: a body that fails on read (not EOF) surfaces as an error.
+func TestValidateFileResponsePeekError(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	resp := &http.Response{Header: http.Header{}, Body: io.NopCloser(errReader{})}
+	if _, _, err := c.validateFileResponse(resp, -1); err == nil {
+		t.Error("validateFileResponse should surface a body read error")
+	}
+}
+
+// TestStreamToPartOpenError covers openPartForStream's OpenFile failure (and its
+// propagation through streamToPartAndVerify): a partial path that is an existing
+// directory cannot be opened for writing.
+func TestStreamToPartOpenError(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	dir := t.TempDir()
+	_, err := c.streamToPartAndVerify(dir, filepath.Join(dir, "dest"), "", strings.NewReader("x"), streamOpts{})
+	if err == nil {
+		t.Error("streamToPartAndVerify should fail when the partial path is a directory")
+	}
+}
+
+// TestOpenPartForStreamRehashError covers the resume re-hash failure: when copying
+// the existing bytes into the digest fails, the partial is closed and the error is
+// wrapped for a later resume.
+func TestOpenPartForStreamRehashError(t *testing.T) {
+	dir := t.TempDir()
+	part := filepath.Join(dir, "p.part")
+	if err := os.WriteFile(part, []byte("existing bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openPartForStream(part, streamOpts{resume: true, existingSize: 14}, failWriter{}); err == nil {
+		t.Error("openPartForStream should fail when re-hashing the partial errors")
+	}
+}
+
+// TestStreamToPartTruncated covers the short-read branch: when contentLength is
+// known but the body delivers fewer bytes, the transfer is a truncated download
+// and the partial is kept so a later call can resume.
+func TestStreamToPartTruncated(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	dir := t.TempDir()
+	part := filepath.Join(dir, "p.part")
+	_, err := c.streamToPartAndVerify(part, filepath.Join(dir, "dest"), "", strings.NewReader("short"), streamOpts{contentLength: 999})
+	if err == nil {
+		t.Fatal("streamToPartAndVerify should fail on a truncated transfer")
+	}
+	if _, statErr := os.Stat(part); os.IsNotExist(statErr) {
+		t.Error("a truncated transfer should keep the .part for a later resume")
+	}
+}
+
+// TestSanitizeFilenameLong covers the length-cap branch: an over-long name is
+// truncated to 200 runes.
+func TestSanitizeFilenameLong(t *testing.T) {
+	got := sanitizeFilename(strings.Repeat("a", 250))
+	if n := len([]rune(got)); n != 200 {
+		t.Errorf("sanitizeFilename(len 250) has %d runes, want 200", n)
+	}
+}
+
+// TestResolveGetURLNoLink covers ResolveGetURL's extraction-failure branch: an
+// ads.php page without a get.php link yields an error.
+func TestResolveGetURLNoLink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "<html><body>no download link here</body></html>")
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	if _, _, err := c.ResolveGetURL(context.Background(), "87a4ebdaf21fa6cc70009a3dd63194ee"); err == nil {
+		t.Error("ResolveGetURL should fail when ads.php carries no get.php link")
+	}
+}
+
+// TestDownloadItemNoSupportingSource covers the "no source supports the item"
+// branch: an item with neither an md5 nor a DOI is claimed by no configured
+// source, so DownloadItem fails before any resolution is attempted.
+func TestDownloadItemNoSupportingSource(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	_, err := c.DownloadItem(context.Background(), Item{}, t.TempDir(), "")
+	if err == nil {
+		t.Fatal("DownloadItem with no supporting source should fail")
+	}
+	if !strings.Contains(err.Error(), "no download source supports") {
+		t.Errorf("err = %v, want a 'no download source supports' message", err)
+	}
+}
+
+// TestStreamResolvedFetchError covers streamResolved's fetch-failure branch: when
+// the resolved file URL is unreachable, the download fails.
+func TestStreamResolvedFetchError(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	c.sources = []DownloadSource{stubSource{name: "dead", supports: true, resolved: Resolved{FileURL: "http://127.0.0.1:0/f"}}}
+	if _, err := c.DownloadItem(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}, t.TempDir(), ""); err == nil {
+		t.Error("download should fail when the resolved file URL is unreachable")
+	}
+}
+
+// TestStreamResolvedMkdirError covers streamResolved's MkdirAll-failure branch:
+// when the destination directory cannot be created (a regular file blocks the
+// path), the download fails after a valid transfer is fetched and validated.
+func TestStreamResolvedMkdirError(t *testing.T) {
+	payload := []byte("%PDF-1.4 mkdir clash payload")
+	cdn := fileCDN(t, payload, "")
+	defer cdn.Close()
+	c := newTestClient(staticMirrors{})
+	c.sources = []DownloadSource{stubSource{name: "cdn", supports: true, resolved: Resolved{FileURL: cdn.URL + "/file"}}}
+
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	badDir := filepath.Join(blocker, "sub") // a file, not a directory, sits in the path
+	if _, err := c.DownloadItem(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}, badDir, ""); err == nil {
+		t.Error("download should fail when the destination directory cannot be created")
+	}
+}
+
+// cancelingSource is a DownloadSource that cancels the download context while
+// resolving, then fails, letting a test drive DownloadItem's cancellation-aware
+// break out of the source loop.
+type cancelingSource struct{ cancel context.CancelFunc }
+
+func (cancelingSource) Name() string       { return "canceling" }
+func (cancelingSource) Supports(Item) bool { return true }
+func (s cancelingSource) Resolve(context.Context, Item) (Resolved, error) {
+	s.cancel()
+	return Resolved{}, errors.New("boom")
+}
+
+// trackingSource records whether it was resolved, so a test can assert a later
+// source in the chain was never reached.
+type trackingSource struct{ ran *bool }
+
+func (trackingSource) Name() string       { return "tracking" }
+func (trackingSource) Supports(Item) bool { return true }
+func (s trackingSource) Resolve(context.Context, Item) (Resolved, error) {
+	*s.ran = true
+	return Resolved{}, errors.New("nope")
+}
+
+// TestDownloadItemContextCanceledBreak covers the loop's cancellation guard: once
+// the context is canceled, DownloadItem stops trying further sources rather than
+// pressing on. The second source must never run.
+func TestDownloadItemContextCanceledBreak(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	ctx, cancel := context.WithCancel(context.Background())
+	var secondRan bool
+	c.sources = []DownloadSource{
+		cancelingSource{cancel: cancel},
+		trackingSource{ran: &secondRan},
+	}
+	if _, err := c.DownloadItem(ctx, Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}, t.TempDir(), ""); err == nil {
+		t.Fatal("DownloadItem should fail after the context is canceled")
+	}
+	if secondRan {
+		t.Error("the second source should not have been reached after cancellation")
+	}
+}

--- a/internal/libgen/search.go
+++ b/internal/libgen/search.go
@@ -257,19 +257,35 @@ func parseIdentifiers(cell *html.Node, r *Result) {
 			continue
 		}
 		if r.ISBNs == nil { // second edition.php link: identifiers
-			for s := range strings.SplitSeq(nodeText(a), ";") {
-				if s = strings.TrimSpace(s); s != "" {
-					r.ISBNs = append(r.ISBNs, s)
-				}
-			}
+			r.ISBNs = splitISBNs(nodeText(a))
 		}
 	}
+	if t := badgeType(cell); t != "" {
+		r.Type = t
+	}
+}
+
+// splitISBNs splits a semicolon-separated identifier string into its non-empty,
+// trimmed parts. It returns nil when no identifier is present.
+func splitISBNs(text string) []string {
+	var out []string
+	for s := range strings.SplitSeq(text, ";") {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// badgeType returns the trimmed text of the first span in cell whose class marks
+// it as the primary badge (the result type), or "" when none is present.
+func badgeType(cell *html.Node) string {
 	for _, s := range elements(cell, "span") {
 		if strings.Contains(attr(s, "class"), "badge-primary") {
-			r.Type = strings.TrimSpace(nodeText(s))
-			break
+			return strings.TrimSpace(nodeText(s))
 		}
 	}
+	return ""
 }
 
 // parseDownloads extracts the md5 and download options from the last cell.

--- a/internal/libgen/search_test.go
+++ b/internal/libgen/search_test.go
@@ -470,6 +470,90 @@ func TestPaginatorReachUnparsable(t *testing.T) {
 	}
 }
 
+// TestParseSearchReaderError covers ParseSearch's html.Parse failure: a reader
+// that errors makes the parse fail.
+func TestParseSearchReaderError(t *testing.T) {
+	if _, err := ParseSearch(errReader{}, "https://libgen.li"); err == nil {
+		t.Error("ParseSearch should fail when the reader errors")
+	}
+}
+
+// TestClientSearchLayoutError covers Search's parse-error branch: a page with no
+// results table (and a non-zero counter) is a layout change surfaced by Search.
+func TestClientSearchLayoutError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body><p>no results table</p></body></html>"))
+	}))
+	defer srv.Close()
+	c := newTestClient(staticMirrors{srv.URL})
+	if _, _, err := c.Search(context.Background(), SearchParams{Query: "golang"}); err == nil {
+		t.Error("Search should surface a layout-changed parse error")
+	}
+}
+
+// TestParseSearchRowWithoutMD5OrTitle covers parseRow's drop branch (a row with
+// the required cells but neither md5 nor title yields no Result) and badgeType's
+// empty branch (an identifier cell with no primary badge).
+func TestParseSearchRowWithoutMD5OrTitle(t *testing.T) {
+	const doc = `<html><body><table id="tablelibgen"><tr>` +
+		`<td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>` +
+		`</tr></table></body></html>`
+	page, err := ParseSearch(strings.NewReader(doc), "https://libgen.li")
+	if err != nil {
+		t.Fatalf("ParseSearch() error = %v", err)
+	}
+	if len(page.Results) != 0 {
+		t.Errorf("Results = %d, want 0 (row without md5/title dropped)", len(page.Results))
+	}
+}
+
+// TestParseSearchRowISBNsAndType covers splitISBNs (trimming, and skipping empty
+// segments) and badgeType's non-empty branch, driven through a full results row.
+func TestParseSearchRowISBNsAndType(t *testing.T) {
+	const doc = `<html><body><table id="tablelibgen"><tr>` +
+		`<td><a href="edition.php?id=42">The Title</a>` +
+		`<a href="edition.php?id=42"> 978-1; 978-2 ; ; 978-3 </a>` +
+		`<span class="badge badge-primary">book</span></td>` +
+		`<td>Author</td><td>Pub</td><td>2020</td><td>en</td><td>300</td>` +
+		`<td></td><td>pdf</td>` +
+		`<td><a href="/ads.php?md5=87a4ebdaf21fa6cc70009a3dd63194ee" title="dl">libgen</a></td>` +
+		`</tr></table></body></html>`
+	page, err := ParseSearch(strings.NewReader(doc), "https://libgen.li")
+	if err != nil {
+		t.Fatalf("ParseSearch() error = %v", err)
+	}
+	if len(page.Results) != 1 {
+		t.Fatalf("Results = %d, want 1", len(page.Results))
+	}
+	r := page.Results[0]
+	if r.Title != "The Title" {
+		t.Errorf("Title = %q, want %q", r.Title, "The Title")
+	}
+	if r.EditionID != "42" {
+		t.Errorf("EditionID = %q, want %q", r.EditionID, "42")
+	}
+	if r.Type != "book" {
+		t.Errorf("Type = %q, want %q", r.Type, "book")
+	}
+	want := []string{"978-1", "978-2", "978-3"}
+	if len(r.ISBNs) != len(want) {
+		t.Fatalf("ISBNs = %v, want %v", r.ISBNs, want)
+	}
+	for i := range want {
+		if r.ISBNs[i] != want[i] {
+			t.Errorf("ISBNs[%d] = %q, want %q", i, r.ISBNs[i], want[i])
+		}
+	}
+}
+
+// TestQueryParamInvalid covers queryParam's parse-error branch: an unparseable URL
+// yields an empty value rather than a panic.
+func TestQueryParamInvalid(t *testing.T) {
+	if got := queryParam("http://%zz", "id"); got != "" {
+		t.Errorf("queryParam on an invalid URL = %q, want empty", got)
+	}
+}
+
 // TestClientSearch verifies ClientSearch.
 func TestClientSearch(t *testing.T) {
 	fixture, _ := os.ReadFile("testdata/search_books.html")

--- a/internal/libgen/source_randombook_test.go
+++ b/internal/libgen/source_randombook_test.go
@@ -217,6 +217,93 @@ func TestRandombookMirrorNon200(t *testing.T) {
 	}
 }
 
+// TestRandombookDefaultClientTransportError covers the default-client fallback
+// (http is nil) together with getJSON's transport-error branch: a dead API address
+// makes the by-id request fail.
+func TestRandombookDefaultClientTransportError(t *testing.T) {
+	s := randombookSource{apiBase: "http://127.0.0.1:0"} // http nil -> default client
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when the API request cannot be sent")
+	}
+}
+
+// TestRandombookRequestBuildError covers getJSON's request-construction failure: a
+// base URL carrying a control character cannot be turned into a request.
+func TestRandombookRequestBuildError(t *testing.T) {
+	s := randombookSource{apiBase: "http://\x7f", http: http.DefaultClient}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when the request cannot be built")
+	}
+}
+
+// TestRandombookEmptyMirrorList covers lookupMirrors' empty-list branch: a valid id
+// whose links-by-id response carries no mirrors yields an error.
+func TestRandombookEmptyMirrorList(t *testing.T) {
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), `{"result":{"list":[]},"isError":false}`)
+	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when the discovered mirror list is empty")
+	}
+}
+
+// TestRandombookLinksNon200 covers lookupMirrors' getJSON error branch: a non-200
+// links-by-id response (by-id having succeeded) surfaces as an error.
+func TestRandombookLinksNon200(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/search/by-id", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(randombookByIDFixture(t)))
+	})
+	mux.HandleFunc("/api/download/links-by-id", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	s := randombookSource{apiBase: srv.URL, http: srv.Client()}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when links-by-id returns a non-200")
+	}
+}
+
+// TestRandombookMirrorRequestBuildError covers resolveViaMirror's
+// request-construction failure and normalizeMirrorBase's bare-host branch: a
+// scheme-less mirror host with a control character is prefixed with https:// and
+// then fails to build a request.
+func TestRandombookMirrorRequestBuildError(t *testing.T) {
+	// A scheme-less host carrying a DEL (0x7f) control byte: it is prefixed with
+	// https:// (the bare-host branch) and then rejected by request construction.
+	links := "{\"result\":{\"list\":[\"\x7fbadhost\"]},\"isError\":false}"
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when a discovered mirror yields an unbuildable request")
+	}
+}
+
+// TestRandombookMirrorBodyReadError covers resolveViaMirror's body-read failure: a
+// mirror that declares more bytes than it sends, then closes, makes reading the
+// ads.php body fail.
+func TestRandombookMirrorBodyReadError(t *testing.T) {
+	badMirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\nshort"))
+		_ = conn.Close()
+	}))
+	t.Cleanup(badMirror.Close)
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, badMirror.URL)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Error("Resolve should fail when a mirror body cannot be fully read")
+	}
+}
+
 // TestRandombookParsesLinksFixture guards the links response parsing against the
 // captured fixture shape: the mirror hostname list is decoded from result.list.
 func TestRandombookParsesLinksFixture(t *testing.T) {

--- a/internal/libgen/source_scihub.go
+++ b/internal/libgen/source_scihub.go
@@ -161,20 +161,9 @@ func pdfElementSrc(body []byte) (string, bool) {
 		if found {
 			return
 		}
-		if n.Type == html.ElementNode {
-			var id, elemSrc string
-			for _, a := range n.Attr {
-				switch a.Key {
-				case "id":
-					id = a.Val
-				case "src":
-					elemSrc = a.Val
-				}
-			}
-			if id == "pdf" && elemSrc != "" {
-				src, found = elemSrc, true
-				return
-			}
+		if s, ok := pdfSrcAttr(n); ok {
+			src, found = s, true
+			return
 		}
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			walk(c)
@@ -182,6 +171,27 @@ func pdfElementSrc(body []byte) (string, bool) {
 	}
 	walk(doc)
 	return src, found
+}
+
+// pdfSrcAttr reports whether n is an element node carrying id="pdf" with a
+// non-empty src attribute, returning that src value.
+func pdfSrcAttr(n *html.Node) (string, bool) {
+	if n.Type != html.ElementNode {
+		return "", false
+	}
+	var id, src string
+	for _, a := range n.Attr {
+		switch a.Key {
+		case "id":
+			id = a.Val
+		case "src":
+			src = a.Val
+		}
+	}
+	if id == "pdf" && src != "" {
+		return src, true
+	}
+	return "", false
 }
 
 // normalizeScihubURL turns a raw PDF reference scraped from a mirror into a

--- a/internal/libgen/source_scihub_test.go
+++ b/internal/libgen/source_scihub_test.go
@@ -137,6 +137,74 @@ func TestScihubRejectsNon200WithPDF(t *testing.T) {
 	}
 }
 
+// TestScihubNoHosts covers the "no hosts configured" branch: with an empty host
+// list and no per-host error, Resolve reports that nothing could be tried.
+func TestScihubNoHosts(t *testing.T) {
+	s := scihubSource{hosts: nil, http: http.DefaultClient, scheme: "http"}
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve with no hosts configured should fail")
+	}
+}
+
+// TestScihubDefaultScheme covers the default-scheme branch: an empty scheme
+// defaults to https, which cannot complete against a plain-http test host, so the
+// host is skipped and Resolve fails.
+func TestScihubDefaultScheme(t *testing.T) {
+	host := scihubHostServer(t, "<html></html>")
+	s := scihubSource{hosts: []string{host}, http: http.DefaultClient} // scheme "" -> https
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve should fail when https is attempted against an http host")
+	}
+}
+
+// TestScihubDefaultClient covers the default-client branch: with a nil http client
+// Resolve uses http.DefaultClient, which resolves the article fixture over http.
+func TestScihubDefaultClient(t *testing.T) {
+	host := scihubHostServer(t, string(scihubFixture(t)))
+	s := scihubSource{hosts: []string{host}, scheme: "http"} // http nil -> default client
+	res, err := s.Resolve(context.Background(), Item{DOI: "10.1016/j.cell.2016.01.043"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if res.FileURL == "" {
+		t.Error("Resolve() returned an empty FileURL")
+	}
+}
+
+// TestScihubRequestBuildError covers tryHost's request-construction failure: a host
+// containing a control character cannot be turned into a request.
+func TestScihubRequestBuildError(t *testing.T) {
+	s := scihubSource{hosts: []string{"\x7fbad"}, http: http.DefaultClient, scheme: "http"}
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve should fail when a host yields an unbuildable request")
+	}
+}
+
+// TestScihubBodyReadError covers tryHost's body-read failure: a mirror that
+// declares more bytes than it sends, then closes, makes reading the body fail.
+func TestScihubBodyReadError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		// Declare 1000 bytes but send only 5, then close: the client's read of the
+		// body fails with an unexpected EOF.
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1000\r\n\r\nshort"))
+		_ = conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	s := scihubSource{hosts: []string{host}, http: http.DefaultClient, scheme: "http"}
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve should fail when the mirror body cannot be fully read")
+	}
+}
+
 // TestScihubSupports verifies the source claims DOI-keyed items only.
 func TestScihubSupports(t *testing.T) {
 	s := scihubSource{}

--- a/internal/libgen/source_unpaywall_test.go
+++ b/internal/libgen/source_unpaywall_test.go
@@ -111,6 +111,25 @@ func TestUnpaywallBadJSON(t *testing.T) {
 	}
 }
 
+// TestUnpaywallRequestBuildError covers the request-construction failure: a base
+// URL carrying a control character cannot be turned into a request.
+func TestUnpaywallRequestBuildError(t *testing.T) {
+	s := unpaywallSource{email: "mail@jmrp.io", baseURL: "http://\x7f", http: http.DefaultClient}
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve should fail when the endpoint cannot be built into a request")
+	}
+}
+
+// TestUnpaywallDefaultClientTransportError covers the default-client fallback (http
+// is nil) together with the transport-error branch: a dead address makes the
+// request fail.
+func TestUnpaywallDefaultClientTransportError(t *testing.T) {
+	s := unpaywallSource{email: "mail@jmrp.io", baseURL: "http://127.0.0.1:0"}
+	if _, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+		t.Error("Resolve should fail when the Unpaywall request cannot be sent")
+	}
+}
+
 // TestUnpaywallSupports verifies that the source claims DOI-keyed items only.
 func TestUnpaywallSupports(t *testing.T) {
 	s := unpaywallSource{email: "mail@jmrp.io"}

--- a/internal/mirrors/mirrors.go
+++ b/internal/mirrors/mirrors.go
@@ -41,33 +41,49 @@ func Parse(r io.Reader) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing mirrors page: %w", err)
 	}
+	out := collectMirrors(doc)
+	if len(out) == 0 {
+		return nil, errors.New("no libgen mirrors found in page (layout change?)")
+	}
+	return out, nil
+}
+
+// collectMirrors walks the parsed document and returns the deduplicated mirror
+// base URLs in document order.
+func collectMirrors(doc *html.Node) []string {
 	var out []string
 	seen := map[string]bool{}
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			for _, a := range n.Attr {
-				if a.Key != "href" {
-					continue
-				}
-				if m := mirrorHostRe.FindStringSubmatch(strings.TrimSpace(a.Val)); m != nil {
-					u := "https://" + m[1]
-					if !seen[u] {
-						seen[u] = true
-						out = append(out, u)
-					}
-				}
-			}
-		}
+		appendMirrorsFromNode(n, seen, &out)
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			walk(c)
 		}
 	}
 	walk(doc)
-	if len(out) == 0 {
-		return nil, errors.New("no libgen mirrors found in page (layout change?)")
+	return out
+}
+
+// appendMirrorsFromNode appends any new mirror base URLs found in n's anchor
+// href attributes to out, tracking already-seen URLs in seen.
+func appendMirrorsFromNode(n *html.Node, seen map[string]bool, out *[]string) {
+	if n.Type != html.ElementNode || n.Data != "a" {
+		return
 	}
-	return out, nil
+	for _, a := range n.Attr {
+		if a.Key != "href" {
+			continue
+		}
+		m := mirrorHostRe.FindStringSubmatch(strings.TrimSpace(a.Val))
+		if m == nil {
+			continue
+		}
+		u := "https://" + m[1]
+		if !seen[u] {
+			seen[u] = true
+			*out = append(*out, u)
+		}
+	}
 }
 
 type cacheFile struct {
@@ -180,7 +196,7 @@ func (m *Manager) writeCache(list []string) {
 	if err != nil {
 		return
 	}
-	if mkErr := os.MkdirAll(filepath.Dir(m.CachePath), 0o750); mkErr != nil {
+	if os.MkdirAll(filepath.Dir(m.CachePath), 0o750) != nil {
 		return
 	}
 	_ = os.WriteFile(m.CachePath, data, 0o600) // best-effort cache

--- a/internal/mirrors/mirrors_test.go
+++ b/internal/mirrors/mirrors_test.go
@@ -3,6 +3,7 @@ package mirrors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,13 @@ import (
 
 	"github.com/jmrplens/libgen-mcp/internal/config"
 )
+
+// errReader is an io.Reader that always fails, used to exercise the html.Parse
+// error path in Parse.
+type errReader struct{}
+
+// Read always returns an error so html.Parse propagates a read failure.
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read boom") }
 
 // TestParseFixture verifies ParseFixture.
 func TestParseFixture(t *testing.T) {
@@ -36,6 +44,14 @@ func TestParseFixture(t *testing.T) {
 func TestParseNoMirrors(t *testing.T) {
 	if _, err := Parse(strings.NewReader("<html><body>nada</body></html>")); err == nil {
 		t.Fatal("Parse() without mirrors should fail")
+	}
+}
+
+// TestParseReadError verifies that Parse surfaces a reader failure instead of
+// returning mirrors.
+func TestParseReadError(t *testing.T) {
+	if _, err := Parse(errReader{}); err == nil {
+		t.Fatal("Parse() with a failing reader should error")
 	}
 }
 
@@ -201,5 +217,107 @@ func TestManagerFallsBackToHardcoded(t *testing.T) {
 	got := m.Mirrors(context.Background())
 	if !reflect.DeepEqual(got, DefaultFallback) {
 		t.Errorf("Mirrors() = %v, want fallback %v", got, DefaultFallback)
+	}
+}
+
+// TestManagerUsesFreshCache verifies that a fresh (non-expired) disk cache is
+// used directly, without hitting the network source.
+func TestManagerUsesFreshCache(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	cachePath := filepath.Join(t.TempDir(), "mirrors.json")
+	fresh := cacheFile{FetchedAt: time.Now(), Mirrors: []string{"https://libgen.bz", "https://libgen.gl"}}
+	data, err := json.Marshal(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writeErr := os.WriteFile(cachePath, data, 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	m := &Manager{SourceURL: srv.URL, CachePath: cachePath, Preferred: "https://libgen.bz", HTTP: srv.Client()}
+	got := m.Mirrors(context.Background())
+	if hits != 0 {
+		t.Fatalf("a fresh cache should not trigger a fetch, hits = %d", hits)
+	}
+	if len(got) != 2 || got[0] != "https://libgen.bz" {
+		t.Fatalf("Mirrors() = %v, want the cached list preferred-first", got)
+	}
+}
+
+// TestFetchInvalidURL verifies that fetch fails when the source URL cannot be
+// turned into a request (the http.NewRequestWithContext error path).
+func TestFetchInvalidURL(t *testing.T) {
+	m := &Manager{SourceURL: "http://invalid\x7fhost/", HTTP: http.DefaultClient}
+	if _, err := m.fetch(context.Background()); err == nil {
+		t.Fatal("fetch() with an invalid URL should error")
+	}
+}
+
+// TestFetchConnectionError verifies that fetch surfaces a transport error when
+// the source is unreachable (the HTTP.Do error path).
+func TestFetchConnectionError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	client := srv.Client()
+	srv.Close() // close before the request so the connection is refused
+	m := &Manager{SourceURL: url, HTTP: client}
+	if _, err := m.fetch(context.Background()); err == nil {
+		t.Fatal("fetch() to a closed server should error")
+	}
+}
+
+// TestReadCacheErrors covers the malformed and empty cache-file paths in readCache.
+func TestReadCacheErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"invalid-json", "{not valid json"},
+		{"empty-mirrors", `{"fetched_at":"2020-01-01T00:00:00Z","mirrors":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mirrors.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			m := &Manager{CachePath: path}
+			if _, err := m.readCache(); err == nil {
+				t.Fatalf("readCache() with %s content should error", tc.name)
+			}
+		})
+	}
+}
+
+// TestWriteCacheMkdirError verifies that writeCache silently gives up (writing no
+// file) when the cache directory cannot be created.
+func TestWriteCacheMkdirError(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The parent of the cache dir is a regular file, so MkdirAll cannot create it.
+	cachePath := filepath.Join(file, "sub", "mirrors.json")
+	m := &Manager{CachePath: cachePath}
+	m.writeCache([]string{"https://libgen.li"})
+	if _, err := os.Stat(cachePath); err == nil {
+		t.Fatal("writeCache() should not create a file when MkdirAll fails")
+	}
+}
+
+// TestNewManagerCacheDirError verifies that NewManager fails when the OS cache
+// directory cannot be resolved.
+func TestNewManagerCacheDirError(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+	if _, err := os.UserCacheDir(); err == nil {
+		t.Skip("os.UserCacheDir still resolves a cache directory on this platform")
+	}
+	if _, err := NewManager(&config.Config{Timeout: time.Second}); err == nil {
+		t.Fatal("NewManager() without a resolvable cache dir should fail")
 	}
 }


### PR DESCRIPTION
Resolves the 15 open SonarCloud issues on main (behaviour unchanged) and raises coverage from **94.4% → 99.1%**.

**Issues fixed**
- **go:S3776** cognitive complexity (8 functions → ≤15) by extracting helpers — verified with `gocognit -over 15` (clean).
- **go:S1192** duplicate literals in `gen_llms` → single `writeMcpServersJSON` helper; generated `llms.txt`/`llms-full.txt` are byte-identical.
- **godre:S8239** `cmd/server` → `context.WithoutCancel(ctx)` for the shutdown timeout.
- **godre:S8193** `mirrors` → inlined `MkdirAll` check.

**Coverage** — new offline, deterministic tests for the uncovered error paths (transport/HTTP errors, non-200 & malformed bodies, size/disk limits, resume/`.part` + MD5 edges, source-not-supported, cache read/write failures). `make cover-check` passes at 99.1%.

Local gates green: tests, golangci-lint, godoc audit, gen_llms --check, format-md-tables --check, gocognit ≤15, e2e compiles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the 15 open SonarCloud issues and raises test coverage from 94.4% to 99.1%, with no behavior changes. Extracts helpers to cut cognitive complexity and adds offline tests for previously uncovered error paths.

- **Refactors**
  - Reduced cognitive complexity (go:S3776) by extracting helpers in `cmd/format_md_tables`, `cmd/gen_llms` (schema/JSON writers), `internal/config` (range checks), `internal/mirrors` (mirror collection), and `internal/libgen` (download streaming, Sci-Hub PDF parsing, search parsing).
  - Removed duplicate literals (go:S1192) in `cmd/gen_llms` via `writeMcpServersJSON`; generated `llms.txt` and `llms-full.txt` are byte-identical.
  - Used `context.WithoutCancel(ctx)` for HTTP shutdown in `cmd/server` (godre:S8239).
  - Inlined `MkdirAll` check in `internal/mirrors` (godre:S8193).

- **Coverage**
  - Added deterministic, offline tests for transport/HTTP errors, non-200 and malformed bodies, size/disk limits, resume/“.part” + MD5 edges, source-not-supported branches, and cache read/write failures.
  - `internal/mirrors` coverage ~98.8%; `internal/libgen` ~99.4%; overall internal coverage 99.1%.

<sup>Written for commit 0fc8f6ce8ebc489120f71989a103c979c4995c5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

