### PR TITLE
feat(eval): add live LLM-driven eval harness under cmd/eval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # golangci-lint (bundles govet, staticcheck, gosec, ...) + govulncheck.
 
 .PHONY: all build build-probe build-all run version \
-        test test-short test-race coverage cover-check \
+        test test-short test-race test-e2e eval coverage cover-check \
         lint golangci-lint govulncheck analyze fmt tidy vet \
         format-md-tables check-md-tables \
         godoc-audit godoc-check \
@@ -98,6 +98,9 @@ test-race: ## Run all tests under the race detector
 
 test-e2e: ## Run the gated live e2e suite against the real site (needs network)
 	LIBGEN_E2E=1 go test -tags e2e -timeout 600s -count=1 ./test/e2e/
+
+eval: ## Run the LIVE LLM-driven eval harness (needs ANTHROPIC_API_KEY; real API + mirrors + downloads)
+	LIBGEN_EVAL=1 go run -tags eval ./cmd/eval
 
 coverage: test ## Generate an HTML coverage report (coverage.html)
 	go tool cover -html=coverage.out -o coverage.html

--- a/cmd/eval/README.md
+++ b/cmd/eval/README.md
@@ -1,0 +1,80 @@
+# cmd/eval — live LLM-driven eval harness
+
+A small end-to-end harness that drives a real Anthropic model over the real
+libgen-mcp tools and grades whether the model picks the right tool with
+well-formed arguments and gets a usable response back.
+
+It is deliberately **not** a unit test. It is:
+
+- **Compiled only under the `eval` build tag** (every file starts with
+  `//go:build eval`), so a normal `go build ./...`, `go test ./...`, or CI run
+  never touches it.
+- **Gated at runtime**: even under the tag it exits 0 with a skip notice unless
+  both `LIBGEN_EVAL=1` and a non-empty `ANTHROPIC_API_KEY` are set.
+
+## What it exercises
+
+The model talks to libgen-mcp's three tools (`search`, `get_details`,
+`download`) registered on an **in-process** MCP server (`mcp.NewServer` +
+`tools.Register` + `mcp.NewInMemoryTransports`). Every tool call the model makes
+is executed for real against Library Genesis via `session.CallTool` — real
+search pages, real details lookups, real downloads.
+
+The Anthropic side is a raw `net/http` Messages API client (no SDK): model
+`claude-haiku-4-5-20251001`, temperature 0, `tool_choice: auto`. The tool-use
+loop runs up to 4 turns per scenario: send the prompt + tool defs, execute each
+`tool_use` block, feed `tool_result` blocks back, and stop when the model
+answers (or asks to clarify) without a tool call.
+
+Assertions check the **tool name, the argument JSON shape, and that the real MCP
+response is non-empty / well-formed** — never exact catalog content, which drifts.
+
+## Scenarios
+
+| ID  | What it checks |
+| --- | --- |
+| S1  | Book search: nonfiction topic, title/author columns, first result has a 32-hex md5 |
+| S2  | Article search: articles topic, at least one result with a valid DOI |
+| S3  | Standards search (SKIPs if the mirror returns 0) |
+| S4  | `get_details` on an md5 taken from a prior search result |
+| S5  | Book download by md5: saved path + non-zero size |
+| S6  | Download **choosing a source**: model sets `source:"scihub"` for an article DOI |
+| S6b | Download choosing a book source: model sets `source:"randombook"` for an md5 |
+| S7  | Open-access article by DOI, served by unpaywall or sci-hub |
+| S8  | Ambiguous "find me a good book" — passes if the model clarifies or the tool rejects it |
+
+S6 / S6b are the reason this harness exists alongside the older checks: the
+`download` tool now takes an optional **`source`** argument, and these scenarios
+assert the model actually sets it (and that `DownloadResult.Source` matches when
+the live fetch succeeds).
+
+## Running
+
+```sh
+# all scenarios
+LIBGEN_EVAL=1 ANTHROPIC_API_KEY=sk-... go run -tags eval ./cmd/eval
+
+# or via the Makefile target (still needs ANTHROPIC_API_KEY in the env)
+ANTHROPIC_API_KEY=sk-... make eval
+
+# a subset, keep the downloads, and write a markdown report
+go run -tags eval ./cmd/eval --only S1,S6 --keep-downloads --results-doc dist/eval.md
+```
+
+Flags: `--only S1,S6` (comma-separated IDs), `--keep-downloads` (don't delete
+the temp dir), `--results-doc <path>` (write a markdown results table).
+
+## Cost, rate, and network caveats
+
+- **It costs money**: every scenario spends Anthropic API tokens (small model,
+  but real spend).
+- **It hits third parties**: real Library Genesis mirrors, Unpaywall, and
+  Sci-Hub. These are flaky and rate-limited; results vary run to run. Download
+  scenarios that correctly select the tool/source but fail on a dead mirror are
+  reported as **SKIP**, not FAIL.
+- **It downloads files**: into an `os.MkdirTemp` directory (removed on exit
+  unless `--keep-downloads`). Downloads are capped at 25 MiB
+  (`LIBGEN_MCP_MAX_DOWNLOAD_BYTES`) and confined to that temp dir
+  (`LIBGEN_MCP_DOWNLOAD_DIR`), both set before the server config loads.
+- The process exits non-zero if any scenario **fails** or **errors** (skips and
+  passes do not).

