### PR TITLE
refactor(tools): reduce detailsHandler cognitive complexity (go:S3776)

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -182,35 +182,48 @@ func detailsHandler(c *libgen.Client) mcp.ToolHandlerFor[DetailsInput, DetailsOu
 		case in.MD5 != "" && in.ID != "":
 			return nil, zero, errors.New("provide md5 or id, not both")
 		case in.MD5 != "":
-			if !md5Re.MatchString(in.MD5) {
-				return nil, zero, errors.New("md5 must be a 32-char hex string")
-			}
-			file, edition, err := c.DetailsByMD5(ctx, strings.ToLower(in.MD5))
-			if err != nil {
-				return nil, zero, err
-			}
-			return nil, DetailsOutput{File: file, Edition: edition}, nil
+			out, err := detailsByMD5(ctx, c, in.MD5)
+			return nil, out, err
 		case in.ID != "":
-			object := "e"
-			switch in.Object {
-			case "", "edition":
-			case "file":
-				object = "f"
-			default:
-				return nil, zero, fmt.Errorf("object must be edition or file, got %q", in.Object)
-			}
-			rec, err := c.DetailsByID(ctx, object, in.ID)
-			if err != nil {
-				return nil, zero, err
-			}
-			if object == "f" {
-				return nil, DetailsOutput{File: rec}, nil
-			}
-			return nil, DetailsOutput{Edition: rec}, nil
+			out, err := detailsByID(ctx, c, in.Object, in.ID)
+			return nil, out, err
 		default:
 			return nil, zero, errors.New("provide md5 or id")
 		}
 	}
+}
+
+// detailsByMD5 validates the md5 and returns the file plus its related edition.
+func detailsByMD5(ctx context.Context, c *libgen.Client, md5 string) (DetailsOutput, error) {
+	if !md5Re.MatchString(md5) {
+		return DetailsOutput{}, errors.New("md5 must be a 32-char hex string")
+	}
+	file, edition, err := c.DetailsByMD5(ctx, strings.ToLower(md5))
+	if err != nil {
+		return DetailsOutput{}, err
+	}
+	return DetailsOutput{File: file, Edition: edition}, nil
+}
+
+// detailsByID resolves a record by edition ("e", default) or file ("f") id,
+// mapping the caller-facing object name to the API code.
+func detailsByID(ctx context.Context, c *libgen.Client, objectName, id string) (DetailsOutput, error) {
+	object := "e"
+	switch objectName {
+	case "", "edition":
+	case "file":
+		object = "f"
+	default:
+		return DetailsOutput{}, fmt.Errorf("object must be edition or file, got %q", objectName)
+	}
+	rec, err := c.DetailsByID(ctx, object, id)
+	if err != nil {
+		return DetailsOutput{}, err
+	}
+	if object == "f" {
+		return DetailsOutput{File: rec}, nil
+	}
+	return DetailsOutput{Edition: rec}, nil
 }
 
 func downloadHandler(c *libgen.Client, cfg *config.Config) mcp.ToolHandlerFor[DownloadInput, libgen.DownloadResult] {


### PR DESCRIPTION
Last of the 15 SonarCloud issues: `internal/tools/tools.go` `detailsHandler` was cognitive complexity 18. Extracted `detailsByMD5` and `detailsByID` helpers → the handler is now well under 15, behaviour identical. `gocognit -over 15` is clean; coverage stays 99.1%.

## Summary by Sourcery

Enhancements:
- Extract helper functions for MD5-based and ID-based detail lookups to simplify the details handler logic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `internal/tools/tools.go` details handler to lower cognitive complexity by extracting `detailsByMD5` and `detailsByID`. Behavior is unchanged; the handler now meets SonarCloud S3776 (<15) and test coverage remains 99.1%.

- **Refactors**
  - Moved MD5 validation and ID object mapping into small helpers.
  - Simplified `detailsHandler` branches; error messages and outputs unchanged.

<sup>Written for commit 20b8b838bf3547fd1feb6b9dc2457dffa27ecbf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

