### PR TITLE
test(eval): add deterministic start-retries scenario (S9)

### DIFF
--- a/cmd/eval/README.md
+++ b/cmd/eval/README.md
@@ -42,11 +42,20 @@ response is non-empty / well-formed** — never exact catalog content, which dri
 | S6b | Download choosing a book source: model sets `source:"randombook"` for an md5 |
 | S7  | Open-access article by DOI, served by unpaywall or sci-hub |
 | S8  | Ambiguous "find me a good book" — passes if the model clarifies or the tool rejects it |
+| S9  | **Start-retries**: sci-hub pinned to a dead host, so the staged retry schedule exhausts and the tool must surface the actionable "could not start" error — and the model must not fabricate success |
 
 S6 / S6b are the reason this harness exists alongside the older checks: the
 `download` tool now takes an optional **`source`** argument, and these scenarios
 assert the model actually sets it (and that `DownloadResult.Source` matches when
 the live fetch succeeds).
+
+S9 exercises the download **start-retry** path deterministically without needing
+a flaky live failure: it enables only `scihub`, points `LIBGEN_MCP_SCIHUB_HOSTS`
+at `127.0.0.1` (connection refused instantly), and shrinks
+`LIBGEN_MCP_DOWNLOAD_START_RETRY_WAITS` to `1ms,1ms` so the whole staged schedule
+runs sub-second. It asserts the tool returns the actionable could-not-start error
+(naming retry-now / retry-later / ask-the-user recovery) and that the model
+reacts — relaying the failure or retrying — instead of claiming a saved file.
 
 ## Running
 

--- a/cmd/eval/scenarios.go
+++ b/cmd/eval/scenarios.go
@@ -22,6 +22,10 @@ const skipPrefix = "SKIP:"
 // download tool call.
 const noDownloadCall = "no download call"
 
+// notAValidDOI is the failure detail when a download call's doi argument is not
+// a syntactically valid DOI.
+const notAValidDOI = "download doi is not a valid DOI"
+
 // openAccessDOI is a stable open-access article DOI used by the DOI download
 // scenario (PLoS ONE, freely available via Unpaywall / Sci-Hub).
 const openAccessDOI = "10.1371/journal.pone.0000308"
@@ -350,7 +354,7 @@ func assertSourcedDownload(tr transcript, want, key string) (pass bool, detail s
 		return false, "download source arg is not " + want
 	}
 	if key == "doi" && !isDOI(stringField(call.Input, "doi")) {
-		return false, "download doi is not a valid DOI"
+		return false, notAValidDOI
 	}
 	if key == "md5" && !isMD5(stringField(call.Input, "md5")) {
 		return false, "download md5 is not 32-hex"
@@ -368,7 +372,7 @@ func assertS7(tr transcript) (pass bool, detail string) {
 		return false, noDownloadCall
 	}
 	if !isDOI(stringField(call.Input, "doi")) {
-		return false, "download doi is not a valid DOI"
+		return false, notAValidDOI
 	}
 	if downloadFailed(call) {
 		return true, skipPrefix + " valid DOI download but the live fetch failed (mirror/network)"
@@ -402,7 +406,7 @@ func assertS9Retry(tr transcript) (pass bool, detail string) {
 		return false, "download source arg is not scihub"
 	}
 	if !isDOI(stringField(call.Input, "doi")) {
-		return false, "download doi is not a valid DOI"
+		return false, notAValidDOI
 	}
 	if !downloadFailed(call) {
 		return false, "expected the download to fail to start against the dead host, but it succeeded"

--- a/cmd/eval/scenarios.go
+++ b/cmd/eval/scenarios.go
@@ -209,6 +209,23 @@ func scenarios() []scenario {
 			Prompt: `Can you find me a good book?`,
 			Assert: assertS8,
 		},
+		{
+			ID:     "S9",
+			Prompt: fmt.Sprintf("Download the open-access article with DOI %s from sci-hub.", openAccessDOI),
+			// Force a fast, deterministic start-failure: sci-hub is the only
+			// enabled source and its sole host is a dead local address, so every
+			// resolve/connect attempt is refused instantly. The 1ms retry waits
+			// keep the whole staged schedule sub-second while still exercising it
+			// end to end, so the tool must surface the actionable could-not-start
+			// error and the model must react without fabricating success.
+			SetupEnv: map[string]string{
+				"LIBGEN_MCP_SOURCES":                    "scihub",
+				"LIBGEN_MCP_SCIHUB_HOSTS":               "127.0.0.1",
+				"LIBGEN_MCP_DOWNLOAD_START_RETRY_WAITS": "1ms,1ms",
+				"LIBGEN_MCP_TIMEOUT":                    "2s",
+			},
+			Assert: assertS9Retry,
+		},
 	}
 }
 
@@ -368,6 +385,62 @@ func assertS7(tr transcript) (pass bool, detail string) {
 		return false, "unexpected article source " + res.Source
 	}
 	return true, "downloaded DOI via " + res.Source
+}
+
+// assertS9Retry checks the staged start-retry schedule end to end: with sci-hub
+// pinned to a dead host, the download must exhaust its retries and surface the
+// actionable "could not start" error (naming retry-now / retry-later / ask-the-
+// user recovery), and the model must react to that error rather than fabricate a
+// successful download. A live success here is impossible (the host is dead), so
+// an unexpected non-error result is a genuine failure, not a SKIP.
+func assertS9Retry(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, noDownloadCall
+	}
+	if stringField(call.Input, "source") != "scihub" {
+		return false, "download source arg is not scihub"
+	}
+	if !isDOI(stringField(call.Input, "doi")) {
+		return false, "download doi is not a valid DOI"
+	}
+	if !downloadFailed(call) {
+		return false, "expected the download to fail to start against the dead host, but it succeeded"
+	}
+	errText := strings.ToLower(resultText(call.Result))
+	if !strings.Contains(errText, "retry") || !strings.Contains(errText, "ask") {
+		return false, "tool error is not the actionable could-not-start message: " + errText
+	}
+	// Valid recovery is either relaying the failure/options to the user or
+	// actively retrying the download itself; fabricating success is the failure.
+	recovered := containsAny(strings.ToLower(tr.FinalText),
+		"retry", "later", "again", "unable", "couldn't", "could not", "failed", "wasn't able", "ask") ||
+		countCalls(tr, "download") >= 2
+	if !recovered {
+		return false, "model neither retried nor surfaced the start-failure to the user"
+	}
+	return true, "start-retries exhausted; actionable error surfaced and the model did not fabricate success"
+}
+
+// containsAny reports whether s contains any of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// countCalls counts the tool calls with the given name in the transcript.
+func countCalls(tr transcript, name string) int {
+	n := 0
+	for _, c := range tr.Calls {
+		if c.Name == name {
+			n++
+		}
+	}
+	return n
 }
 
 // assertS8 passes when the model asks to clarify (no tool call) or the search


