### PR TITLE
feat(tools): richer discoverability — next_steps, Markdown output, download-link guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ claude mcp add libgen -- docker run -i --rm ghcr.io/jmrplens/libgen-mcp:latest
 
 ## Tools
 
+Every result is returned on two channels: the structured JSON output (fields below) and a human-readable Markdown rendering in the text content — for `search`, a results table with each result's clickable download links. Both channels lead with a `next_steps` guidance list, and the search guidance tells the model to include the download links when presenting results.
+
 ### `search`
 
 Search the Library Genesis catalog. Returns a page of file results with metadata, MD5 hashes, and download options, plus pagination metadata.
@@ -106,17 +108,18 @@ Search the Library Genesis catalog. Returns a page of file results with metadata
 
 The response includes pagination metadata so the model can decide whether to page or refine:
 
-| Field              | Type   | Description                                                                                     |
-| ------------------ | ------ | ----------------------------------------------------------------------------------------------- |
-| `results`          | array  | The file records on this page.                                                                  |
-| `page`             | int    | The page number returned.                                                                       |
-| `results_per_page` | int    | Page size in effect.                                                                            |
-| `total_files`      | string | Total matches reported by the mirror for the query.                                             |
-| `reachable`        | int    | How many of those matches were actually parsed/reachable.                                       |
-| `truncated`        | bool   | `true` when only the first slice of matches is reachable.                                       |
-| `hint`             | string | When truncated, a suggestion to refine the query (add author/year, title-only columns, topics). |
-| `has_more`         | bool   | `true` when a full page was returned (more results likely on the next page).                    |
-| `mirror`           | string | The mirror that served the query.                                                               |
+| Field              | Type   | Description                                                                                                                                                                                                |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps`       | array  | Model-facing follow-up suggestions with a ready-to-run example (e.g. a `get_details`/`download` call using a result's `md5`/`doi`, or how to broaden a no-match query). Every tool output leads with this. |
+| `results`          | array  | The file records on this page.                                                                                                                                                                             |
+| `page`             | int    | The page number returned.                                                                                                                                                                                  |
+| `results_per_page` | int    | Page size in effect.                                                                                                                                                                                       |
+| `total_files`      | string | Total matches reported by the mirror for the query.                                                                                                                                                        |
+| `reachable`        | int    | How many of those matches were actually parsed/reachable.                                                                                                                                                  |
+| `truncated`        | bool   | `true` when only the first slice of matches is reachable.                                                                                                                                                  |
+| `hint`             | string | When truncated, a suggestion to refine the query (add author/year, title-only columns, topics).                                                                                                            |
+| `has_more`         | bool   | `true` when a full page was returned (more results likely on the next page).                                                                                                                               |
+| `mirror`           | string | The mirror that served the query.                                                                                                                                                                          |
 
 ### `get_details`
 

--- a/cmd/eval/README.md
+++ b/cmd/eval/README.md
@@ -43,6 +43,14 @@ response is non-empty / well-formed** — never exact catalog content, which dri
 | S7  | Open-access article by DOI via unpaywall (needs a contact email) |
 | S8  | Ambiguous "find me a good book" — passes if the model clarifies or the tool rejects it |
 | S9  | **Start-retries**: sci-hub pinned to a dead host, so the staged retry schedule exhausts and the tool must surface the actionable "could not start" error — and the model must not fabricate success |
+| S10 | **Unguided book search** ("I want to read _Dune_…") — model must form a search from a bare request, no collection/field hints |
+| S11 | **Unguided search, comics** ("find the graphic novel _Watchmen_") — tests whether the model discovers the right collection unaided |
+| S12 | **Unguided book download** ("download _Clean Code_…") — model must search, then download by an md5 it discovered, choosing the source itself |
+| S13 | **Unguided article download** ("get me a PDF of _Hallmarks of Cancer_") — model must discover that articles are keyed by DOI, not md5 |
+| S14 | **Download progress** — attaches a progress token to the download and asserts progress notifications actually reach the client end to end |
+| S15 | **Ordered table with links** — a large, sorted results request; asserts the model sets a big page size + ordering and includes the results' download links in its answer (the tool's next_steps instructs it to) |
+
+**Guided vs. unguided.** S1–S9 spell out the collection / fields / source to exercise a specific path deterministically. S10–S13 are deliberately **under-specified** — the prompts read like a real user and give no such guidance, so they test whether the model can discover the right tool arguments from the tool and field descriptions alone. They are a proxy for how well the server self-describes to an unguided LLM; a live mirror miss is a SKIP, the model's argument choice still graded.
 
 S6 / S6b are the reason this harness exists alongside the older checks: the
 `download` tool takes an optional **`source`** argument, and these scenarios

--- a/cmd/eval/README.md
+++ b/cmd/eval/README.md
@@ -62,7 +62,7 @@ call; if the model picks the right source but the live fetch fails, it SKIPs
 rather than fails, because the external sources are not equally reliable:
 
 - **libgen** (S5) and **unpaywall** (S7) are the dependable download paths.
-- **sci-hub** (S6) mirrors are volatile and only host *paywalled* papers — S6 uses
+- **sci-hub** (S6) mirrors are volatile and only host _paywalled_ papers — S6 uses
   a heavily-cited paywalled DOI (not an arXiv one, which Sci-Hub does not carry),
   so it can actually complete when a mirror is up, and SKIPs when none are.
 - **randombook** (S6b) rediscovers fresh mirrors each run, so whether a given md5

--- a/cmd/eval/host.go
+++ b/cmd/eval/host.go
@@ -20,14 +20,14 @@ import (
 // libgen mirrors and download sources. The cleanup closes the client and drains
 // the server session. Construction is offline: config.Load and
 // mirrors.NewManager do no network I/O.
-func newHostSession(ctx context.Context) (session *mcp.ClientSession, cleanup func(), err error) {
+func newHostSession(ctx context.Context) (session *mcp.ClientSession, progress *progressCapture, cleanup func(), err error) {
 	cfg, err := config.Load()
 	if err != nil {
-		return nil, nil, fmt.Errorf("load config: %w", err)
+		return nil, nil, nil, fmt.Errorf("load config: %w", err)
 	}
 	mgr, err := mirrors.NewManager(cfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create mirror manager: %w", err)
+		return nil, nil, nil, fmt.Errorf("create mirror manager: %w", err)
 	}
 	client := libgen.New(mgr, cfg)
 
@@ -38,18 +38,26 @@ func newHostSession(ctx context.Context) (session *mcp.ClientSession, cleanup fu
 
 	serverSession, err := server.Connect(ctx, st, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("server connect: %w", err)
+		return nil, nil, nil, fmt.Errorf("server connect: %w", err)
 	}
 
-	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "libgen-eval-client", Version: "0.0.1"}, nil)
+	// Register a progress handler so scenarios can assert that download progress
+	// notifications actually reach the client end to end (see progress token in
+	// executeTool).
+	progress = &progressCapture{}
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "libgen-eval-client", Version: "0.0.1"}, &mcp.ClientOptions{
+		ProgressNotificationHandler: func(_ context.Context, r *mcp.ProgressNotificationClientRequest) {
+			progress.add(r.Params)
+		},
+	})
 	session, err = mcpClient.Connect(ctx, ct, nil)
 	if err != nil {
 		_ = serverSession.Close()
 		_ = serverSession.Wait()
-		return nil, nil, fmt.Errorf("client connect: %w", err)
+		return nil, nil, nil, fmt.Errorf("client connect: %w", err)
 	}
 
-	return session, func() {
+	return session, progress, func() {
 		_ = session.Close()
 		_ = serverSession.Wait()
 	}, nil

--- a/cmd/eval/loop.go
+++ b/cmd/eval/loop.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -17,6 +18,36 @@ const maxTurns = 4
 // maxToolResultLen caps the size of a tool result fed back to the model.
 const maxToolResultLen = 20_000
 
+// downloadProgressToken is attached to every download tool call so the server
+// emits progress notifications the eval client can capture and assert on.
+const downloadProgressToken = "eval-progress"
+
+// progressCapture accumulates the progress notifications the client receives,
+// guarded for the SDK's notification goroutine.
+type progressCapture struct {
+	mu     sync.Mutex
+	events []mcp.ProgressNotificationParams
+}
+
+// add records one received progress notification.
+func (p *progressCapture) add(e *mcp.ProgressNotificationParams) {
+	if e == nil {
+		return
+	}
+	p.mu.Lock()
+	p.events = append(p.events, *e)
+	p.mu.Unlock()
+}
+
+// snapshot returns a copy of the notifications received so far.
+func (p *progressCapture) snapshot() []mcp.ProgressNotificationParams {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]mcp.ProgressNotificationParams, len(p.events))
+	copy(out, p.events)
+	return out
+}
+
 // toolCall records one executed model tool call and the real MCP response.
 type toolCall struct {
 	Name       string
@@ -26,11 +57,12 @@ type toolCall struct {
 }
 
 // transcript captures everything a scenario's assertions grade against: every
-// executed tool call and the model's final prose (when it stopped without a
-// tool call).
+// executed tool call, the model's final prose (when it stopped without a tool
+// call), and the progress notifications the client received during the run.
 type transcript struct {
 	Calls     []toolCall
 	FinalText string
+	Progress  []mcp.ProgressNotificationParams
 }
 
 // runScenario drives one scenario to completion: it applies any per-scenario
@@ -38,11 +70,11 @@ type transcript struct {
 // tool-use loop (send prompt + tools; execute each tool_use against the real
 // MCP session; feed tool_result blocks back) until the model answers without a
 // tool call or the turn budget is exhausted.
-func runScenario(ctx context.Context, ac *anthropicClient, sc scenario) (transcript, error) {
+func runScenario(ctx context.Context, ac *anthropicClient, sc scenario) (tr transcript, err error) {
 	restore := applyEnv(sc.SetupEnv)
 	defer restore()
 
-	session, cleanup, err := newHostSession(ctx)
+	session, progress, cleanup, err := newHostSession(ctx)
 	if err != nil {
 		return transcript{}, err
 	}
@@ -58,7 +90,9 @@ func runScenario(ctx context.Context, ac *anthropicClient, sc scenario) (transcr
 		toolChoice = "auto"
 	}
 
-	var tr transcript
+	// Snapshot the progress notifications at every exit (named return tr), including
+	// the early return when the model answers without a tool call.
+	defer func() { tr.Progress = progress.snapshot() }()
 	messages := []message{{Role: "user", Content: []contentBlock{{Type: "text", Text: sc.Prompt}}}}
 	for range maxTurns {
 		resp, callErr := ac.call(ctx, anthropicRequest{
@@ -94,7 +128,13 @@ func runScenario(ctx context.Context, ac *anthropicClient, sc scenario) (transcr
 // both the recorded toolCall and the tool_result block to feed back to the model.
 func executeTool(ctx context.Context, session *mcp.ClientSession, use contentBlock) (toolCall, contentBlock) {
 	call := toolCall{Name: use.Name, Input: use.Input}
-	res, err := session.CallTool(ctx, &mcp.CallToolParams{Name: use.Name, Arguments: use.Input})
+	params := &mcp.CallToolParams{Name: use.Name, Arguments: use.Input}
+	// Attach a progress token to download calls so the server emits progress
+	// notifications the client captures (see progressCapture).
+	if use.Name == "download" {
+		params.SetProgressToken(downloadProgressToken)
+	}
+	res, err := session.CallTool(ctx, params)
 	if err != nil {
 		return call, contentBlock{
 			Type:      "tool_result",

--- a/cmd/eval/scenarios.go
+++ b/cmd/eval/scenarios.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/jmrplens/libgen-mcp/internal/libgen"
 	"github.com/jmrplens/libgen-mcp/internal/tools"
 )
@@ -176,6 +178,26 @@ func md5InSearchResults(tr transcript, md5 string) bool {
 	return false
 }
 
+// doiInSearchResults reports whether doi appears in any prior search result of
+// the transcript.
+func doiInSearchResults(tr transcript, doi string) bool {
+	for _, c := range tr.Calls {
+		if c.Name != "search" {
+			continue
+		}
+		var out tools.SearchOutput
+		if decodeStructured(c.Structured, &out) != nil {
+			continue
+		}
+		for _, r := range out.Results {
+			if strings.EqualFold(r.DOI, doi) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // scenarios returns the ordered list of live scenarios.
 func scenarios() []scenario {
 	return []scenario{
@@ -244,7 +266,208 @@ func scenarios() []scenario {
 			},
 			Assert: assertS9Retry,
 		},
+		// S10–S13 are deliberately under-specified: the prompts read like a real
+		// user request and give NO guidance on which collection, search fields, or
+		// download source to use. They test that the model can discover the right
+		// tool arguments from the tool/field descriptions alone — a proxy for how
+		// well the server self-describes to an unguided LLM.
+		{
+			ID:     "S10",
+			Prompt: `I want to read the novel "Dune" by Frank Herbert — can you find it in the library for me?`,
+			Assert: assertNaturalSearch("dune"),
+		},
+		{
+			ID:     "S11",
+			Prompt: `Find the graphic novel "Watchmen" by Alan Moore.`,
+			Assert: assertNaturalSearch("watchmen"),
+		},
+		{
+			ID:     "S12",
+			Prompt: `Can you download the book "Clean Code" by Robert C. Martin for me?`,
+			Assert: assertNaturalBookDownload,
+		},
+		{
+			ID: "S13",
+			Prompt: `Get me a PDF of the research paper "Hallmarks of Cancer: The Next Generation" ` +
+				`by Hanahan and Weinberg.`,
+			// A paywalled paper Sci-Hub actually mirrors (unlike an arXiv-only paper),
+			// so the article download path can complete. The model must discover on
+			// its own that articles are fetched by DOI, not md5. Unpaywall is left
+			// disabled (this paper is not open access); Sci-Hub serves it.
+			Assert: assertNaturalArticleDownload,
+		},
+		{
+			ID:     "S14",
+			Prompt: `Find "The C Programming Language" by Kernighan and Ritchie and download it.`,
+			// Progress path: the harness attaches a progress token to every download
+			// call, so a successful download must surface progress notifications to
+			// the client. Asserts the notifications actually arrived end to end.
+			Assert: assertDownloadProgress,
+		},
+		{
+			ID: "S15",
+			Prompt: `List 50 science fiction books sorted by year, newest first, ` +
+				`as a table, and include each book's download links.`,
+			// Surface test: the model must set a large page size and an ordering, and
+			// — because the tool tells it to via next_steps — actually include the
+			// download links in its written answer.
+			Assert: assertOrderedTableWithLinks,
+		},
 	}