--- a/cmd/eval/anthropic.go
+++ b/cmd/eval/anthropic.go
@@ -1,0 +1,151 @@
+//go:build eval
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	// anthropicEndpoint is the Anthropic Messages API endpoint.
+	anthropicEndpoint = "https://api.anthropic.com/v1/messages"
+	// anthropicVersion is the Anthropic API version header value.
+	anthropicVersion = "2023-06-01"
+	// evalModel is the small, cheap model the harness drives.
+	evalModel = "claude-haiku-4-5-20251001"
+	// maxTokens caps each model response.
+	maxTokens = 1024
+	// maxResponseBytes caps the API response body kept in memory.
+	maxResponseBytes = 4 << 20
+)
+
+// anthropicRequest is the JSON body of a Messages API call.
+type anthropicRequest struct {
+	Model       string         `json:"model"`
+	MaxTokens   int            `json:"max_tokens"`
+	Temperature float64        `json:"temperature"`
+	Tools       []toolDef      `json:"tools"`
+	ToolChoice  map[string]any `json:"tool_choice"`
+	Messages    []message      `json:"messages"`
+}
+
+// toolDef is a tool definition as the Messages API expects it, built from the
+// MCP server's advertised tools.
+type toolDef struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"input_schema"`
+}
+
+// message is one conversation turn (user or assistant) of content blocks.
+type message struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+// contentBlock is a single content block. It covers the block kinds the harness
+// exchanges with the API: text, tool_use (assistant), and tool_result (user).
+type contentBlock struct {
+	Type      string         `json:"type"`
+	Text      string         `json:"text,omitempty"`
+	ID        string         `json:"id,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Input     map[string]any `json:"input,omitempty"`
+	ToolUseID string         `json:"tool_use_id,omitempty"`
+	Content   string         `json:"content,omitempty"`
+	IsError   bool           `json:"is_error,omitempty"`
+}
+
+// MarshalJSON emits the block in the shape the Messages API requires. In
+// particular a tool_use block always carries a non-null input object, which the
+// API rejects when omitted.
+func (b contentBlock) MarshalJSON() ([]byte, error) {
+	payload := map[string]any{"type": b.Type}
+	switch b.Type {
+	case "text":
+		payload["text"] = b.Text
+	case "tool_use":
+		payload["id"] = b.ID
+		payload["name"] = b.Name
+		if b.Input == nil {
+			payload["input"] = map[string]any{}
+		} else {
+			payload["input"] = b.Input
+		}
+	case "tool_result":
+		payload["tool_use_id"] = b.ToolUseID
+		payload["content"] = b.Content
+		if b.IsError {
+			payload["is_error"] = true
+		}
+	}
+	return json.Marshal(payload)
+}
+
+// anthropicResponse is the subset of the Messages API response the harness reads.
+type anthropicResponse struct {
+	Content    []contentBlock  `json:"content"`
+	StopReason string          `json:"stop_reason"`
+	Error      *anthropicError `json:"error,omitempty"`
+}
+
+// anthropicError is the API-level error object.
+type anthropicError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// anthropicClient makes raw net/http Messages API calls with an API key.
+type anthropicClient struct {
+	apiKey string
+	http   *http.Client
+}
+
+// newAnthropicClient builds a client bound to the given API key.
+func newAnthropicClient(apiKey string) *anthropicClient {
+	return &anthropicClient{apiKey: apiKey, http: &http.Client{Timeout: 90 * time.Second}}
+}
+
+// call sends one Messages request and decodes the response, surfacing HTTP and
+// API-level errors.
+func (c *anthropicClient) call(ctx context.Context, req anthropicRequest) (anthropicResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return anthropicResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, anthropicEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return anthropicResponse{}, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("content-type", "application/json")
+	httpReq.Header.Set("x-api-key", c.apiKey)
+	httpReq.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return anthropicResponse{}, fmt.Errorf("anthropic request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return anthropicResponse{}, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return anthropicResponse{}, fmt.Errorf("anthropic status %d: %s", resp.StatusCode, string(data))
+	}
+	var out anthropicResponse
+	if err = json.Unmarshal(data, &out); err != nil {
+		return anthropicResponse{}, fmt.Errorf("decode response: %w", err)
+	}
+	if out.Error != nil {
+		return anthropicResponse{}, fmt.Errorf("anthropic error %s: %s", out.Error.Type, out.Error.Message)
+	}
+	return out, nil
+}

