### PR TITLE
feat(download): add optional source parameter to the download tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ Full metadata for a record (description, identifiers, DOI, cover, related editio
 
 Download a file to a local directory. Provide `md5` for a book **or** `doi` for an article (at least one is required); the server resolves the appropriate source chain and, for book (`md5`) downloads, verifies the result against the expected hash (DOI/article downloads are not MD5-verified). Returns the saved path, size, and the source that served it.
 
-| Parameter  | Type   | Required | Description                                                                          |
-| ---------- | ------ | -------- | ------------------------------------------------------------------------------------ |
-| `md5`      | string | one of   | File MD5 hash from a book search result.                                             |
-| `doi`      | string | one of   | DOI from an article search result; articles are fetched by DOI.                      |
-| `path`     | string | no       | Destination directory (default: `LIBGEN_MCP_DOWNLOAD_DIR` or `~/Downloads`).         |
-| `filename` | string | no       | Destination filename (default: a clean name from the record metadata or the mirror). |
+| Parameter  | Type   | Required | Description                                                                                                                           |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `md5`      | string | one of   | File MD5 hash from a book search result.                                                                                              |
+| `doi`      | string | one of   | DOI from an article search result; articles are fetched by DOI.                                                                       |
+| `path`     | string | no       | Destination directory (default: `LIBGEN_MCP_DOWNLOAD_DIR` or `~/Downloads`).                                                          |
+| `filename` | string | no       | Destination filename (default: a clean name from the record metadata or the mirror).                                                  |
+| `source`   | string | no       | Restrict the download to one source: `libgen`/`randombook` (books) or `unpaywall`/`scihub` (articles). Omit to try all with failover. |
 
 If both `md5` and `doi` are given, article sources are tried first, then book sources.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -89,12 +89,13 @@ at least one is required. Returns the saved path, size, and the source that serv
 
 ### download input
 
-| Parameter  | Type   | Required | Description                                                                                                                |
-| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `md5`      | string | one of   | File MD5 hash from a book search result. Must be a 32-character hex string.                                                |
-| `doi`      | string | one of   | DOI from an article search result. Articles are fetched by DOI.                                                            |
-| `path`     | string | no       | Destination directory. Defaults to `LIBGEN_MCP_DOWNLOAD_DIR` (or `~/Downloads`).                                           |
-| `filename` | string | no       | Destination filename. Defaults to a clean name from the record metadata, else the name the mirror announces, else the MD5. |
+| Parameter  | Type   | Required | Description                                                                                                                                                                           |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `md5`      | string | one of   | File MD5 hash from a book search result. Must be a 32-character hex string.                                                                                                           |
+| `doi`      | string | one of   | DOI from an article search result. Articles are fetched by DOI.                                                                                                                       |
+| `path`     | string | no       | Destination directory. Defaults to `LIBGEN_MCP_DOWNLOAD_DIR` (or `~/Downloads`).                                                                                                      |
+| `filename` | string | no       | Destination filename. Defaults to a clean name from the record metadata, else the name the mirror announces, else the MD5.                                                            |
+| `source`   | string | no       | Restrict the download to a single source: `libgen`/`randombook` (books, `md5`) or `unpaywall`/`scihub` (articles, `doi`). Omit to try every compatible source in order with failover. |
 
 At least one of `md5` or `doi` is required. A malformed `md5` (not 32 hex chars) is
 rejected before any work.

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -265,12 +265,22 @@ func (c *Client) DownloadItem(ctx context.Context, item Item, dir, filename stri
 	}
 	defer c.releaseSlot()
 
+	// When the item names a source, restrict the download to that single source;
+	// otherwise try the whole configured chain in order.
+	sources := c.sources
+	if item.Source != "" {
+		sources = sourcesNamed(c.sources, item.Source)
+		if len(sources) == 0 {
+			return nil, fmt.Errorf("download source %q is not enabled (check LIBGEN_MCP_SOURCES)", item.Source)
+		}
+	}
+
 	req := downloadReq{item: item, dir: dir, filename: filename, onProgress: onProgress}
 	// Try each supporting source in order: a source that fails to resolve or whose
 	// stream is rejected (HTML page / integrity mismatch / short read) advances to
 	// the next. The first success returns; if all fail, the joined errors surface.
 	var errs []error
-	for _, src := range c.sources {
+	for _, src := range sources {
 		if !src.Supports(item) {
 			continue
 		}
@@ -285,9 +295,24 @@ func (c *Client) DownloadItem(ctx context.Context, item Item, dir, filename stri
 		}
 	}
 	if len(errs) == 0 {
+		if item.Source != "" {
+			return nil, fmt.Errorf("source %q cannot serve md5=%q doi=%q (md5 uses libgen/randombook; doi uses unpaywall/scihub)", item.Source, item.MD5, item.DOI)
+		}
 		return nil, fmt.Errorf("no download source supports md5=%q doi=%q", item.MD5, item.DOI)
 	}
 	return nil, errors.Join(errs...)
+}
+
+// sourcesNamed returns the single source whose Name matches name (case-insensitive),
+// or nil when no enabled source has that name.
+func sourcesNamed(all []DownloadSource, name string) []DownloadSource {
+	name = strings.ToLower(strings.TrimSpace(name))
+	for _, s := range all {
+		if s.Name() == name {
+			return []DownloadSource{s}
+		}
+	}
+	return nil
 }
 
 // acquireSlot takes a download concurrency slot, honoring context cancellation so

--- a/internal/libgen/download_source_test.go
+++ b/internal/libgen/download_source_test.go
@@ -1,0 +1,72 @@
+package libgen
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// serveStaticBytes returns an httptest server that serves content at any path.
+func serveStaticBytes(t *testing.T, content []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDownloadItemRestrictToSource verifies that Item.Source restricts the
+// download to a single named source instead of walking the whole chain, and
+// that an unknown/disabled source name is a clear error.
+func TestDownloadItemRestrictToSource(t *testing.T) {
+	srvA := serveStaticBytes(t, []byte("%PDF-1.4 AAAA "+strings.Repeat("a", 600)))
+	srvB := serveStaticBytes(t, []byte("%PDF-1.7 BBBB "+strings.Repeat("b", 600)))
+
+	newClient := func() *Client {
+		c := newTestClient(staticMirrors{})
+		c.sources = []DownloadSource{
+			stubSource{name: "srca", supports: true, resolved: Resolved{FileURL: srvA.URL + "/f", VerifyMD5: false}},
+			stubSource{name: "srcb", supports: true, resolved: Resolved{FileURL: srvB.URL + "/f", VerifyMD5: false}},
+		}
+		return c
+	}
+
+	// Restrict to srcb even though srca is first and would serve on its own.
+	res, err := newClient().DownloadItem(context.Background(), Item{DOI: "10.1/x", Source: "srcb"}, t.TempDir(), "o.pdf")
+	if err != nil {
+		t.Fatalf("restrict to srcb: %v", err)
+	}
+	if res.Source != "srcb" {
+		t.Errorf("Source = %q, want srcb", res.Source)
+	}
+
+	// Restrict to srca.
+	res, err = newClient().DownloadItem(context.Background(), Item{DOI: "10.1/x", Source: "srca"}, t.TempDir(), "o.pdf")
+	if err != nil {
+		t.Fatalf("restrict to srca: %v", err)
+	}
+	if res.Source != "srca" {
+		t.Errorf("Source = %q, want srca", res.Source)
+	}
+
+	// An unknown / disabled source name is a clear error, not a silent fallback.
+	_, uerr := newClient().DownloadItem(context.Background(), Item{DOI: "10.1/x", Source: "nope"}, t.TempDir(), "o.pdf")
+	if uerr == nil || !strings.Contains(uerr.Error(), "not enabled") {
+		t.Errorf("unknown source error = %v, want it to mention 'not enabled'", uerr)
+	}
+}
+
+// TestDownloadItemRestrictIncompatibleSource verifies that restricting to a
+// source that does not support the item type returns a targeted error rather
+// than the generic "no source supports" message.
+func TestDownloadItemRestrictIncompatibleSource(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	c.sources = []DownloadSource{stubSource{name: "onlydoi", supports: false}}
+	_, err := c.DownloadItem(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee", Source: "onlydoi"}, t.TempDir(), "")
+	if err == nil || !strings.Contains(err.Error(), "cannot serve") {
+		t.Errorf("incompatible source error = %v, want it to mention 'cannot serve'", err)
+	}
+}

--- a/internal/libgen/source.go
+++ b/internal/libgen/source.go
@@ -21,6 +21,10 @@ type Item struct {
 	// DOI is the Digital Object Identifier, when the file is keyed by DOI (e.g.
 	// Unpaywall or Sci-Hub). Empty when unknown.
 	DOI string
+	// Source, when set, restricts the download to that single named source (one
+	// of config.KnownSources). Empty means try the full configured source chain
+	// in order with transparent failover.
+	Source string
 	// Meta carries bibliographic fields for naming; may be nil.
 	Meta *FileMeta
 }

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"regexp"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"time"
 
@@ -72,6 +73,7 @@ type DownloadInput struct {
 	DOI      string `json:"doi,omitempty" jsonschema:"DOI from an article search result; articles are fetched by DOI; provide md5 or doi"`
 	Path     string `json:"path,omitempty" jsonschema:"destination directory (default: LIBGEN_MCP_DOWNLOAD_DIR or ~/Downloads)"`
 	Filename string `json:"filename,omitempty" jsonschema:"destination filename (default: a clean name from the record metadata or the name the mirror announces)"`
+	Source   string `json:"source,omitempty" jsonschema:"restrict the download to a single source instead of trying all: libgen or randombook for books (md5); unpaywall or scihub for articles (doi). Omit to try every compatible source in order with failover"`
 }
 
 // Register wires the search, get_details and download tools onto the MCP server,
@@ -96,6 +98,7 @@ func Register(server *mcp.Server, client *libgen.Client, cfg *config.Config) {
 		Description: "Download a file to a local directory. Provide md5 for a book or doi for an article (at least one is required). " +
 			"Books are tried against libgen (ads.php key + CDN) then randombook (fresh-mirror discovery); articles are tried against unpaywall (open-access PDF) then sci-hub. " +
 			"If both md5 and doi are given, article sources (unpaywall, sci-hub) are tried first, then book sources (libgen, randombook). " +
+			"Set source to restrict the download to a single provider (libgen/randombook for books, unpaywall/scihub for articles) instead of trying them all. " +
 			"Returns the saved path, size and the source that served it.",
 		Annotations: &mcp.ToolAnnotations{Title: "Download file", DestructiveHint: &falsy, IdempotentHint: true, OpenWorldHint: &truthy},
 	}, withRecovery("download", downloadHandler(client, cfg)))
@@ -226,22 +229,36 @@ func detailsByID(ctx context.Context, c *libgen.Client, objectName, id string) (
 	return DetailsOutput{Edition: rec}, nil
 }
 
+// validateDownloadInput normalizes and validates the download request, returning
+// the cleaned md5, doi and source (source is "" when unset). At least one of md5
+// or doi is required; md5 must be 32-hex; source, when set, must be a known one.
+func validateDownloadInput(in DownloadInput) (md5, doi, source string, err error) {
+	md5 = strings.ToLower(strings.TrimSpace(in.MD5))
+	doi = strings.TrimSpace(in.DOI)
+	source = strings.ToLower(strings.TrimSpace(in.Source))
+	switch {
+	case md5 == "" && doi == "":
+		return "", "", "", errors.New("provide md5 (book) or doi (article)")
+	case md5 != "" && !md5Re.MatchString(md5):
+		return "", "", "", errors.New("md5 must be a 32-char hex string")
+	case source != "" && !slices.Contains(config.KnownSources, source):
+		return "", "", "", fmt.Errorf("source must be one of %s, got %q", strings.Join(config.KnownSources, ", "), in.Source)
+	}
+	return md5, doi, source, nil
+}
+
 func downloadHandler(c *libgen.Client, cfg *config.Config) mcp.ToolHandlerFor[DownloadInput, libgen.DownloadResult] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, in DownloadInput) (*mcp.CallToolResult, libgen.DownloadResult, error) {
 		var zero libgen.DownloadResult
-		md5 := strings.ToLower(strings.TrimSpace(in.MD5))
-		doi := strings.TrimSpace(in.DOI)
-		if md5 == "" && doi == "" {
-			return nil, zero, errors.New("provide md5 (book) or doi (article)")
-		}
-		if md5 != "" && !md5Re.MatchString(md5) {
-			return nil, zero, errors.New("md5 must be a 32-char hex string")
+		md5, doi, source, err := validateDownloadInput(in)
+		if err != nil {
+			return nil, zero, err
 		}
 		dir := in.Path
 		if dir == "" {
 			dir = cfg.DownloadDir
 		}
-		item := libgen.Item{MD5: md5, DOI: doi}
+		item := libgen.Item{MD5: md5, DOI: doi, Source: source}
 		// For a book download with no explicit name, fill bibliographic metadata so
 		// the file lands under a clean "Author - Title (Year).ext" name. Best-effort:
 		// a details lookup failure must not fail the download.

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -388,6 +388,21 @@ func TestDownloadToolBadMD5(t *testing.T) {
 	}
 }
 
+// TestDownloadToolBadSource verifies the tool rejects an unknown source name.
+func TestDownloadToolBadSource(t *testing.T) {
+	session := newSession(t)
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "download",
+		Arguments: map[string]any{"md5": "87a4ebdaf21fa6cc70009a3dd63194ee", "source": "nosuchsource"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("download with an unknown source should be a tool error")
+	}
+}
+
 // md5ErrSource is a DownloadSource that supports md5 items but always fails to
 // resolve, so the download handler's error path can be exercised without a network.
 type md5ErrSource struct{}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -48,7 +48,7 @@ Annotations: readOnly=true, destructive=false, idempotent=false, openWorld=true
 
 **Download file**
 
-Download a file to a local directory. Provide md5 for a book or doi for an article (at least one is required). Books are tried against libgen (ads.php key + CDN) then randombook (fresh-mirror discovery); articles are tried against unpaywall (open-access PDF) then sci-hub. If both md5 and doi are given, article sources (unpaywall, sci-hub) are tried first, then book sources (libgen, randombook). Returns the saved path, size and the source that served it.
+Download a file to a local directory.
 
 **Parameters:**
 
@@ -56,6 +56,7 @@ Download a file to a local directory. Provide md5 for a book or doi for an artic
 - `filename` (string): destination filename (default: a clean name from the record metadata or the name the mirror announces)
 - `md5` (string): file md5 hash from a book search result; provide md5 or doi
 - `path` (string): destination directory (default: LIBGEN_MCP_DOWNLOAD_DIR or ~/Downloads)
+- `source` (string): restrict the download to a single source instead of trying all: libgen or randombook for books (md5); unpaywall or scihub for articles (doi). Omit to try every compatible source in order with failover
 
 Annotations: readOnly=false, destructive=false, idempotent=true, openWorld=true
 

--- a/site/src/content/docs/es/tools.mdx
+++ b/site/src/content/docs/es/tools.mdx
@@ -89,12 +89,12 @@ Descarga un archivo a un directorio local. Proporciona `md5` para un libro **o**
 
 ### entrada de download
 
-| Parámetro  | Tipo   | Requerido | Descripción                                                                                                                             |
-| ---------- | ------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `md5`      | string | uno de    | Hash MD5 de archivo de un resultado de búsqueda de libro. Debe ser una cadena hexadecimal de 32 caracteres.                             |
-| `doi`      | string | uno de    | DOI de un resultado de búsqueda de artículo. Los artículos se obtienen por DOI.                                                         |
-| `path`     | string | no        | Directorio de destino. Por defecto `LIBGEN_MCP_DOWNLOAD_DIR` (o `~/Downloads`).                                                         |
-| `filename` | string | no        | Nombre de archivo de destino. Por defecto un nombre limpio de los metadatos del registro, si no el que anuncia el mirror, si no el MD5. |
+| Parámetro  | Tipo   | Requerido | Descripción                                                                                                                                                                                         |
+| ---------- | ------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `md5`      | string | uno de    | Hash MD5 de archivo de un resultado de búsqueda de libro. Debe ser una cadena hexadecimal de 32 caracteres.                                                                                         |
+| `doi`      | string | uno de    | DOI de un resultado de búsqueda de artículo. Los artículos se obtienen por DOI.                                                                                                                     |
+| `path`     | string | no        | Directorio de destino. Por defecto `LIBGEN_MCP_DOWNLOAD_DIR` (o `~/Downloads`).                                                                                                                     |
+| `filename` | string | no        | Nombre de archivo de destino. Por defecto un nombre limpio de los metadatos del registro, si no el que anuncia el mirror, si no el MD5.                                                             |
 | `source`   | string | no        | Restringe la descarga a una única fuente: `libgen`/`randombook` (libros, `md5`) o `unpaywall`/`scihub` (artículos, `doi`). Omítelo para probar todas las fuentes compatibles en orden con failover. |
 
 Se requiere al menos uno de `md5` o `doi`. Un `md5` mal formado (no 32 caracteres hex) se rechaza antes de cualquier trabajo.

--- a/site/src/content/docs/es/tools.mdx
+++ b/site/src/content/docs/es/tools.mdx
@@ -95,6 +95,7 @@ Descarga un archivo a un directorio local. Proporciona `md5` para un libro **o**
 | `doi`      | string | uno de    | DOI de un resultado de búsqueda de artículo. Los artículos se obtienen por DOI.                                                         |
 | `path`     | string | no        | Directorio de destino. Por defecto `LIBGEN_MCP_DOWNLOAD_DIR` (o `~/Downloads`).                                                         |
 | `filename` | string | no        | Nombre de archivo de destino. Por defecto un nombre limpio de los metadatos del registro, si no el que anuncia el mirror, si no el MD5. |
+| `source`   | string | no        | Restringe la descarga a una única fuente: `libgen`/`randombook` (libros, `md5`) o `unpaywall`/`scihub` (artículos, `doi`). Omítelo para probar todas las fuentes compatibles en orden con failover. |
 
 Se requiere al menos uno de `md5` o `doi`. Un `md5` mal formado (no 32 caracteres hex) se rechaza antes de cualquier trabajo.
 

--- a/site/src/content/docs/tools.mdx
+++ b/site/src/content/docs/tools.mdx
@@ -88,12 +88,12 @@ Download a file to a local directory. Provide `md5` for a book **or** `doi` for 
 
 ### download input
 
-| Parameter  | Type   | Required | Description                                                                                                                |
-| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `md5`      | string | one of   | File MD5 hash from a book search result. Must be a 32-character hex string.                                                |
-| `doi`      | string | one of   | DOI from an article search result. Articles are fetched by DOI.                                                            |
-| `path`     | string | no       | Destination directory. Defaults to `LIBGEN_MCP_DOWNLOAD_DIR` (or `~/Downloads`).                                           |
-| `filename` | string | no       | Destination filename. Defaults to a clean name from the record metadata, else the name the mirror announces, else the MD5. |
+| Parameter  | Type   | Required | Description                                                                                                                                                                           |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `md5`      | string | one of   | File MD5 hash from a book search result. Must be a 32-character hex string.                                                                                                           |
+| `doi`      | string | one of   | DOI from an article search result. Articles are fetched by DOI.                                                                                                                       |
+| `path`     | string | no       | Destination directory. Defaults to `LIBGEN_MCP_DOWNLOAD_DIR` (or `~/Downloads`).                                                                                                      |
+| `filename` | string | no       | Destination filename. Defaults to a clean name from the record metadata, else the name the mirror announces, else the MD5.                                                            |
 | `source`   | string | no       | Restrict the download to a single source: `libgen`/`randombook` (books, `md5`) or `unpaywall`/`scihub` (articles, `doi`). Omit to try every compatible source in order with failover. |
 
 At least one of `md5` or `doi` is required. A malformed `md5` (not 32 hex chars) is rejected before any work.

--- a/site/src/content/docs/tools.mdx
+++ b/site/src/content/docs/tools.mdx
@@ -94,6 +94,7 @@ Download a file to a local directory. Provide `md5` for a book **or** `doi` for 
 | `doi`      | string | one of   | DOI from an article search result. Articles are fetched by DOI.                                                            |
 | `path`     | string | no       | Destination directory. Defaults to `LIBGEN_MCP_DOWNLOAD_DIR` (or `~/Downloads`).                                           |
 | `filename` | string | no       | Destination filename. Defaults to a clean name from the record metadata, else the name the mirror announces, else the MD5. |
+| `source`   | string | no       | Restrict the download to a single source: `libgen`/`randombook` (books, `md5`) or `unpaywall`/`scihub` (articles, `doi`). Omit to try every compatible source in order with failover. |
 
 At least one of `md5` or `doi` is required. A malformed `md5` (not 32 hex chars) is rejected before any work.
 


### PR DESCRIPTION
Lets the model choose *where* to download from, not just *what*. The `download` tool gains an optional `source` (`libgen`/`randombook` for books by md5; `unpaywall`/`scihub` for articles by doi); `Item.Source` restricts `DownloadItem` to that single provider with clear errors when it's disabled or can't serve the item type. Omitting it keeps the existing full-chain failover.

Tests cover restrict-to-source selection, unknown/disabled source, incompatible source, and the tool's validation. Docs (README, docs/tools.md, site EN/ES) + llms-full.txt updated. `validateDownloadInput` extracted to keep the handler under the cognitive-complexity threshold. Local gates green; coverage 99.0%.

Groundwork for the upcoming LLM eval scenario 'download from a chosen source'.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `source` parameter to the `download` tool so callers can pick a single provider; omitting it keeps the current failover behavior. This enables precise provider selection with clear errors when a source is disabled or incompatible.

- New Features
  - `download` input now supports `source` (`libgen`/`randombook` for `md5`; `unpaywall`/`scihub` for `doi`), validated against `config.KnownSources`.
  - `Item.Source` added; `Client.DownloadItem` restricts to the named source, with explicit errors for not enabled or cannot serve.
  - Extracted `validateDownloadInput` to simplify the handler.
  - Docs updated (README, `docs/tools.md`, site EN/ES, `llms-full.txt`) with formatted source tables, and tests added for restrict-to-source, unknown/disabled source, incompatible source, and tool validation.

<sup>Written for commit 52f08ca254dfd7bd97b7d89c7dd598192883b225. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