+}
+
+// assertOrderedTableWithLinks checks a large, ordered results request that asks
+// for download links: the model must set a big page size and an ordering, get a
+// sizable page whose results carry links, and then include those links in its
+// final answer (the tool's next_steps instructs it to). A thin mirror page is a
+// SKIP.
+func assertOrderedTableWithLinks(tr transcript) (pass bool, detail string) {
+	call, out, err := searchOutput(tr)
+	if err != nil {
+		return false, err.Error()
+	}
+	if per, _ := call.Input["results_per_page"].(float64); per < 50 {
+		return false, fmt.Sprintf("results_per_page should be large (>=50) for a big list; got %v", call.Input["results_per_page"])
+	}
+	if stringField(call.Input, "order") == "" {
+		return false, "model did not set an order for a sorted list"
+	}
+	if len(out.Results) < 25 {
+		return true, fmt.Sprintf("%s ordered search returned only %d results from the mirror", skipPrefix, len(out.Results))
+	}
+	if !resultsCarryLinks(out.Results) {
+		return true, skipPrefix + " results carried no download links from the mirror"
+	}
+	if !finalTextHasLink(tr.FinalText) {
+		return false, "model did not include any download link in its answer despite the results carrying links"
+	}
+	return true, fmt.Sprintf("ordered page of %d with links; model surfaced links in its answer", len(out.Results))
+}
+
+// resultsCarryLinks reports whether any search result exposes a download link.
+func resultsCarryLinks(results []libgen.Result) bool {
+	for _, r := range results {
+		for _, d := range r.Downloads {
+			if d.URL != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// finalTextHasLink reports whether the model's final prose contains a URL or a
+// Markdown link (evidence it surfaced the download links to the user).
+func finalTextHasLink(s string) bool {
+	return strings.Contains(s, "http://") || strings.Contains(s, "https://") || strings.Contains(s, "](")
+}
+
+// assertDownloadProgress checks that a successful download emitted progress
+// notifications that reached the client (the harness attaches a progress token to
+// download calls). A live fetch failure is a SKIP, since no progress can flow when
+// the download never starts.
+func assertDownloadProgress(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, noDownloadCall
+	}
+	if downloadFailed(call) {
+		return true, skipPrefix + " download did not complete live, so no progress could be emitted (mirror/network)"
+	}
+	var last *mcp.ProgressNotificationParams
+	n := 0
+	for i := range tr.Progress {
+		if fmt.Sprint(tr.Progress[i].ProgressToken) == downloadProgressToken {
+			last = &tr.Progress[i]
+			n++
+		}
+	}
+	if n == 0 {
+		return false, "download succeeded but no progress notifications reached the client"
+	}
+	if last.Progress <= 0 {
+		return false, fmt.Sprintf("final progress notification reported no bytes (progress=%v)", last.Progress)
+	}
+	detail = fmt.Sprintf("received %d progress notification(s); final progress=%v total=%v", n, last.Progress, last.Total)
+	return true, detail
+}
+
+// assertNaturalSearch builds an assertion for an under-specified search prompt:
+// the model must translate the request into a single search call whose query
+// carries the distinctive title token, with no guidance on topic or search
+// fields. A mirror that returns nothing is a SKIP, not a failure.
+func assertNaturalSearch(titleToken string) func(transcript) (bool, string) {
+	return func(tr transcript) (pass bool, detail string) {
+		call, out, err := searchOutput(tr)
+		if err != nil {
+			return false, err.Error()
+		}
+		query := strings.ToLower(stringField(call.Input, "query"))
+		if query == "" {
+			return false, "empty query"
+		}
+		if !strings.Contains(query, titleToken) {
+			return false, fmt.Sprintf("query %q does not mention %q", query, titleToken)
+		}
+		if len(out.Results) == 0 {
+			return true, skipPrefix + " search well-formed but the mirror returned 0 results"
+		}
+		topics := stringSlice(call.Input, "topics")
+		return true, fmt.Sprintf("unguided search; %d results; topics=%v", len(out.Results), topics)
+	}
+}
+
+// assertNaturalBookDownload checks an under-specified "download this book" prompt:
+// the model must search, then download by an md5 it discovered — without being
+// told to use md5 or which source. A live fetch failure is a SKIP.
+func assertNaturalBookDownload(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, noDownloadCall
+	}
+	md5 := stringField(call.Input, "md5")
+	if !isMD5(md5) {
+		return false, "model did not download by a valid md5 (books are md5-keyed)"
+	}
+	if !md5InSearchResults(tr, md5) {
+		return false, "download md5 did not come from a prior search result"
+	}
+	if downloadFailed(call) {
+		return true, skipPrefix + " model discovered the md5 download flow but the live fetch failed (mirror/network)"
+	}
+	return checkDownloadedFile(call, "")
+}
+
+// assertNaturalArticleDownload checks an under-specified "get me the PDF of this
+// paper" prompt: the model must discover that articles are keyed by DOI (not
+// md5) and download by a valid DOI — no source named. Downloading by a valid DOI
+// is the discovery signal under test; whether the DOI came from a prior search or
+// the model already knew it is not graded (a wrong DOI would simply fail to
+// resolve → SKIP, never a false pass). A live fetch failure is a SKIP.
+func assertNaturalArticleDownload(tr transcript) (pass bool, detail string) {
+	call, ok := findCall(tr, "download")
+	if !ok {
+		return false, noDownloadCall
+	}
+	doi := stringField(call.Input, "doi")
+	if !isDOI(doi) {
+		if isMD5(stringField(call.Input, "md5")) {
+			return false, "model downloaded by md5; articles must be keyed by doi"
+		}
+		return false, "model did not download by a valid doi"
+	}
+	via := "known"
+	if doiInSearchResults(tr, doi) {
+		via = "search"
+	}
+	if downloadFailed(call) {
+		return true, fmt.Sprintf("%s model chose a valid doi (%s) but the live fetch failed (mirror/network)", skipPrefix, via)
+	}
+	ok2, msg := checkDownloadedFile(call, "")
+	if !ok2 {
+		return ok2, msg
+	}
+	return true, msg + " (doi via " + via + ")"
 }
 
 // assertS1 checks a nonfiction title+author search with a valid first md5.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,6 +6,12 @@ and [`download`](#download). All three are annotated with an open-world hint; `s
 is panic-safe: an unexpected failure is returned as a tool error, never as a crash of the
 session.
 
+Every result is returned on **two channels**: the structured JSON output (fields documented
+below) and a human-readable Markdown rendering in the text content — for `search`, a results
+table that includes each result's clickable download links. Both channels lead with a
+`next_steps` guidance list; the search guidance tells the model to include the download links
+when it presents the results to the user.
+
 ## search
 
 Search the Library Genesis catalog. Returns a page of file results with metadata, MD5
@@ -27,6 +33,7 @@ hashes, and per-result download options, plus pagination metadata.
 
 | Field              | Type   | Description                                                                                                                                                                                                                       |
 | ------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps`       | array  | Model-facing follow-up suggestions with a ready-to-run example (e.g. a `get_details`/`download` call using the first result's `md5`/`doi`, or, on no matches, how to broaden the query). Every tool output leads with this.       |
 | `results`          | array  | The file records on this page. Each carries `md5` (books), `doi` (articles), title, authors, publisher, year, language, pages, size, extension, type, ISBNs, ids, and labeled `downloads`. Empty array when there are no matches. |
 | `page`             | int    | The page number returned.                                                                                                                                                                                                         |
 | `results_per_page` | int    | The page size in effect.                                                                                                                                                                                                          |
@@ -73,10 +80,11 @@ Provide exactly one of `md5` or `id`. Supplying both, neither, an `md5` that is 
 
 ### get_details output
 
-| Field     | Type   | Description                                                                                                   |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| `file`    | object | The file record (present for an `md5` lookup, or an `id` lookup with `object: file`).                         |
-| `edition` | object | The edition record (present for an `md5` lookup's related edition, or an `id` lookup with `object: edition`). |
+| Field        | Type   | Description                                                                                                    |
+| ------------ | ------ | -------------------------------------------------------------------------------------------------------------- |
+| `next_steps` | array  | Model-facing follow-up suggestion, e.g. a `download` call using this record's `md5` (book) or `doi` (article). |
+| `file`       | object | The file record (present for an `md5` lookup, or an `id` lookup with `object: file`).                          |
+| `edition`    | object | The edition record (present for an `md5` lookup's related edition, or an `id` lookup with `object: edition`).  |
 
 An `md5` lookup returns `file` and, best-effort, its related `edition`. An `id` lookup
 returns whichever object was requested. A lookup that matches nothing returns a
@@ -117,6 +125,7 @@ result names it. See [Architecture](architecture.md) for the full chain.
 
 | Field               | Type   | Description                                                                                                                                      |
 | ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `next_steps`        | array  | Model-facing follow-up suggestion — confirms the file was saved and is ready to open or read.                                                    |
 | `path`              | string | Absolute path of the saved file.                                                                                                                 |
 | `size_bytes`        | int    | Final file size in bytes.                                                                                                                        |
 | `original_filename` | string | The name the mirror/CDN announced (from `Content-Disposition`), if any.                                                                          |

--- a/internal/libgen/details.go
+++ b/internal/libgen/details.go
@@ -32,7 +32,7 @@ func (c *Client) DetailsByMD5(ctx context.Context, md5 string) (file, edition ma
 		return nil, nil, err
 	}
 	if len(files) == 0 {
-		return nil, nil, fmt.Errorf("no file found for md5 %s", md5)
+		return nil, nil, fmt.Errorf("no file found for md5 %s — verify the md5 comes from a search result (run the search tool first to obtain valid md5s)", md5)
 	}
 	for id, f := range files {
 		f["file_id"] = id
@@ -72,11 +72,11 @@ func (c *Client) DetailsByID(ctx context.Context, object, id string) (map[string
 		return nil, err
 	}
 	if len(objs) == 0 {
-		return nil, fmt.Errorf("no %s record found with id %s", object, id)
+		return nil, fmt.Errorf("no %s record found with id %s — verify the id comes from a search result or get_details response", object, id)
 	}
 	for oid, o := range objs {
 		o["id"] = oid
 		return o, nil
 	}
-	return nil, fmt.Errorf("no %s record found with id %s", object, id)
+	return nil, fmt.Errorf("no %s record found with id %s — verify the id comes from a search result or get_details response", object, id)
 }

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -138,20 +138,20 @@ func (c *Client) ResolveGetURL(ctx context.Context, md5 string) (getURL, base st
 // DownloadResult describes a completed download: where the file landed, its size
 // and mirror, and whether it was integrity-verified and/or resumed.
 type DownloadResult struct {
-	Path             string `json:"path"`
-	SizeBytes        int64  `json:"size_bytes"`
-	OriginalFilename string `json:"original_filename,omitempty"`
-	Mirror           string `json:"mirror"`
+	Path             string `json:"path" jsonschema:"absolute path of the saved file"`
+	SizeBytes        int64  `json:"size_bytes" jsonschema:"final file size in bytes"`
+	OriginalFilename string `json:"original_filename,omitempty" jsonschema:"the name the mirror/CDN announced, if any"`
+	Mirror           string `json:"mirror" jsonschema:"the scheme://host origin that served the bytes"`
 	// Source is the Name() of the DownloadSource that served the file (e.g.
 	// "libgen"), identifying which provider in the chain succeeded.
-	Source string `json:"source,omitempty"`
+	Source string `json:"source,omitempty" jsonschema:"the source that served the file (libgen randombook unpaywall or scihub)"`
 	// Verified reports whether the downloaded file's MD5 digest matched the
 	// requested md5 (integrity confirmed end to end). It is false when the serving
 	// source did not request MD5 verification.
-	Verified bool `json:"verified"`
+	Verified bool `json:"verified" jsonschema:"true when the bytes' MD5 matched the requested md5 (book downloads); false for DOI sources"`
 	// Resumed reports whether the download continued from a pre-existing partial
 	// (the CDN honored a Range request) rather than starting from zero.
-	Resumed bool `json:"resumed"`
+	Resumed bool `json:"resumed" jsonschema:"true when the download resumed from a pre-existing partial via an HTTP Range request"`
 }
 
 // errIntegrityCheckFailed is returned when the downloaded content's MD5 digest

--- a/internal/libgen/search.go
+++ b/internal/libgen/search.go
@@ -43,6 +43,12 @@ func allowed[V any](m map[string]V) string {
 	return strings.Join(keys, ", ")
 }
 
+// TopicNames returns the recognized search topic names in a stable order, for
+// surfacing the collection choices to callers (e.g. in no-result guidance).
+func TopicNames() []string {
+	return []string{"nonfiction", "fiction", "articles", "magazines", "comics", "standards", "fiction_rus"}
+}
+
 // SearchParams holds the parameters of a catalog search.
 type SearchParams struct {
 	Query          string
@@ -110,28 +116,28 @@ func (p SearchParams) values() url.Values {
 
 // DownloadOption is a single labeled download link for a result.
 type DownloadOption struct {
-	Label string `json:"label"`
-	URL   string `json:"url"`
+	Label string `json:"label" jsonschema:"human label for this download link"`
+	URL   string `json:"url" jsonschema:"direct download URL for this option"`
 }
 
 // Result is one catalog entry from a search page, with its metadata and download
-// options.
+// options. The identifier fields are the pivot keys for the other tools.
 type Result struct {
-	EditionID string           `json:"edition_id,omitempty"`
-	FileID    string           `json:"file_id,omitempty"`
-	MD5       string           `json:"md5"`
-	DOI       string           `json:"doi,omitempty"`
-	Title     string           `json:"title"`
-	ISBNs     []string         `json:"isbns,omitempty"`
-	Authors   string           `json:"authors,omitempty"`
-	Publisher string           `json:"publisher,omitempty"`
-	Year      string           `json:"year,omitempty"`
-	Language  string           `json:"language,omitempty"`
-	Pages     string           `json:"pages,omitempty"`
-	Size      string           `json:"size,omitempty"`
-	Extension string           `json:"extension,omitempty"`
-	Type      string           `json:"type,omitempty"`
-	Downloads []DownloadOption `json:"downloads"`
+	EditionID string           `json:"edition_id,omitempty" jsonschema:"edition id; pass to get_details as id (with object=edition)"`
+	FileID    string           `json:"file_id,omitempty" jsonschema:"file id; pass to get_details as id with object=file"`
+	MD5       string           `json:"md5" jsonschema:"file MD5 hash (32 hex chars); pass to get_details or download to fetch this book"`
+	DOI       string           `json:"doi,omitempty" jsonschema:"article DOI; pass to download to fetch this article"`
+	Title     string           `json:"title" jsonschema:"record title"`
+	ISBNs     []string         `json:"isbns,omitempty" jsonschema:"ISBNs for this record, if any"`
+	Authors   string           `json:"authors,omitempty" jsonschema:"authors"`
+	Publisher string           `json:"publisher,omitempty" jsonschema:"publisher"`
+	Year      string           `json:"year,omitempty" jsonschema:"publication year"`
+	Language  string           `json:"language,omitempty" jsonschema:"language"`
+	Pages     string           `json:"pages,omitempty" jsonschema:"page count"`
+	Size      string           `json:"size,omitempty" jsonschema:"human-readable file size"`
+	Extension string           `json:"extension,omitempty" jsonschema:"file extension (e.g. pdf, epub)"`
+	Type      string           `json:"type,omitempty" jsonschema:"record type"`
+	Downloads []DownloadOption `json:"downloads" jsonschema:"labeled download links; prefer the download tool, which handles mirrors and verification"`
 }
 
 // SearchPage is a parsed page of search results plus the total file count.

--- a/internal/tools/markdown.go
+++ b/internal/tools/markdown.go
@@ -1,0 +1,142 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jmrplens/libgen-mcp/internal/libgen"
+)
+
+// This file renders each tool's structured output as a human-readable Markdown
+// block. The MCP result carries both channels: the structured JSON (for the
+// model) and this Markdown (for clients that surface the text content to a
+// person). The "💡 Next steps" block mirrors the structured next_steps field so
+// guidance is visible in both channels.
+
+// writeNextSteps appends a "💡 Next steps" section listing the guidance strings.
+// It is a no-op when there are none.
+func writeNextSteps(b *strings.Builder, steps []string) {
+	if len(steps) == 0 {
+		return
+	}
+	b.WriteString("\n💡 **Next steps:**\n")
+	for _, s := range steps {
+		fmt.Fprintf(b, "- %s\n", s)
+	}
+}
+
+// mdCell sanitizes a value for a Markdown table cell: it collapses newlines and
+// escapes pipes so the value cannot break the table layout.
+func mdCell(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return strings.TrimSpace(s)
+}
+
+// resultIdentifier returns the pivot identifier for a result: its md5 (books) or
+// doi (articles), labeled so the reader knows which key it is.
+func resultIdentifier(r libgen.Result) string {
+	switch {
+	case r.MD5 != "":
+		return "md5:" + r.MD5
+	case r.DOI != "":
+		return "doi:" + r.DOI
+	default:
+		return ""
+	}
+}
+
+// resultLinks renders a result's download options as space-separated Markdown
+// links so a client that shows the text can offer clickable navigation. Empty
+// when the result carries no links.
+func resultLinks(r libgen.Result) string {
+	parts := make([]string, 0, len(r.Downloads))
+	for _, d := range r.Downloads {
+		if d.URL == "" {
+			continue
+		}
+		label := d.Label
+		if label == "" {
+			label = "download"
+		}
+		parts = append(parts, fmt.Sprintf("[%s](%s)", mdCell(label), d.URL))
+	}
+	return strings.Join(parts, " ")
+}
+
+// renderSearchMarkdown renders a search result page as a Markdown summary plus a
+// results table (or a no-results note), followed by the next-steps block.
+func renderSearchMarkdown(out SearchOutput) string {
+	var b strings.Builder
+	if len(out.Results) == 0 {
+		fmt.Fprintf(&b, "No results (mirror %s).\n", out.Mirror)
+		writeNextSteps(&b, out.NextSteps)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Found %d results on page %d", len(out.Results), out.Page)
+	if out.TotalFiles != "" {
+		fmt.Fprintf(&b, " of %s reported", out.TotalFiles)
+	}
+	fmt.Fprintf(&b, " (mirror %s).\n\n", out.Mirror)
+	b.WriteString("| # | Title | Authors | Year | Ext | Size | Identifier | Download links |\n")
+	b.WriteString("| - | ----- | ------- | ---- | --- | ---- | ---------- | -------------- |\n")
+	for i, r := range out.Results {
+		fmt.Fprintf(&b, "| %d | %s | %s | %s | %s | %s | %s | %s |\n",
+			i+1, mdCell(r.Title), mdCell(r.Authors), mdCell(r.Year),
+			mdCell(r.Extension), mdCell(r.Size), mdCell(resultIdentifier(r)), resultLinks(r))
+	}
+	if out.Truncated && out.Hint != "" {
+		fmt.Fprintf(&b, "\n> %s\n", out.Hint)
+	}
+	writeNextSteps(&b, out.NextSteps)
+	return b.String()
+}
+
+// renderDetailsMarkdown renders a details record as a short field list (title,
+// authors, year, identifiers) drawn from the file/edition maps, plus next steps.
+func renderDetailsMarkdown(out DetailsOutput) string {
+	var b strings.Builder
+	rec := out.File
+	if rec == nil {
+		rec = out.Edition
+	}
+	title := stringField(rec, "title")
+	if title == "" {
+		title = "(record)"
+	}
+	fmt.Fprintf(&b, "**%s**\n", mdCell(title))
+	for _, f := range []struct{ label, key string }{
+		{"Authors", "author"},
+		{"Year", "year"},
+		{"Publisher", "publisher"},
+		{"md5", "md5"},
+		{"doi", "doi"},
+	} {
+		if v := stringField(rec, f.key); v != "" {
+			fmt.Fprintf(&b, "- %s: %s\n", f.label, mdCell(v))
+		}
+	}
+	writeNextSteps(&b, out.NextSteps)
+	return b.String()
+}
+
+// renderDownloadMarkdown renders a completed download as a one-line confirmation
+// (name, size, source, path, verification) plus the next-steps block.
+func renderDownloadMarkdown(out DownloadOutput) string {
+	var b strings.Builder
+	name := out.OriginalFilename
+	if name == "" {
+		name = out.Path
+	}
+	verified := "no"
+	if out.Verified {
+		verified = "yes"
+	}
+	fmt.Fprintf(&b, "Downloaded **%s** — %d bytes via %s.\n", mdCell(name), out.SizeBytes, mdCell(out.Source))
+	fmt.Fprintf(&b, "- Path: %s\n- Verified: %s\n", mdCell(out.Path), verified)
+	if out.Resumed {
+		b.WriteString("- Resumed from a partial download.\n")
+	}
+	writeNextSteps(&b, out.NextSteps)
+	return b.String()
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -32,39 +32,52 @@ Use get_details with a result md5 for full metadata, and download to fetch the f
 
 // SearchInput holds the parameters for the search tool.
 type SearchInput struct {
-	Query          string   `json:"query" jsonschema:"search text,required"`
-	Topics         []string `json:"topics,omitempty" jsonschema:"collections to search: nonfiction fiction articles magazines comics standards fiction_rus (omit for all)"`
-	SearchIn       []string `json:"search_in,omitempty" jsonschema:"fields to match: title author series year publisher isbn (omit for all)"`
-	ResultsPerPage int      `json:"results_per_page,omitempty" jsonschema:"results per page: 25 50 or 100"`
-	Page           int      `json:"page,omitempty" jsonschema:"result page starting at 1"`
-	Order          string   `json:"order,omitempty" jsonschema:"sort by: id time_added title author year size"`
-	OrderMode      string   `json:"order_mode,omitempty" jsonschema:"asc or desc"`
+	Query          string   `json:"query" jsonschema:"search text (e.g. a title, author, or ISBN),required"`
+	Topics         []string `json:"topics,omitempty" jsonschema:"array of collections to search: nonfiction fiction articles magazines comics standards fiction_rus (omit for all). Use fiction for novels comics for graphic novels articles for research papers"`
+	SearchIn       []string `json:"search_in,omitempty" jsonschema:"array of fields to match: title author series year publisher isbn (omit to match all fields)"`
+	ResultsPerPage int      `json:"results_per_page,omitempty" jsonschema:"a single number: 25 50 or 100 (default 25)"`
+	Page           int      `json:"page,omitempty" jsonschema:"result page number starting at 1 (default 1)"`
+	Order          string   `json:"order,omitempty" jsonschema:"a single value (not an array) to sort by: id time_added title author year or size"`
+	OrderMode      string   `json:"order_mode,omitempty" jsonschema:"a single value (not an array): asc or desc"`
 }
 
-// SearchOutput holds a page of search results plus pagination metadata.
+// SearchOutput holds a page of search results plus pagination metadata. NextSteps
+// leads so the model sees what to do with the results before reading them.
 type SearchOutput struct {
-	Results        []libgen.Result `json:"results"`
-	Page           int             `json:"page"`
-	ResultsPerPage int             `json:"results_per_page"`
-	TotalFiles     string          `json:"total_files,omitempty"`
-	Reachable      int             `json:"reachable"`
-	Truncated      bool            `json:"truncated"`
-	Hint           string          `json:"hint,omitempty"`
-	HasMore        bool            `json:"has_more"`
-	Mirror         string          `json:"mirror"`
+	NextSteps      []string        `json:"next_steps,omitempty" jsonschema:"suggested follow-up tool calls given these results (e.g. get_details or download with a result's md5/doi)"`
+	Results        []libgen.Result `json:"results" jsonschema:"the file records on this page; each carries the md5/doi/id you pass to get_details or download"`
+	Page           int             `json:"page" jsonschema:"the page number returned"`
+	ResultsPerPage int             `json:"results_per_page" jsonschema:"the page size in effect"`
+	TotalFiles     string          `json:"total_files,omitempty" jsonschema:"total matches the mirror reports (may be a capped indicator such as 1000+)"`
+	Reachable      int             `json:"reachable" jsonschema:"how many results are actually reachable across all pages"`
+	Truncated      bool            `json:"truncated" jsonschema:"true when total_files exceeds reachable, i.e. some matches cannot be paged to"`
+	Hint           string          `json:"hint,omitempty" jsonschema:"present only when truncated: advises how to refine the query"`
+	HasMore        bool            `json:"has_more" jsonschema:"true when this page is full, suggesting a next page may exist"`
+	Mirror         string          `json:"mirror" jsonschema:"the mirror base URL that served this search"`
 }
 
 // DetailsInput holds the parameters for the get_details tool.
 type DetailsInput struct {
-	MD5    string `json:"md5,omitempty" jsonschema:"file md5 hash from a search result (use md5 OR id, not both)"`
-	ID     string `json:"id,omitempty" jsonschema:"edition or file id (use md5 OR id, not both)"`
-	Object string `json:"object,omitempty" jsonschema:"with id: edition (default) or file"`
+	MD5    string `json:"md5,omitempty" jsonschema:"file md5 hash from a search result (use md5 OR id, not both). Get it from a prior search result's md5 field"`
+	ID     string `json:"id,omitempty" jsonschema:"edition or file id from a search result (use md5 OR id, not both). Get it from a result's edition_id or file_id field"`
+	Object string `json:"object,omitempty" jsonschema:"with id: a single value edition (default) or file"`
 }
 
 // DetailsOutput holds the file and/or edition record returned by get_details.
+// NextSteps leads so the model sees the download follow-up before the payload.
 type DetailsOutput struct {
-	File    map[string]any `json:"file,omitempty"`
-	Edition map[string]any `json:"edition,omitempty"`
+	NextSteps []string       `json:"next_steps,omitempty" jsonschema:"suggested follow-up (e.g. download this record by its md5 or doi)"`
+	File      map[string]any `json:"file,omitempty" jsonschema:"the file record (present for an md5 lookup, or an id lookup with object=file)"`
+	Edition   map[string]any `json:"edition,omitempty" jsonschema:"the edition record (present for an md5 lookup's related edition, or an id lookup with object=edition)"`
+}
+
+// DownloadOutput wraps the domain download result with leading NextSteps guidance.
+// The embedded DownloadResult's fields are promoted, so the wire shape is the
+// result fields plus a leading next_steps; the domain type stays free of any
+// MCP-presentation concern.
+type DownloadOutput struct {
+	NextSteps []string `json:"next_steps,omitempty" jsonschema:"suggested follow-up now that the file is saved"`
+	libgen.DownloadResult
 }
 
 // DownloadInput holds the parameters for the download tool. Provide md5 (books)
@@ -90,7 +103,7 @@ func Register(server *mcp.Server, client *libgen.Client, cfg *config.Config) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "get_details",
 		Title:       "Get record details",
-		Description: "Full metadata for a Library Genesis record (description, identifiers, DOI, cover, related edition) via its JSON API. Look up by md5 (returns file + related edition) or by edition/file id.",
+		Description: "Full metadata for a Library Genesis record (description, identifiers, DOI, cover, related edition) via its JSON API. Look up by md5 (returns file + related edition) or by edition/file id. The md5/id come from a prior search result. See also: search (to find records), download (to fetch the file).",
 		Annotations: &mcp.ToolAnnotations{Title: "Get record details", ReadOnlyHint: true, OpenWorldHint: &truthy},
 	}, withRecovery("get_details", detailsHandler(client)))
 	book, article := client.EnabledSourceNames()
@@ -168,8 +181,82 @@ func downloadToolDescription(book, article []string) string {
 	}
 	fmt.Fprintf(&b, "Set source to restrict the download to a single enabled provider (%s) instead of trying them all. ",
 		strings.Join(orderedEnabledSources(book, article), ", "))
-	b.WriteString("Returns the saved path, size and the source that served it.")
+	b.WriteString("The md5/doi come from a prior search result. Returns the saved path, size and the source that served it. See also: search (to find the md5/doi).")
 	return b.String()
+}
+
+// hintIncludeLinks tells the model to surface the results' download links to the
+// user when it presents them, so the links are not dropped from the reply.
+const hintIncludeLinks = "When you present these results to the user, include each result's download links as clickable [label](url) Markdown links (they are in the results' downloads field and the Markdown table) so the user can navigate directly."
+
+// resultsHaveLinks reports whether any result carries at least one download link.
+func resultsHaveLinks(results []libgen.Result) bool {
+	for _, r := range results {
+		for _, d := range r.Downloads {
+			if d.URL != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// searchNextSteps builds the follow-up guidance for a search result, embedding a
+// concrete, ready-to-run example that uses the first result's real identifier so
+// the model can pivot to get_details/download without guessing the argument shape.
+// On zero results it returns recovery suggestions instead.
+func searchNextSteps(out SearchOutput) []string {
+	if len(out.Results) == 0 {
+		return []string{
+			"No matches. Broaden the query text, drop search_in field filters, or try other topics: " +
+				strings.Join(libgen.TopicNames(), ", ") + ".",
+		}
+	}
+	first := out.Results[0]
+	steps := []string{}
+	if first.MD5 != "" {
+		steps = append(steps,
+			fmt.Sprintf("For full metadata on a result, call get_details with its md5, e.g. {\"md5\":%q}.", first.MD5),
+			fmt.Sprintf("To fetch a book, call download with its md5, e.g. {\"md5\":%q}.", first.MD5))
+	}
+	if first.DOI != "" {
+		steps = append(steps,
+			fmt.Sprintf("To fetch an article, call download with its doi, e.g. {\"doi\":%q}.", first.DOI))
+	}
+	if resultsHaveLinks(out.Results) {
+		steps = append(steps, hintIncludeLinks)
+	}
+	if out.Truncated {
+		steps = append(steps, "Many matches are unreachable; refine the query (add author/year or narrow topics) rather than deep-paging.")
+	} else if out.HasMore {
+		steps = append(steps, fmt.Sprintf("This page is full; request page %d for more results.", out.Page+1))
+	}
+	return steps
+}
+
+// detailsNextSteps suggests the download follow-up for a details record, using
+// the md5/doi found on the record so the model can act without re-deriving them.
+func detailsNextSteps(out DetailsOutput) []string {
+	md5 := stringField(out.File, "md5")
+	doi := stringField(out.File, "doi")
+	if doi == "" {
+		doi = stringField(out.Edition, "doi")
+	}
+	switch {
+	case md5 != "":
+		return []string{fmt.Sprintf("To download this book, call download with {\"md5\":%q}.", md5)}
+	case doi != "":
+		return []string{fmt.Sprintf("To download this article, call download with {\"doi\":%q}.", doi)}
+	default:
+		return []string{"To fetch the file, call download with this record's md5 (book) or doi (article)."}
+	}
+}
+
+// downloadNextSteps confirms the saved file and points at the next natural action.
+func downloadNextSteps(res libgen.DownloadResult) []string {
+	return []string{
+		fmt.Sprintf("File saved to %s (%d bytes) via %s; it is ready to open or read.", res.Path, res.SizeBytes, res.Source),
+	}
 }
 
 // withRecovery wraps a typed MCP tool handler to make it panic-safe and
@@ -242,25 +329,40 @@ func searchHandler(c *libgen.Client) mcp.ToolHandlerFor[SearchInput, SearchOutpu
 		if out.Results == nil {
 			out.Results = []libgen.Result{}
 		}
-		return nil, out, nil
+		out.NextSteps = searchNextSteps(out)
+		return markdownResult(renderSearchMarkdown(out)), out, nil
 	}
+}
+
+// markdownResult wraps a human-readable Markdown rendering in a CallToolResult.
+// The SDK keeps this Content and additionally sets StructuredContent to the
+// output JSON, so the client receives both channels.
+func markdownResult(md string) *mcp.CallToolResult {
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: md}}}
 }
 
 func detailsHandler(c *libgen.Client) mcp.ToolHandlerFor[DetailsInput, DetailsOutput] {
 	return func(ctx context.Context, _ *mcp.CallToolRequest, in DetailsInput) (*mcp.CallToolResult, DetailsOutput, error) {
 		var zero DetailsOutput
+		var (
+			out DetailsOutput
+			err error
+		)
 		switch {
 		case in.MD5 != "" && in.ID != "":
 			return nil, zero, errors.New("provide md5 or id, not both")
 		case in.MD5 != "":
-			out, err := detailsByMD5(ctx, c, in.MD5)
-			return nil, out, err
+			out, err = detailsByMD5(ctx, c, in.MD5)
 		case in.ID != "":
-			out, err := detailsByID(ctx, c, in.Object, in.ID)
-			return nil, out, err
+			out, err = detailsByID(ctx, c, in.Object, in.ID)
 		default:
 			return nil, zero, errors.New("provide md5 or id")
 		}
+		if err != nil {
+			return nil, zero, err
+		}
+		out.NextSteps = detailsNextSteps(out)
+		return markdownResult(renderDetailsMarkdown(out)), out, nil
 	}
 }
 
@@ -315,9 +417,9 @@ func validateDownloadInput(in DownloadInput) (md5, doi, source string, err error
 	return md5, doi, source, nil
 }
 
-func downloadHandler(c *libgen.Client, cfg *config.Config) mcp.ToolHandlerFor[DownloadInput, libgen.DownloadResult] {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in DownloadInput) (*mcp.CallToolResult, libgen.DownloadResult, error) {
-		var zero libgen.DownloadResult
+func downloadHandler(c *libgen.Client, cfg *config.Config) mcp.ToolHandlerFor[DownloadInput, DownloadOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in DownloadInput) (*mcp.CallToolResult, DownloadOutput, error) {
+		var zero DownloadOutput
 		md5, doi, source, err := validateDownloadInput(in)
 		if err != nil {
 			return nil, zero, err
@@ -337,7 +439,8 @@ func downloadHandler(c *libgen.Client, cfg *config.Config) mcp.ToolHandlerFor[Do
 		if err != nil {
 			return nil, zero, err
 		}
-		return nil, *res, nil
+		out := DownloadOutput{NextSteps: downloadNextSteps(*res), DownloadResult: *res}
+		return markdownResult(renderDownloadMarkdown(out)), out, nil
 	}
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -206,6 +206,186 @@ func TestDownloadSchemaReflectsEnabledSources(t *testing.T) {
 	}
 }
 
+// TestSearchNextSteps verifies the search follow-up guidance: with results it
+// embeds executable get_details/download examples carrying the first result's
+// real md5; with no results it returns recovery suggestions naming the topics.
+func TestSearchNextSteps(t *testing.T) {
+	withResults := searchNextSteps(SearchOutput{
+		Results: []libgen.Result{{MD5: "0123456789abcdef0123456789abcdef", DOI: "10.1/x"}},
+		Page:    1,
+	})
+	joined := strings.Join(withResults, "\n")
+	if !strings.Contains(joined, "get_details") || !strings.Contains(joined, "download") {
+		t.Errorf("next_steps should mention get_details and download; got %q", joined)
+	}
+	if !strings.Contains(joined, "0123456789abcdef0123456789abcdef") {
+		t.Errorf("next_steps should embed the first result's md5; got %q", joined)
+	}
+	if !strings.Contains(joined, "10.1/x") {
+		t.Errorf("next_steps should embed the first result's doi; got %q", joined)
+	}
+
+	empty := searchNextSteps(SearchOutput{Results: []libgen.Result{}})
+	if len(empty) == 0 || !strings.Contains(empty[0], "No matches") {
+		t.Errorf("empty search should suggest recovery; got %q", empty)
+	}
+	if !strings.Contains(empty[0], "comics") {
+		t.Errorf("empty-search suggestion should list topics; got %q", empty[0])
+	}
+}
+
+// TestDetailsNextSteps verifies the details follow-up prefers the record's md5,
+// falls back to its doi, and always suggests download.
+func TestDetailsNextSteps(t *testing.T) {
+	byMD5 := detailsNextSteps(DetailsOutput{File: map[string]any{"md5": "abc"}})
+	if len(byMD5) != 1 || !strings.Contains(byMD5[0], `"md5":"abc"`) {
+		t.Errorf("md5 record should suggest download by md5; got %q", byMD5)
+	}
+	byDOI := detailsNextSteps(DetailsOutput{Edition: map[string]any{"doi": "10.1/y"}})
+	if len(byDOI) != 1 || !strings.Contains(byDOI[0], `"doi":"10.1/y"`) {
+		t.Errorf("doi record should suggest download by doi; got %q", byDOI)
+	}
+	none := detailsNextSteps(DetailsOutput{})
+	if len(none) != 1 || !strings.Contains(none[0], "download") {
+		t.Errorf("empty record should still suggest download; got %q", none)
+	}
+}
+
+// TestDownloadNextSteps verifies the download follow-up names the saved path,
+// size and source.
+func TestDownloadNextSteps(t *testing.T) {
+	steps := downloadNextSteps(libgen.DownloadResult{Path: "/tmp/book.pdf", SizeBytes: 123, Source: "libgen"})
+	if len(steps) != 1 {
+		t.Fatalf("want 1 step, got %d", len(steps))
+	}
+	for _, want := range []string{"/tmp/book.pdf", "123", "libgen"} {
+		if !strings.Contains(steps[0], want) {
+			t.Errorf("download step should mention %q; got %q", want, steps[0])
+		}
+	}
+}
+
+// TestSearchToolEmitsNextSteps verifies the registered search tool surfaces
+// next_steps in its structured output over a real tools/call round-trip.
+func TestSearchToolEmitsNextSteps(t *testing.T) {
+	session := newSession(t)
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: map[string]any{"query": "golang", "topics": []string{"nonfiction"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out SearchOutput
+	data, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uerr := json.Unmarshal(data, &out); uerr != nil {
+		t.Fatal(uerr)
+	}
+	if len(out.NextSteps) == 0 {
+		t.Errorf("search output should carry next_steps; structured=%s", data)
+	}
+}
+
+// textContent returns the concatenated text of a result's TextContent blocks.
+func textContent(res *mcp.CallToolResult) string {
+	var b strings.Builder
+	for _, c := range res.Content {
+		if tc, ok := c.(*mcp.TextContent); ok {
+			b.WriteString(tc.Text)
+		}
+	}
+	return b.String()
+}
+
+// TestSearchToolReturnsMarkdownAndStructured verifies a search call carries BOTH
+// channels: a human-readable Markdown text block (with a results table and the
+// next-steps section) and the structured JSON output.
+func TestSearchToolReturnsMarkdownAndStructured(t *testing.T) {
+	session := newSession(t)
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "search",
+		Arguments: map[string]any{"query": "golang", "topics": []string{"nonfiction"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := textContent(res)
+	if !strings.Contains(md, "| # | Title") {
+		t.Errorf("markdown should contain a results table header; got:\n%s", md)
+	}
+	if !strings.Contains(md, "Next steps") {
+		t.Errorf("markdown should contain a next-steps section; got:\n%s", md)
+	}
+	if strings.HasPrefix(strings.TrimSpace(md), "{") {
+		t.Errorf("text content should be markdown, not raw JSON; got:\n%s", md)
+	}
+	if res.StructuredContent == nil {
+		t.Error("result should still carry structured JSON output alongside the markdown")
+	}
+}
+
+// TestSearchLinksSurfacedAndHinted verifies the search markdown table renders
+// each result's download links as Markdown links, and that the structured
+// next_steps carries the instruction to include those links in the reply.
+func TestSearchLinksSurfacedAndHinted(t *testing.T) {
+	out := SearchOutput{
+		Mirror: "m", Page: 1,
+		Results: []libgen.Result{{
+			Title: "A Book", MD5: "0123456789abcdef0123456789abcdef",
+			Downloads: []libgen.DownloadOption{{Label: "GET", URL: "https://mirror/dl/1"}},
+		}},
+	}
+	out.NextSteps = searchNextSteps(out)
+
+	md := renderSearchMarkdown(out)
+	if !strings.Contains(md, "Download links") {
+		t.Errorf("table should have a Download links column; got:\n%s", md)
+	}
+	if !strings.Contains(md, "[GET](https://mirror/dl/1)") {
+		t.Errorf("table should render the download link; got:\n%s", md)
+	}
+	steps := strings.Join(out.NextSteps, "\n")
+	if !strings.Contains(steps, "download links") {
+		t.Errorf("next_steps should instruct the model to include download links; got %q", steps)
+	}
+
+	// No links → no preserve-links hint.
+	noLinks := SearchOutput{Mirror: "m", Page: 1, Results: []libgen.Result{{Title: "B", MD5: "abc"}}}
+	if resultsHaveLinks(noLinks.Results) {
+		t.Fatal("fixture should have no links")
+	}
+	if strings.Contains(strings.Join(searchNextSteps(noLinks), "\n"), "download links") {
+		t.Error("next_steps should not mention download links when results carry none")
+	}
+}
+
+// TestRenderMarkdownEdgeCases covers the empty-search, doi-only details, and
+// resumed-download rendering branches.
+func TestRenderMarkdownEdgeCases(t *testing.T) {
+	empty := renderSearchMarkdown(SearchOutput{Mirror: "m", NextSteps: []string{"broaden it"}})
+	if !strings.Contains(empty, "No results") || !strings.Contains(empty, "broaden it") {
+		t.Errorf("empty search markdown should note no results and next steps; got:\n%s", empty)
+	}
+
+	details := renderDetailsMarkdown(DetailsOutput{
+		Edition:   map[string]any{"title": "Paper", "doi": "10.1/z"},
+		NextSteps: []string{"download it"},
+	})
+	if !strings.Contains(details, "Paper") || !strings.Contains(details, "10.1/z") {
+		t.Errorf("details markdown should show title and doi; got:\n%s", details)
+	}
+
+	dl := renderDownloadMarkdown(DownloadOutput{
+		DownloadResult: libgen.DownloadResult{Path: "/p", SizeBytes: 9, Source: "libgen", Resumed: true},
+	})
+	if !strings.Contains(dl, "Resumed") {
+		t.Errorf("resumed download markdown should note the resume; got:\n%s", dl)
+	}
+}
+
 // TestToolsRegistered verifies ToolsRegistered.
 func TestToolsRegistered(t *testing.T) {
 	session := newSession(t)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -20,13 +20,13 @@ Use get_details with a result md5 for full metadata, and download to fetch the f
 
 **Parameters:**
 
-- `order` (string): sort by: id time_added title author year size
-- `order_mode` (string): asc or desc
-- `page` (integer): result page starting at 1
-- `query` (string) (required): search text
-- `results_per_page` (integer): results per page: 25 50 or 100
-- `search_in` (array of strings): fields to match: title author series year publisher isbn (omit for all)
-- `topics` (array of strings): collections to search: nonfiction fiction articles magazines comics standards fiction_rus (omit for all)
+- `order` (string): a single value (not an array) to sort by: id time_added title author year or size
+- `order_mode` (string): a single value (not an array): asc or desc
+- `page` (integer): result page number starting at 1 (default 1)
+- `query` (string) (required): search text (e.g. a title, author, or ISBN)
+- `results_per_page` (integer): a single number: 25 50 or 100 (default 25)
+- `search_in` (array of strings): array of fields to match: title author series year publisher isbn (omit to match all fields)
+- `topics` (array of strings): array of collections to search: nonfiction fiction articles magazines comics standards fiction_rus (omit for all). Use fiction for novels comics for graphic novels articles for research papers
 
 Annotations: readOnly=true, destructive=false, idempotent=false, openWorld=true
 
@@ -34,13 +34,13 @@ Annotations: readOnly=true, destructive=false, idempotent=false, openWorld=true
 
 **Get record details**
 
-Full metadata for a Library Genesis record (description, identifiers, DOI, cover, related edition) via its JSON API. Look up by md5 (returns file + related edition) or by edition/file id.
+Full metadata for a Library Genesis record (description, identifiers, DOI, cover, related edition) via its JSON API. Look up by md5 (returns file + related edition) or by edition/file id. The md5/id come from a prior search result. See also: search (to find records), download (to fetch the file).
 
 **Parameters:**
 
-- `id` (string): edition or file id (use md5 OR id, not both)
-- `md5` (string): file md5 hash from a search result (use md5 OR id, not both)
-- `object` (string): with id: edition (default) or file
+- `id` (string): edition or file id from a search result (use md5 OR id, not both). Get it from a result's edition_id or file_id field
+- `md5` (string): file md5 hash from a search result (use md5 OR id, not both). Get it from a prior search result's md5 field
+- `object` (string): with id: a single value edition (default) or file
 
 Annotations: readOnly=true, destructive=false, idempotent=false, openWorld=true
 
@@ -48,7 +48,7 @@ Annotations: readOnly=true, destructive=false, idempotent=false, openWorld=true
 
 **Download file**
 
-Download a file to a local directory. Provide md5 for a book or doi for an article (at least one is required). Books are tried against libgen then randombook; articles against unpaywall then scihub. If both md5 and doi are given, article sources are tried first, then book sources. Set source to restrict the download to a single enabled provider (unpaywall, scihub, libgen, randombook) instead of trying them all. Returns the saved path, size and the source that served it.
+Download a file to a local directory. Provide md5 for a book or doi for an article (at least one is required). Books are tried against libgen then randombook; articles against unpaywall then scihub. If both md5 and doi are given, article sources are tried first, then book sources. Set source to restrict the download to a single enabled provider (unpaywall, scihub, libgen, randombook) instead of trying them all. The md5/doi come from a prior search result. Returns the saved path, size and the source that served it. See also: search (to find the md5/doi).
 
 **Parameters:**
 

--- a/site/src/content/docs/es/tools.mdx
+++ b/site/src/content/docs/es/tools.mdx
@@ -7,6 +7,8 @@ import { Aside } from "@astrojs/starlight/components";
 
 `libgen-mcp` expone tres herramientas MCP: [`search`](#search), [`get_details`](#get_details) y [`download`](#download). Las tres están anotadas con una pista de mundo abierto; `search` y `get_details` son de solo lectura, y `download` es no destructiva e idempotente. Cada handler es a prueba de panics: un fallo inesperado se devuelve como error de herramienta, nunca como una caída de la sesión.
 
+Cada resultado se devuelve por dos canales: la salida JSON estructurada que se documenta más abajo, y una representación Markdown legible en el contenido de texto. Para `search`, el Markdown es una tabla de resultados que incluye los enlaces de descarga de cada resultado. Ambos canales empiezan por un campo `next_steps`, y la guía de búsqueda le indica al modelo que incluya los enlaces de descarga al presentarte los resultados.
+
 ## search
 
 Busca en el catálogo de Library Genesis. Devuelve una página de resultados de archivos con metadatos, hashes MD5 y opciones de descarga por resultado, más metadatos de paginación.
@@ -27,6 +29,7 @@ Busca en el catálogo de Library Genesis. Devuelve una página de resultados de 
 
 | Campo              | Tipo   | Descripción                                                                                                                                                                                                                                            |
 | ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `next_steps`       | array  | Llamadas de seguimiento sugeridas — p. ej. un ejemplo de `get_details` o `download` usando el `md5`/`doi` del primer resultado, o, cuando no hay coincidencias, cómo ampliar la consulta. Presente para guiar al modelo; se puede ignorar.             |
 | `results`          | array  | Los registros de archivo de esta página. Cada uno incluye `md5` (libros), `doi` (artículos), título, autores, editorial, año, idioma, páginas, tamaño, extensión, tipo, ISBNs, ids y `downloads` etiquetados. Array vacío cuando no hay coincidencias. |
 | `page`             | int    | El número de página devuelto.                                                                                                                                                                                                                          |
 | `results_per_page` | int    | El tamaño de página en vigor.                                                                                                                                                                                                                          |
@@ -69,10 +72,11 @@ Metadatos completos de un registro vía la API JSON de LibGen — descripción, 
 
 ### salida de get_details
 
-| Campo     | Tipo   | Descripción                                                                                                                           |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `file`    | object | El registro de archivo (presente en una consulta por `md5`, o una consulta por `id` con `object: file`).                              |
-| `edition` | object | El registro de edición (presente en la edición relacionada de una consulta por `md5`, o una consulta por `id` con `object: edition`). |
+| Campo        | Tipo   | Descripción                                                                                                                                                                  |
+| ------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps` | array  | Llamada de seguimiento sugerida — p. ej. una llamada a `download` con el `md5` (libro) o `doi` (artículo) de este registro. Presente para guiar al modelo; se puede ignorar. |
+| `file`       | object | El registro de archivo (presente en una consulta por `md5`, o una consulta por `id` con `object: file`).                                                                     |
+| `edition`    | object | El registro de edición (presente en la edición relacionada de una consulta por `md5`, o una consulta por `id` con `object: edition`).                                        |
 
 Una consulta por `md5` devuelve `file` y, en la medida de lo posible, su `edition` relacionada. Una consulta por `id` devuelve el objeto que se haya pedido. Una consulta que no coincide con nada devuelve un error "no file found".
 
@@ -113,6 +117,7 @@ Gana la primera fuente que resuelve y transmite un archivo válido; el campo `so
 
 | Campo               | Tipo   | Descripción                                                                                                                                                          |
 | ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps`        | array  | Confirma que el archivo se guardó y está listo para abrir o leer. Presente para guiar al modelo; se puede ignorar.                                                   |
 | `path`              | string | Ruta absoluta del archivo guardado.                                                                                                                                  |
 | `size_bytes`        | int    | Tamaño final del archivo en bytes.                                                                                                                                   |
 | `original_filename` | string | El nombre que anunció el mirror/CDN (desde `Content-Disposition`), si lo hay.                                                                                        |

--- a/site/src/content/docs/tools.mdx
+++ b/site/src/content/docs/tools.mdx
@@ -7,6 +7,8 @@ import { Aside } from "@astrojs/starlight/components";
 
 `libgen-mcp` exposes three MCP tools: [`search`](#search), [`get_details`](#get_details), and [`download`](#download). All three are annotated with an open-world hint; `search` and `get_details` are read-only, and `download` is non-destructive and idempotent. Every handler is panic-safe: an unexpected failure is returned as a tool error, never as a crash of the session.
 
+Every result is returned on two channels: the structured JSON output documented below, and a human-readable Markdown rendering in the text content. For `search`, the Markdown is a results table that includes each result's clickable download links. Both channels lead with a `next_steps` field, and the search guidance tells the model to include the download links when it presents the results to you.
+
 ## search
 
 Search the Library Genesis catalog. Returns a page of file results with metadata, MD5 hashes, and per-result download options, plus pagination metadata.
@@ -25,17 +27,18 @@ Search the Library Genesis catalog. Returns a page of file results with metadata
 
 ### search output
 
-| Field              | Type   | Description                                                                                                                                                                                                                       |
-| ------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `results`          | array  | The file records on this page. Each carries `md5` (books), `doi` (articles), title, authors, publisher, year, language, pages, size, extension, type, ISBNs, ids, and labeled `downloads`. Empty array when there are no matches. |
-| `page`             | int    | The page number returned.                                                                                                                                                                                                         |
-| `results_per_page` | int    | The page size in effect.                                                                                                                                                                                                          |
-| `total_files`      | string | Total matches the mirror reports for the query. May be a capped indicator such as `1000+`.                                                                                                                                        |
-| `reachable`        | int    | How many results are actually reachable across all pages (mirrors cap this below `total_files`).                                                                                                                                  |
-| `truncated`        | bool   | `true` when `total_files` exceeds `reachable`, i.e. some matches cannot be paged to.                                                                                                                                              |
-| `hint`             | string | Present only when `truncated` — advises refining the query (add author/year, use title-only columns, or narrow topics).                                                                                                           |
-| `has_more`         | bool   | `true` when this page is full (`len(results) >= results_per_page`), suggesting a next page may exist.                                                                                                                             |
-| `mirror`           | string | The mirror base URL that served this search.                                                                                                                                                                                      |
+| Field              | Type   | Description                                                                                                                                                                                                                                    |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps`       | array  | Suggested follow-up tool calls given this result — e.g. an example `get_details` or `download` call using the first result's `md5`/`doi`, or, when there are no matches, how to broaden the query. Present to guide the model; safe to ignore. |
+| `results`          | array  | The file records on this page. Each carries `md5` (books), `doi` (articles), title, authors, publisher, year, language, pages, size, extension, type, ISBNs, ids, and labeled `downloads`. Empty array when there are no matches.              |
+| `page`             | int    | The page number returned.                                                                                                                                                                                                                      |
+| `results_per_page` | int    | The page size in effect.                                                                                                                                                                                                                       |
+| `total_files`      | string | Total matches the mirror reports for the query. May be a capped indicator such as `1000+`.                                                                                                                                                     |
+| `reachable`        | int    | How many results are actually reachable across all pages (mirrors cap this below `total_files`).                                                                                                                                               |
+| `truncated`        | bool   | `true` when `total_files` exceeds `reachable`, i.e. some matches cannot be paged to.                                                                                                                                                           |
+| `hint`             | string | Present only when `truncated` — advises refining the query (add author/year, use title-only columns, or narrow topics).                                                                                                                        |
+| `has_more`         | bool   | `true` when this page is full (`len(results) >= results_per_page`), suggesting a next page may exist.                                                                                                                                          |
+| `mirror`           | string | The mirror base URL that served this search.                                                                                                                                                                                                   |
 
 ### Pagination and truncation
 
@@ -69,10 +72,11 @@ Full metadata for a record via the LibGen JSON API — description, identifiers,
 
 ### get_details output
 
-| Field     | Type   | Description                                                                                                   |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| `file`    | object | The file record (present for an `md5` lookup, or an `id` lookup with `object: file`).                         |
-| `edition` | object | The edition record (present for an `md5` lookup's related edition, or an `id` lookup with `object: edition`). |
+| Field        | Type   | Description                                                                                                                                                                |
+| ------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps` | array  | Suggested follow-up tool calls given this result — e.g. a `download` call using this record's `md5` (book) or `doi` (article). Present to guide the model; safe to ignore. |
+| `file`       | object | The file record (present for an `md5` lookup, or an `id` lookup with `object: file`).                                                                                      |
+| `edition`    | object | The edition record (present for an `md5` lookup's related edition, or an `id` lookup with `object: edition`).                                                              |
 
 An `md5` lookup returns `file` and, best-effort, its related `edition`. An `id` lookup returns whichever object was requested. A lookup that matches nothing returns a "no file found" error.
 
@@ -110,15 +114,16 @@ The first source that resolves and streams a valid file wins; the `source` field
 
 ### download output
 
-| Field               | Type   | Description                                                                                                                                      |
-| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `path`              | string | Absolute path of the saved file.                                                                                                                 |
-| `size_bytes`        | int    | Final file size in bytes.                                                                                                                        |
-| `original_filename` | string | The name the mirror/CDN announced (from `Content-Disposition`), if any.                                                                          |
-| `mirror`            | string | The `scheme://host` origin that served the bytes.                                                                                                |
-| `source`            | string | The source that succeeded: `libgen`, `randombook`, `unpaywall`, or `scihub`.                                                                     |
-| `verified`          | bool   | `true` when the downloaded bytes' MD5 matched the requested `md5` (book downloads). `false` for DOI-keyed sources, which carry no LibGen digest. |
-| `resumed`           | bool   | `true` when the download continued from a pre-existing partial via an HTTP `Range` request rather than starting from zero.                       |
+| Field               | Type   | Description                                                                                                                                              |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next_steps`        | array  | Suggested follow-up tool calls given this result — confirms the file was saved and is ready to open or read. Present to guide the model; safe to ignore. |
+| `path`              | string | Absolute path of the saved file.                                                                                                                         |
+| `size_bytes`        | int    | Final file size in bytes.                                                                                                                                |
+| `original_filename` | string | The name the mirror/CDN announced (from `Content-Disposition`), if any.                                                                                  |
+| `mirror`            | string | The `scheme://host` origin that served the bytes.                                                                                                        |
+| `source`            | string | The source that succeeded: `libgen`, `randombook`, `unpaywall`, or `scihub`.                                                                             |
+| `verified`          | bool   | `true` when the downloaded bytes' MD5 matched the requested `md5` (book downloads). `false` for DOI-keyed sources, which carry no LibGen digest.         |
+| `resumed`           | bool   | `true` when the download continued from a pre-existing partial via an HTTP `Range` request rather than starting from zero.                               |
 
 ### Behavior and errors
 


### PR DESCRIPTION
Make the tool surface self-describing so an **unguided LLM** uses it correctly (some models won't discover capabilities from terse schemas), and prove it with new eval scenarios. Ports the high-value discoverability patterns from the sibling `gitlab-mcp-server`, scaled to a 3-tool server.

## Model-facing improvements (`internal/tools`, `internal/libgen`)

- **`next_steps`** — every output (`search`/`get_details`/`download`) now leads with a `next_steps` array of follow-up suggestions that embed **ready-to-run examples using the result's real `md5`/`doi`**. Empty search returns recovery suggestions naming the topics.
- **Dual-channel output** — each result carries **both** the structured JSON (for the model) and a **human-readable Markdown rendering** in the text content. For `search` that's a results **table with each result's clickable download links**. (Returned via a `CallToolResult` the SDK augments with the JSON — verified.)
- **Download-link guidance** — search `next_steps` instructs the model to **include the download links** when it presents results (the sibling's preserve-links pattern).
- **Schema polish** — per-field `jsonschema` descriptions on `Result`/`DownloadResult`/outputs; scalar-vs-array hints on `order`/`order_mode`/`topics`/`search_in` (fixes an observed `order:["year"]` confusion); `See also:` cross-references from `get_details`/`download` back to `search`; actionable "not found" messages.

## Eval (`cmd/eval`)

- **S10–S13** — unguided prompts (model picks collection/fields/source itself).
- **S14** — end-to-end **download-progress** capture: the eval client registers a `ProgressNotificationHandler` and asserts notifications actually arrive during a live download.
- **S15** — ordered large-page request; asserts the model **surfaces download links** in its answer.

**Live results (real API + mirrors):** S10–S15 all **PASS** — e.g. S13 now searches→finds DOI→downloads via sci-hub; S14 saw **18 progress notifications** (final 982888/982888); S15 returned an ordered page of 50 and the model included the links.

## Docs & verification

- README, `docs/tools.md`, site EN/ES `tools.mdx`: `next_steps` rows + dual-channel/links note. `llms.txt`/`llms-full.txt` regenerated (auto-derived from the tools).
- `go test ./... -race` ✅ · `make golangci-lint` (+ eval tag) ✅ · `gocognit -over 15` ✅ · `make godoc-check` ✅ · `make check-llms`/`check-md-tables` ✅ · `make cover-check` → **98.7%** ✅

New tests: next_steps builders, Markdown rendering (+ links column, empty/doi/resumed branches), dual-channel protocol test, link-surfacing + preserve-links hint.

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the tools self-describing with `next_steps` and Markdown output so unguided models use `search`, `get_details`, and `download` correctly. Adds link-surfacing guidance and eval scenarios with progress capture to verify behavior end to end.

- New Features
  - `next_steps` on all outputs with ready-to-run examples using real `md5`/`doi`; empty `search` returns recovery tips with topic names.
  - Dual-channel output: structured JSON + readable Markdown via `CallToolResult`; `search` renders a results table with clickable download links and tells the model to include links in its answer.
  - Schema and errors: per-field `jsonschema` descriptions; scalar-vs-array hints for `order`/`order_mode`/`topics`/`search_in`; cross-references between tools; actionable not-found messages in `internal/libgen`.
  - Eval (`cmd/eval`): S10–S13 unguided prompts; S14 attaches a progress token and asserts notifications reach the client; S15 ordered large page with link surfacing. All pass.
  - Tests and docs: unit tests for `next_steps`, Markdown rendering, dual-channel behavior, and link surfacing; README and docs updated (EN/ES); `llms.txt` regenerated; coverage 98.7%.

<sup>Written for commit 5507b0303137620a0556352f2950786fd2509d5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