--- a/cmd/eval/host.go
+++ b/cmd/eval/host.go
@@ -1,0 +1,78 @@
+//go:build eval
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/libgen-mcp/internal/config"
+	"github.com/jmrplens/libgen-mcp/internal/libgen"
+	"github.com/jmrplens/libgen-mcp/internal/mirrors"
+	"github.com/jmrplens/libgen-mcp/internal/tools"
+)
+
+// newHostSession loads the configuration from the environment, builds a real
+// libgen-mcp server with its three tools registered, and connects an in-memory
+// MCP client to it over ctx. Tool calls on the returned session hit the real
+// libgen mirrors and download sources. The cleanup closes the client and drains
+// the server session. Construction is offline: config.Load and
+// mirrors.NewManager do no network I/O.
+func newHostSession(ctx context.Context) (session *mcp.ClientSession, cleanup func(), err error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, nil, fmt.Errorf("load config: %w", err)
+	}
+	mgr, err := mirrors.NewManager(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create mirror manager: %w", err)
+	}
+	client := libgen.New(mgr, cfg)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "libgen-eval", Version: "0.0.1"}, nil)
+	tools.Register(server, client, cfg)
+
+	st, ct := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("server connect: %w", err)
+	}
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "libgen-eval-client", Version: "0.0.1"}, nil)
+	session, err = mcpClient.Connect(ctx, ct, nil)
+	if err != nil {
+		_ = serverSession.Close()
+		_ = serverSession.Wait()
+		return nil, nil, fmt.Errorf("client connect: %w", err)
+	}
+
+	return session, func() {
+		_ = session.Close()
+		_ = serverSession.Wait()
+	}, nil
+}
+
+// toolDefs lists the server's tools over a real MCP tools/list round-trip and
+// converts them to Messages API tool definitions. A nil input schema falls back
+// to an empty object schema.
+func toolDefs(ctx context.Context, session *mcp.ClientSession) ([]toolDef, error) {
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list tools: %w", err)
+	}
+	defs := make([]toolDef, 0, len(result.Tools))
+	for _, tool := range result.Tools {
+		if tool == nil {
+			continue
+		}
+		schema := tool.InputSchema
+		if schema == nil {
+			schema = map[string]any{"type": "object"}
+		}
+		defs = append(defs, toolDef{Name: tool.Name, Description: tool.Description, InputSchema: schema})
+	}
+	return defs, nil
+}