### PR DESCRIPTION
Extends the gated LLM eval harness (`cmd/eval`, `//go:build eval`) to cover the new download **start-retry** path — the follow-up to PR #10 that added the staged retry schedule and progress-aware stall timeout.

## What S9 checks

A deterministic start-failure, no flaky live mirror required:

- Enables only `scihub` (`LIBGEN_MCP_SOURCES=scihub`).
- Pins `LIBGEN_MCP_SCIHUB_HOSTS=127.0.0.1` → every resolve/connect attempt is refused instantly.
- Shrinks `LIBGEN_MCP_DOWNLOAD_START_RETRY_WAITS=1ms,1ms` so the whole staged schedule runs sub-second.

The assertion verifies both layers:

1. **Tool contract** — the download exhausts the retry schedule and returns the actionable `errDownloadCouldNotStart` message (naming retry-now / retry-later / ask-the-user recovery).
2. **Model behavior** — the model honors `source:"scihub"`, and on the errored result it *reacts* (relays the failure / offers to retry / retries the tool) instead of fabricating a saved file.

## Verification

- `go build -tags eval ./cmd/eval/` ✅
- `go vet -tags eval ./cmd/eval/` ✅
- `golangci-lint run --build-tags eval ./cmd/eval/...` ✅
- `gocognit -over 15` ✅ (assertS9Retry under threshold)
- `make check-md-tables` ✅

README scenario table updated with S9 and the env-knob explanation.

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic start-retry scenario (S9) to the `cmd/eval` harness to exercise the download start-retry path end to end. Also deduplicates the invalid-DOI error text via a constant for consistent assertions.

- New Features
  - S9 enables only `scihub`, pins host to 127.0.0.1, and sets `LIBGEN_MCP_DOWNLOAD_START_RETRY_WAITS=1ms,1ms` and `LIBGEN_MCP_TIMEOUT=2s` for a fast, deterministic failure.
  - Verifies `source:"scihub"`, valid DOI, retries are exhausted, actionable “could not start” error (retry-now / retry-later / ask-the-user), and that the model relays or retries instead of faking success. README updated with S9 and env-knob notes.

- Refactors
  - Extracted the repeated “download doi is not a valid DOI” string to a `notAValidDOI` constant and used it where applicable.

<sup>Written for commit 272f584d22ff971996207c1cc193240fb75daed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

