### PR TITLE
docs(site): add Glama directory link to Astro JSON-LD metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=coverage)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmrplens/libgen-mcp.svg)](https://pkg.go.dev/github.com/jmrplens/libgen-mcp)
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-1f9cf0?style=flat&logo=cursor&logoColor=white)](https://cursor.directory/plugins/libgen-mcp)
+[![libgen-mcp MCP server](https://glama.ai/mcp/servers/jmrplens/libgen-mcp/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/libgen-mcp)
 
 </p>
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -161,6 +161,7 @@ const jsonLd = JSON.stringify({
 				`${fullUrl}/`,
 				repositoryUrl,
 				"https://cursor.directory/plugins/libgen-mcp",
+				"https://glama.ai/mcp/servers/jmrplens/libgen-mcp",
 				"https://registry.modelcontextprotocol.io/v0/servers?search=io.github.jmrplens/libgen-mcp",
 			],
 		},


### PR DESCRIPTION
Adds the Glama MCP directory listing to the site's structured metadata.

- `site/astro.config.mjs`: `https://glama.ai/mcp/servers/jmrplens/libgen-mcp` added to the JSON-LD `SoftwareApplication` `sameAs` array, next to `cursor.directory` and the MCP registry — the same place the other directory listings live, so search/AI engines associate the Glama page with the project.

Verified: `astro build` (13 pages, all internal links valid), `prettier --check` clean; the link renders into the JSON-LD across the built pages.

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the Glama MCP directory page to the site's JSON-LD (SoftwareApplication.sameAs) and a Glama score badge to the README to improve discoverability and associate the listing with the project. Inserted https://glama.ai/mcp/servers/jmrplens/libgen-mcp alongside cursor.directory and MCP registry links; added the score badge linking to that page.

<sup>Written for commit b706bee9e3221303a5ecce55df5c630c69633566. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