--- a/cmd/eval/loop.go
+++ b/cmd/eval/loop.go
@@ -172,7 +172,7 @@ func truncate(s string, n int) string {
 // that puts the previous values back. A nil or empty map is a no-op.
 func applyEnv(env map[string]string) func() {
 	if len(env) == 0 {
-		return func() {}
+		return func() { /* no variables changed, nothing to restore */ }
 	}
 	saved := make(map[string]*string, len(env))
 	for key, value := range env {

--- a/cmd/eval/loop.go
+++ b/cmd/eval/loop.go
@@ -1,0 +1,196 @@
+//go:build eval
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// maxTurns bounds how many model calls one scenario conversation may make.
+const maxTurns = 4
+
+// maxToolResultLen caps the size of a tool result fed back to the model.
+const maxToolResultLen = 20_000
+
+// toolCall records one executed model tool call and the real MCP response.
+type toolCall struct {
+	Name       string
+	Input      map[string]any
+	Result     *mcp.CallToolResult
+	Structured any
+}
+
+// transcript captures everything a scenario's assertions grade against: every
+// executed tool call and the model's final prose (when it stopped without a
+// tool call).
+type transcript struct {
+	Calls     []toolCall
+	FinalText string
+}
+
+// runScenario drives one scenario to completion: it applies any per-scenario
+// environment, builds a fresh in-process libgen-mcp host, then runs the
+// tool-use loop (send prompt + tools; execute each tool_use against the real
+// MCP session; feed tool_result blocks back) until the model answers without a
+// tool call or the turn budget is exhausted.
+func runScenario(ctx context.Context, ac *anthropicClient, sc scenario) (transcript, error) {
+	restore := applyEnv(sc.SetupEnv)
+	defer restore()
+
+	session, cleanup, err := newHostSession(ctx)
+	if err != nil {
+		return transcript{}, err
+	}
+	defer cleanup()
+
+	defs, err := toolDefs(ctx, session)
+	if err != nil {
+		return transcript{}, err
+	}
+
+	toolChoice := sc.ToolChoice
+	if toolChoice == "" {
+		toolChoice = "auto"
+	}
+
+	var tr transcript
+	messages := []message{{Role: "user", Content: []contentBlock{{Type: "text", Text: sc.Prompt}}}}
+	for range maxTurns {
+		resp, callErr := ac.call(ctx, anthropicRequest{
+			Model:       evalModel,
+			MaxTokens:   maxTokens,
+			Temperature: 0,
+			Tools:       defs,
+			ToolChoice:  map[string]any{"type": toolChoice},
+			Messages:    messages,
+		})
+		if callErr != nil {
+			return tr, callErr
+		}
+		messages = append(messages, message{Role: "assistant", Content: resp.Content})
+
+		uses := toolUseBlocks(resp.Content)
+		if len(uses) == 0 {
+			tr.FinalText = textOf(resp.Content)
+			return tr, nil
+		}
+		results := make([]contentBlock, 0, len(uses))
+		for _, use := range uses {
+			call, block := executeTool(ctx, session, use)
+			tr.Calls = append(tr.Calls, call)
+			results = append(results, block)
+		}
+		messages = append(messages, message{Role: "user", Content: results})
+	}
+	return tr, nil
+}
+
+// executeTool runs one model tool_use against the live MCP session and returns
+// both the recorded toolCall and the tool_result block to feed back to the model.
+func executeTool(ctx context.Context, session *mcp.ClientSession, use contentBlock) (toolCall, contentBlock) {
+	call := toolCall{Name: use.Name, Input: use.Input}
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: use.Name, Arguments: use.Input})
+	if err != nil {
+		return call, contentBlock{
+			Type:      "tool_result",
+			ToolUseID: use.ID,
+			Content:   "tool call failed: " + err.Error(),
+			IsError:   true,
+		}
+	}
+	call.Result = res
+	if res != nil {
+		call.Structured = res.StructuredContent
+	}
+	return call, contentBlock{
+		Type:      "tool_result",
+		ToolUseID: use.ID,
+		Content:   resultText(res),
+		IsError:   res != nil && res.IsError,
+	}
+}
+
+// toolUseBlocks returns the tool_use blocks from a model response, in order.
+func toolUseBlocks(blocks []contentBlock) []contentBlock {
+	var uses []contentBlock
+	for _, b := range blocks {
+		if b.Type == "tool_use" {
+			uses = append(uses, b)
+		}
+	}
+	return uses
+}
+
+// textOf joins the text blocks of a model response.
+func textOf(blocks []contentBlock) string {
+	var parts []string
+	for _, b := range blocks {
+		if b.Type == "text" && strings.TrimSpace(b.Text) != "" {
+			parts = append(parts, b.Text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// resultText renders an MCP tool result as text for the model, preferring the
+// structured content JSON and falling back to text content.
+func resultText(res *mcp.CallToolResult) string {
+	if res == nil {
+		return "empty result"
+	}
+	if res.StructuredContent != nil {
+		if data, err := json.Marshal(res.StructuredContent); err == nil {
+			return truncate(string(data), maxToolResultLen)
+		}
+	}
+	var parts []string
+	for _, content := range res.Content {
+		if text, ok := content.(*mcp.TextContent); ok && strings.TrimSpace(text.Text) != "" {
+			parts = append(parts, text.Text)
+		}
+	}
+	if len(parts) == 0 {
+		return "ok"
+	}
+	return truncate(strings.Join(parts, "\n"), maxToolResultLen)
+}
+
+// truncate clips s to at most n bytes, appending an ellipsis marker when cut.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}
+
+// applyEnv sets the given environment variables and returns a restore function
+// that puts the previous values back. A nil or empty map is a no-op.
+func applyEnv(env map[string]string) func() {
+	if len(env) == 0 {
+		return func() {}
+	}
+	saved := make(map[string]*string, len(env))
+	for key, value := range env {
+		if old, ok := os.LookupEnv(key); ok {
+			restore := old
+			saved[key] = &restore
+		} else {
+			saved[key] = nil
+		}
+		_ = os.Setenv(key, value)
+	}
+	return func() {
+		for key, old := range saved {
+			if old == nil {
+				_ = os.Unsetenv(key)
+			} else {
+				_ = os.Setenv(key, *old)
+			}
+		}
+	}
+}

--- a/cmd/eval/main.go
+++ b/cmd/eval/main.go
@@ -1,0 +1,125 @@
+//go:build eval
+
+// Command eval is a LIVE, LLM-driven eval harness for libgen-mcp. It drives a
+// small Anthropic model (claude-haiku-4-5) over the real libgen-mcp tools,
+// registered on an in-process MCP server, and grades whether the model selects
+// the right tool with well-formed arguments and gets a usable real response.
+//
+// It is LIVE: it spends Anthropic API tokens, hits real Library Genesis mirrors
+// and article sources, and downloads real files into a temporary directory. It
+// is compiled only under the "eval" build tag and, even then, refuses to run
+// unless LIBGEN_EVAL=1 and ANTHROPIC_API_KEY are both set.
+//
+// Usage:
+//
+//	LIBGEN_EVAL=1 ANTHROPIC_API_KEY=sk-... go run -tags eval ./cmd/eval
+//	go run -tags eval ./cmd/eval --only S1,S6 --results-doc out.md --keep-downloads
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// maxDownloadBytes caps every download the harness makes (25 MiB) so a runaway
+// file never fills the disk.
+const maxDownloadBytes = 25 * 1024 * 1024
+
+func main() {
+	only := flag.String("only", "", "comma-separated scenario IDs to run (e.g. S1,S6); empty runs all")
+	keep := flag.Bool("keep-downloads", false, "keep the temporary download directory instead of removing it")
+	resultsDoc := flag.String("results-doc", "", "write a markdown results table to this path")
+	flag.Parse()
+
+	if os.Getenv("LIBGEN_EVAL") != "1" || strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) == "" {
+		fmt.Println("libgen-mcp eval is gated. This is a LIVE harness (real Anthropic API + real libgen mirrors + real downloads).")
+		fmt.Println("Set LIBGEN_EVAL=1 and ANTHROPIC_API_KEY to run it. Skipping.")
+		return
+	}
+	os.Exit(runEval(*only, *keep, *resultsDoc))
+}
+
+// runEval sets up the temporary download sandbox, runs the selected scenarios,
+// prints the report, and returns the process exit code (non-zero when any
+// scenario failed or errored).
+func runEval(only string, keep bool, resultsDoc string) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	dir, err := os.MkdirTemp("", "libgen-eval-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "create temp download dir:", err)
+		return 1
+	}
+	defer func() {
+		if keep {
+			fmt.Println("kept downloads in", dir)
+			return
+		}
+		_ = os.RemoveAll(dir)
+	}()
+
+	// Point the server at the sandbox and cap download size BEFORE any
+	// config.Load (newHostSession loads config per scenario).
+	_ = os.Setenv("LIBGEN_MCP_DOWNLOAD_DIR", dir)
+	_ = os.Setenv("LIBGEN_MCP_MAX_DOWNLOAD_BYTES", strconv.Itoa(maxDownloadBytes))
+
+	scs := selectScenarios(scenarios(), only)
+	if len(scs) == 0 {
+		fmt.Fprintf(os.Stderr, "no scenarios matched --only=%q\n", only)
+		return 1
+	}
+
+	ac := newAnthropicClient(os.Getenv("ANTHROPIC_API_KEY"))
+	outcomes := make([]outcome, 0, len(scs))
+	failures := 0
+	for _, sc := range scs {
+		oc := runOne(ctx, ac, sc)
+		outcomes = append(outcomes, oc)
+		if oc.Status == statusFail || oc.Status == statusError {
+			failures++
+		}
+		fmt.Printf("[%-5s] %s: %s\n", strings.ToUpper(oc.Status), oc.ID, oc.Message)
+	}
+
+	printReport(os.Stdout, outcomes)
+	if resultsDoc != "" {
+		if writeErr := writeResultsDoc(resultsDoc, outcomes, evalModel); writeErr != nil {
+			fmt.Fprintln(os.Stderr, writeErr)
+			return 1
+		}
+	}
+	if failures > 0 {
+		return 1
+	}
+	return 0
+}
+
+// runOne runs a single scenario and grades its transcript into an outcome. A
+// harness/API error is an "error"; an assertion SKIP message is a "skip".
+func runOne(ctx context.Context, ac *anthropicClient, sc scenario) outcome {
+	tr, err := runScenario(ctx, ac, sc)
+	oc := outcome{ID: sc.ID, Calls: len(tr.Calls)}
+	if err != nil {
+		oc.Status = statusError
+		oc.Message = err.Error()
+		return oc
+	}
+	ok, msg := sc.Assert(tr)
+	oc.Message = msg
+	switch {
+	case strings.HasPrefix(msg, skipPrefix):
+		oc.Status = statusSkip
+	case ok:
+		oc.Status = statusPass
+	default:
+		oc.Status = statusFail
+	}
+	return oc
+}

--- a/cmd/eval/report.go
+++ b/cmd/eval/report.go
@@ -1,0 +1,70 @@
+//go:build eval
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// scenario outcome statuses.
+const (
+	statusPass  = "pass"
+	statusFail  = "fail"
+	statusSkip  = "skip"
+	statusError = "error"
+)
+
+// outcome is the graded result of one scenario.
+type outcome struct {
+	ID      string
+	Status  string
+	Message string
+	Calls   int
+}
+
+// printReport writes a human-readable summary of all outcomes to w.
+func printReport(w io.Writer, outcomes []outcome) {
+	fmt.Fprintln(w, "\nlibgen-mcp live LLM eval results")
+	fmt.Fprintln(w, "================================")
+	var pass, fail, skip, fail2 int
+	for _, o := range outcomes {
+		fmt.Fprintf(w, "%-4s %-6s %s\n", o.ID, strings.ToUpper(o.Status), o.Message)
+		switch o.Status {
+		case statusPass:
+			pass++
+		case statusFail:
+			fail++
+		case statusSkip:
+			skip++
+		case statusError:
+			fail2++
+		}
+	}
+	fmt.Fprintf(w, "--------------------------------\n%d passed, %d failed, %d errored, %d skipped (of %d)\n",
+		pass, fail, fail2, skip, len(outcomes))
+}
+
+// writeResultsDoc writes a markdown results table to path.
+func writeResultsDoc(path string, outcomes []outcome, model string) error {
+	var b strings.Builder
+	b.WriteString("# libgen-mcp live LLM eval results\n\n")
+	fmt.Fprintf(&b, "Model: `%s`\n\n", model)
+	b.WriteString("| Scenario | Status | Detail |\n| --- | --- | --- |\n")
+	for _, o := range outcomes {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", o.ID, strings.ToUpper(o.Status), escapeCell(o.Message))
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return fmt.Errorf("write results doc: %w", err)
+	}
+	return nil
+}
+
+// escapeCell makes a message safe for a single markdown table cell.
+func escapeCell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
+}

--- a/cmd/eval/scenarios.go
+++ b/cmd/eval/scenarios.go
@@ -18,6 +18,10 @@ import (
 // flaky live mirror), not a pass or a fail.
 const skipPrefix = "SKIP:"
 
+// noDownloadCall is the failure detail when a download scenario produced no
+// download tool call.
+const noDownloadCall = "no download call"
+
 // openAccessDOI is a stable open-access article DOI used by the DOI download
 // scenario (PLoS ONE, freely available via Unpaywall / Sci-Hub).
 const openAccessDOI = "10.1371/journal.pone.0000308"
@@ -294,7 +298,7 @@ func assertS4(tr transcript) (pass bool, detail string) {
 func assertS5(tr transcript) (pass bool, detail string) {
 	call, ok := findCall(tr, "download")
 	if !ok {
-		return false, "no download call"
+		return false, noDownloadCall
 	}
 	if !isMD5(stringField(call.Input, "md5")) {
 		return false, "download md5 is not 32-hex"
@@ -323,7 +327,7 @@ func assertS6Randombook(tr transcript) (pass bool, detail string) {
 func assertSourcedDownload(tr transcript, want, key string) (pass bool, detail string) {
 	call, ok := findCall(tr, "download")
 	if !ok {
-		return false, "no download call"
+		return false, noDownloadCall
 	}
 	if stringField(call.Input, "source") != want {
 		return false, "download source arg is not " + want
@@ -344,7 +348,7 @@ func assertSourcedDownload(tr transcript, want, key string) (pass bool, detail s
 func assertS7(tr transcript) (pass bool, detail string) {
 	call, ok := findCall(tr, "download")
 	if !ok {
-		return false, "no download call"
+		return false, noDownloadCall
 	}
 	if !isDOI(stringField(call.Input, "doi")) {
 		return false, "download doi is not a valid DOI"

--- a/cmd/eval/scenarios.go
+++ b/cmd/eval/scenarios.go
@@ -1,0 +1,419 @@
+//go:build eval
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/jmrplens/libgen-mcp/internal/libgen"
+	"github.com/jmrplens/libgen-mcp/internal/tools"
+)
+
+// skipPrefix marks an assertion message as a SKIP (an unmet precondition or a
+// flaky live mirror), not a pass or a fail.
+const skipPrefix = "SKIP:"
+
+// openAccessDOI is a stable open-access article DOI used by the DOI download
+// scenario (PLoS ONE, freely available via Unpaywall / Sci-Hub).
+const openAccessDOI = "10.1371/journal.pone.0000308"
+
+// scenario is one live end-to-end check: a natural-language prompt, an optional
+// per-scenario environment, and an assertion over the resulting transcript.
+// Assertions grade the tool name, the argument JSON shape, and whether the real
+// MCP response is non-empty / well-formed — never exact catalog content.
+type scenario struct {
+	ID         string
+	Prompt     string
+	ToolChoice string
+	SetupEnv   map[string]string
+	Assert     func(transcript) (bool, string)
+}
+
+var (
+	md5Pattern = regexp.MustCompile(`^[0-9a-fA-F]{32}$`)
+	doiPattern = regexp.MustCompile(`^10\.\d{4,9}/`)
+)
+
+// isMD5 reports whether s is a 32-character hex md5.
+func isMD5(s string) bool { return md5Pattern.MatchString(strings.TrimSpace(s)) }
+
+// isDOI reports whether s looks like a DOI (10.<registrant>/...).
+func isDOI(s string) bool { return doiPattern.MatchString(strings.TrimSpace(s)) }
+
+// hasTopic reports whether the tool input's topics array contains topic.
+func hasTopic(input map[string]any, topic string) bool {
+	return slices.Contains(stringSlice(input, "topics"), topic)
+}
+
+// subsetOf reports whether every value in got is one of the allowed values. An
+// empty got is trivially a subset.
+func subsetOf(got []string, allowed ...string) bool {
+	for _, g := range got {
+		if !slices.Contains(allowed, g) {
+			return false
+		}
+	}
+	return true
+}
+
+// stringSlice extracts a string slice from a JSON-decoded tool input value.
+func stringSlice(input map[string]any, key string) []string {
+	raw, ok := input[key]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, isStr := item.(string); isStr {
+				out = append(out, s)
+			}
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+// stringField extracts a string field from a JSON-decoded tool input value.
+func stringField(input map[string]any, key string) string {
+	if s, ok := input[key].(string); ok {
+		return strings.TrimSpace(s)
+	}
+	return ""
+}
+
+// findCall returns the first tool call with the given name.
+func findCall(tr transcript, name string) (toolCall, bool) {
+	for _, c := range tr.Calls {
+		if c.Name == name {
+			return c, true
+		}
+	}
+	return toolCall{}, false
+}
+
+// decodeStructured re-marshals a JSON-decoded structured content value into a
+// typed target.
+func decodeStructured(v, target any) error {
+	if v == nil {
+		return errors.New("no structured content")
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal structured: %w", err)
+	}
+	if err = json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("decode structured: %w", err)
+	}
+	return nil
+}
+
+// searchOutput finds the first search call and decodes its structured output.
+func searchOutput(tr transcript) (toolCall, tools.SearchOutput, error) {
+	call, ok := findCall(tr, "search")
+	if !ok {
+		return toolCall{}, tools.SearchOutput{}, errors.New("no search call")
+	}
+	var out tools.SearchOutput
+	if err := decodeStructured(call.Structured, &out); err != nil {
+		return call, tools.SearchOutput{}, err
+	}
+	return call, out, nil
+}
+
+// downloadFailed reports whether a download tool call did not produce a file
+// (protocol error or an IsError result), which for a live mirror is treated as
+// a SKIP rather than a model failure.
+func downloadFailed(call toolCall) bool {
+	return call.Result == nil || call.Result.IsError
+}
+
+// md5InSearchResults reports whether md5 appears in any prior search result of
+// the transcript.
+func md5InSearchResults(tr transcript, md5 string) bool {
+	for _, c := range tr.Calls {
+		if c.Name != "search" {
+			continue
+		}
+		var out tools.SearchOutput
+		if decodeStructured(c.Structured, &out) != nil {
+			continue
+		}
+		for _, r := range out.Results {
+			if strings.EqualFold(r.MD5, md5) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// scenarios returns the ordered list of live scenarios.
+func scenarios() []scenario {
+	return []scenario{
+		{
+			ID:     "S1",
+			Prompt: `Find the book "Introduction to Algorithms" by Cormen. It is a non-fiction textbook: search the nonfiction collection and match on the title and author fields.`,
+			Assert: assertS1,
+		},
+		{
+			ID:     "S2",
+			Prompt: `Search for the research article "Attention Is All You Need" in the articles collection.`,
+			Assert: assertS2,
+		},
+		{
+			ID:     "S3",
+			Prompt: `Search Library Genesis for the standard "ISO 9001" in the standards collection.`,
+			Assert: assertS3,
+		},
+		{
+			ID:     "S4",
+			Prompt: `Find the book "Introduction to Algorithms" by Cormen in the nonfiction collection, then fetch the full details of the first result.`,
+			Assert: assertS4,
+		},
+		{
+			ID:     "S5",
+			Prompt: `Find "The C Programming Language" by Kernighan and Ritchie and download it for me.`,
+			Assert: assertS5,
+		},
+		{
+			ID:     "S6",
+			Prompt: `Search for the paper "Attention Is All You Need", then download this paper from sci-hub.`,
+			Assert: assertS6Scihub,
+		},
+		{
+			ID:     "S6b",
+			Prompt: `Find the book "The C Programming Language" by Kernighan and Ritchie, then download it from the randombook source.`,
+			Assert: assertS6Randombook,
+		},
+		{
+			ID:     "S7",
+			Prompt: fmt.Sprintf("Download the open-access article with DOI %s.", openAccessDOI),
+			Assert: assertS7,
+		},
+		{
+			ID:     "S8",
+			Prompt: `Can you find me a good book?`,
+			Assert: assertS8,
+		},
+	}
+}
+
+// assertS1 checks a nonfiction title+author search with a valid first md5.
+func assertS1(tr transcript) (pass bool, detail string) {
+	call, out, err := searchOutput(tr)
+	if err != nil {
+		return false, err.Error()
+	}
+	if stringField(call.Input, "query") == "" {
+		return false, "empty query"
+	}
+	if !hasTopic(call.Input, "nonfiction") {
+		return false, "topics missing nonfiction"
+	}
+	if !subsetOf(stringSlice(call.Input, "search_in"), "title", "author") {
+		return false, "search_in not a subset of {title, author}"
+	}
+	if len(out.Results) == 0 {
+		return false, "search returned no results"
+	}
+	if !isMD5(out.Results[0].MD5) {
+		return false, "first result md5 is not 32-hex"
+	}
+	return true, fmt.Sprintf("nonfiction search; %d results; first md5 ok", len(out.Results))
+}
+
+// assertS2 checks an articles search that yields at least one DOI.
+func assertS2(tr transcript) (pass bool, detail string) {
+	call, out, err := searchOutput(tr)
+	if err != nil {
+		return false, err.Error()
+	}
+	if !hasTopic(call.Input, "articles") {
+		return false, "topics missing articles"
+	}
+	for _, r := range out.Results {
+		if isDOI(r.DOI) {
+			return true, "articles search; found a result with a valid DOI"
+		}
+	}
+	return false, "no result carried a valid DOI"
+}
+
+// assertS3 checks a standards search, skipping when the mirror returns nothing.
+func assertS3(tr transcript) (pass bool, detail string) {
+	call, out, err := searchOutput(tr)
+	if err != nil {
+		return false, err.Error()
+	}
+	if !hasTopic(call.Input, "standards") {
+		return false, "topics missing standards"
+	}
+	if len(out.Results) == 0 {
+		return true, skipPrefix + " standards search returned 0 results from the mirror"
+	}
+	return true, fmt.Sprintf("standards search; %d results", len(out.Results))
+}
+
+// assertS4 checks a get_details call keyed by an md5 from a prior search result.
+func assertS4(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "get_details")
+	if !ok {
+		return false, "no get_details call"
+	}
+	md5 := stringField(call.Input, "md5")
+	if !isMD5(md5) {
+		return false, "get_details md5 is not 32-hex"
+	}
+	if !md5InSearchResults(tr, md5) {
+		return false, "get_details md5 did not come from a prior search result"
+	}
+	if call.Result == nil || call.Result.IsError {
+		return true, skipPrefix + " details lookup failed against the live mirror"
+	}
+	var out tools.DetailsOutput
+	if err := decodeStructured(call.Structured, &out); err != nil {
+		return false, err.Error()
+	}
+	if len(out.File) == 0 && len(out.Edition) == 0 {
+		return false, "details had neither File nor Edition"
+	}
+	return true, "get_details returned a File or Edition record"
+}
+
+// assertS5 checks a book download by md5 produces a saved, non-empty file.
+func assertS5(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, "no download call"
+	}
+	if !isMD5(stringField(call.Input, "md5")) {
+		return false, "download md5 is not 32-hex"
+	}
+	if downloadFailed(call) {
+		return true, skipPrefix + " valid md5 download but the live fetch failed (mirror/network)"
+	}
+	return checkDownloadedFile(call, "")
+}
+
+// assertS6Scihub checks a source-restricted article download from sci-hub.
+func assertS6Scihub(tr transcript) (pass bool, detail string) {
+	return assertSourcedDownload(tr, "scihub", "doi")
+}
+
+// assertS6Randombook checks a source-restricted book download from randombook.
+func assertS6Randombook(tr transcript) (pass bool, detail string) {
+	return assertSourcedDownload(tr, "randombook", "md5")
+}
+
+// assertSourcedDownload checks that the model set the source arg to want and
+// keyed the download by the expected identifier (doi or md5). When the live
+// fetch succeeds it also confirms DownloadResult.Source == want; a live fetch
+// failure is a SKIP since the model behavior under test (source selection) was
+// still correct.
+func assertSourcedDownload(tr transcript, want, key string) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, "no download call"
+	}
+	if stringField(call.Input, "source") != want {
+		return false, "download source arg is not " + want
+	}
+	if key == "doi" && !isDOI(stringField(call.Input, "doi")) {
+		return false, "download doi is not a valid DOI"
+	}
+	if key == "md5" && !isMD5(stringField(call.Input, "md5")) {
+		return false, "download md5 is not 32-hex"
+	}
+	if downloadFailed(call) {
+		return true, skipPrefix + " model set source=" + want + " correctly but the live download failed (mirror/network)"
+	}
+	return checkDownloadedFile(call, want)
+}
+
+// assertS7 checks an open-access DOI download served by unpaywall or sci-hub.
+func assertS7(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, "no download call"
+	}
+	if !isDOI(stringField(call.Input, "doi")) {
+		return false, "download doi is not a valid DOI"
+	}
+	if downloadFailed(call) {
+		return true, skipPrefix + " valid DOI download but the live fetch failed (mirror/network)"
+	}
+	fileOK, msg := checkDownloadedFile(call, "")
+	if !fileOK {
+		return fileOK, msg
+	}
+	var res libgen.DownloadResult
+	if err := decodeStructured(call.Structured, &res); err != nil {
+		return false, err.Error()
+	}
+	if res.Source != "unpaywall" && res.Source != "scihub" {
+		return false, "unexpected article source " + res.Source
+	}
+	return true, "downloaded DOI via " + res.Source
+}
+
+// assertS8 passes when the model asks to clarify (no tool call) or the search
+// tool's own validation rejects the missing query.
+func assertS8(tr transcript) (pass bool, detail string) {
+	if len(tr.Calls) == 0 {
+		return true, "model asked to clarify instead of guessing (no tool call)"
+	}
+	for _, c := range tr.Calls {
+		if c.Name == "search" && c.Result != nil && c.Result.IsError {
+			return true, "search validation rejected the underspecified query"
+		}
+	}
+	return false, "model called a tool without clarifying the ambiguous request"
+}
+
+// checkDownloadedFile decodes a download result and confirms a non-empty saved
+// path and size, plus (when want is non-empty) the serving source.
+func checkDownloadedFile(call toolCall, want string) (pass bool, detail string) {
+	var res libgen.DownloadResult
+	if err := decodeStructured(call.Structured, &res); err != nil {
+		return false, err.Error()
+	}
+	if res.Path == "" || res.SizeBytes <= 0 {
+		return false, "download result had an empty path or zero size"
+	}
+	if want != "" && res.Source != want {
+		return false, "DownloadResult.Source is " + res.Source + ", want " + want
+	}
+	return true, fmt.Sprintf("downloaded %d bytes via %s", res.SizeBytes, res.Source)
+}
+
+// selectScenarios filters scenarios by a comma-separated --only list (empty
+// runs all).
+func selectScenarios(all []scenario, only string) []scenario {
+	only = strings.TrimSpace(only)
+	if only == "" {
+		return all
+	}
+	wanted := map[string]bool{}
+	for id := range strings.SplitSeq(only, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			wanted[id] = true
+		}
+	}
+	var out []scenario
+	for _, sc := range all {
+		if wanted[sc.ID] {
+			out = append(out, sc)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
A small, LIVE eval harness (`cmd/eval`, gated behind `//go:build eval` + `LIBGEN_EVAL=1` + `ANTHROPIC_API_KEY`) that drives Claude **Haiku** with the 3 MCP tools in-process and asserts the model calls the right tool with the right arguments and the MCP returns the expected result from real Library Genesis.

- Raw net/http Anthropic Messages client (no SDK); in-process MCP host reusing the gen_llms pattern; a bounded tool-use loop executing **real** `session.CallTool`.
- 9 scenarios: book/article/standard search with filters, `get_details` on a live md5, book & open-access-article downloads, and **S6/S6b that assert the model sets the new `source` arg** (`scihub`/`randombook`) — the payoff of the download-source feature.
- Fully gated: invisible to `go build ./...`, `go test ./...`, and CI; no-env run prints a skip notice and exits 0. Downloads go to a temp dir with a 25 MiB cap and are cleaned up. `make eval` target added.

Verified locally: `go build -tags eval ./cmd/eval` + vet + gofmt clean; normal build/tests unaffected; golangci (with the eval tag) and godoc audit clean. The live eval was intentionally NOT run here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live eval harness in `cmd/eval` that drives a real Anthropic model over `search`, `get_details`, and `download`, verifying the model chooses the right tool and arguments against Library Genesis. It’s tag- and env-gated, so normal builds, tests, and CI stay untouched.

- **New Features**
  - Compiled only with `//go:build eval`; requires `LIBGEN_EVAL=1` and `ANTHROPIC_API_KEY`.
  - Raw `net/http` Messages API client (`claude-haiku-4-5-20251001`); temperature 0; `tool_choice: auto`; up to 4 turns.
  - Fresh in-process MCP host per scenario; executes real `session.CallTool`.
  - 9 scenarios across searches, details, and downloads; asserts `download.source` (`scihub`, `randombook`).
  - Downloads to a temp dir capped at 25 MiB via `LIBGEN_MCP_MAX_DOWNLOAD_BYTES`; flags: `--only`, `--keep-downloads`, `--results-doc`.
  - `Makefile` adds `eval` target (`LIBGEN_EVAL=1 go run -tags eval ./cmd/eval`).

- **Refactors**
  - Resolved SonarCloud findings (empty func comment, deduplicated literal); no behavior changes.

<sup>Written for commit 899e8348360cf9805dd23db5b210a3c4337756e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

