### PR TITLE
chore(seo): apply on-site GEO audit fixes

### DIFF
--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -42,6 +42,7 @@ const (
 	llmsSummaryItemFormat = "- %s: %s\n"
 	llmsBoldTitleFormat   = "**%s**\n\n"
 	docsSiteURL           = "https://jmrplens.github.io/libgen-mcp/"
+	repoBlobURL           = "https://github.com/jmrplens/libgen-mcp/blob/main/"
 )
 
 func main() {
@@ -231,17 +232,20 @@ func writeLLMSTxt(version string, toolList []*mcp.Tool, checkOnly bool) error {
 	}
 	b.WriteString("\n")
 
+	// Absolute URLs so the links resolve when llms.txt is fetched from its served
+	// location (…/libgen-mcp/llms.txt), not just from the repo root. Doc pages point
+	// at the rendered site; repo-only files point at their GitHub blob.
 	b.WriteString("## Documentation\n\n")
-	writeLLMSLink(&b, "Getting started", "docs/getting-started.md", "Installation and first-run guide")
-	writeLLMSLink(&b, "Configuration", "docs/configuration.md", "Full environment-variable configuration reference")
-	writeLLMSLink(&b, "Tools", "docs/tools.md", "Per-tool reference for search, get_details and download")
-	writeLLMSLink(&b, "Architecture", "docs/architecture.md", "Internal architecture, mirror discovery and download sources")
-	writeLLMSLink(&b, "Troubleshooting", "docs/troubleshooting.md", "Common setup and runtime issues")
-	writeLLMSLink(&b, "Privacy policy", "PRIVACY.md", "No telemetry; requests go only to Library Genesis mirrors and article sources")
-	writeLLMSLink(&b, "Headless install", "llms-install.md", "Machine-readable install guide for AI assistants")
+	writeLLMSLink(&b, "Getting started", docsSiteURL+"getting-started/", "Installation and first-run guide")
+	writeLLMSLink(&b, "Configuration", docsSiteURL+"configuration/", "Full environment-variable configuration reference")
+	writeLLMSLink(&b, "Tools", docsSiteURL+"tools/", "Per-tool reference for search, get_details and download")
+	writeLLMSLink(&b, "Architecture", docsSiteURL+"architecture/", "Internal architecture, mirror discovery and download sources")
+	writeLLMSLink(&b, "Troubleshooting", docsSiteURL+"troubleshooting/", "Common setup and runtime issues")
+	writeLLMSLink(&b, "Privacy policy", repoBlobURL+"PRIVACY.md", "No telemetry; requests go only to Library Genesis mirrors and article sources")
+	writeLLMSLink(&b, "Headless install", repoBlobURL+"llms-install.md", "Machine-readable install guide for AI assistants")
 
 	b.WriteString("\n## Optional\n\n")
-	writeLLMSLink(&b, "Full LLM reference", llmsFullFileName, "Generated companion reference with full tool schemas")
+	writeLLMSLink(&b, "Full LLM reference", docsSiteURL+llmsFullFileName, "Generated companion reference with full tool schemas")
 	writeLLMSLink(&b, "Documentation site", docsSiteURL, "Rendered documentation site")
 
 	content := b.String()

--- a/llms.txt
+++ b/llms.txt
@@ -56,15 +56,15 @@ Tools:
 
 ## Documentation
 
-- [Getting started](docs/getting-started.md): Installation and first-run guide
-- [Configuration](docs/configuration.md): Full environment-variable configuration reference
-- [Tools](docs/tools.md): Per-tool reference for search, get_details and download
-- [Architecture](docs/architecture.md): Internal architecture, mirror discovery and download sources
-- [Troubleshooting](docs/troubleshooting.md): Common setup and runtime issues
-- [Privacy policy](PRIVACY.md): No telemetry; requests go only to Library Genesis mirrors and article sources
-- [Headless install](llms-install.md): Machine-readable install guide for AI assistants
+- [Getting started](https://jmrplens.github.io/libgen-mcp/getting-started/): Installation and first-run guide
+- [Configuration](https://jmrplens.github.io/libgen-mcp/configuration/): Full environment-variable configuration reference
+- [Tools](https://jmrplens.github.io/libgen-mcp/tools/): Per-tool reference for search, get_details and download
+- [Architecture](https://jmrplens.github.io/libgen-mcp/architecture/): Internal architecture, mirror discovery and download sources
+- [Troubleshooting](https://jmrplens.github.io/libgen-mcp/troubleshooting/): Common setup and runtime issues
+- [Privacy policy](https://github.com/jmrplens/libgen-mcp/blob/main/PRIVACY.md): No telemetry; requests go only to Library Genesis mirrors and article sources
+- [Headless install](https://github.com/jmrplens/libgen-mcp/blob/main/llms-install.md): Machine-readable install guide for AI assistants
 
 ## Optional
 
-- [Full LLM reference](llms-full.txt): Generated companion reference with full tool schemas
+- [Full LLM reference](https://jmrplens.github.io/libgen-mcp/llms-full.txt): Generated companion reference with full tool schemas
 - [Documentation site](https://jmrplens.github.io/libgen-mcp/): Rendered documentation site

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -6,7 +6,7 @@ import starlightLinksValidator from "starlight-links-validator";
 import mermaid from "astro-mermaid";
 
 const siteDescription =
-	"Open source Model Context Protocol server for Library Genesis — search books and resolve download links from your AI assistant.";
+	"Open-source MCP server in Go for Library Genesis: three tools to search and download books, papers and more from your AI assistant — no account required.";
 
 // --- Identity, URLs and structured-data ids ------------------------------
 const siteUrl = "https://jmrplens.github.io";
@@ -131,16 +131,12 @@ const jsonLd = JSON.stringify({
 			url: repositoryUrl,
 			downloadUrl: "https://github.com/jmrplens/libgen-mcp/releases/latest",
 			installUrl: "https://jmrplens.github.io/libgen-mcp/getting-started/",
-			releaseNotes:
-				"https://github.com/jmrplens/libgen-mcp/releases/tag/v1.0.0",
+			// Track the current release so this never lags behind softwareVersion.
+			releaseNotes: softwareVersion
+				? `https://github.com/jmrplens/libgen-mcp/releases/tag/v${softwareVersion}`
+				: "https://github.com/jmrplens/libgen-mcp/releases/latest",
 			codeRepository: repositoryUrl,
 			image: socialImage,
-			screenshot: {
-				"@type": "ImageObject",
-				url: socialImageUrl,
-				width: 1200,
-				height: 630,
-			},
 			license: "https://opensource.org/licenses/MIT",
 			isAccessibleForFree: true,
 			datePublished,

--- a/site/src/content/docs/es/index.mdx
+++ b/site/src/content/docs/es/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: LibGen MCP
-description: Servidor Model Context Protocol de código abierto para Library Genesis — busca libros y resuelve enlaces de descarga desde tu asistente de IA.
+description: "Servidor MCP en Go de código abierto para Library Genesis: tres herramientas para buscar y descargar libros, artículos y más desde tu asistente de IA — sin cuenta."
 head:
   - tag: title
     content: "LibGen MCP — buscar libros y artículos en Library Genesis"
@@ -50,7 +50,7 @@ head:
         ]
       }
 hero:
-  tagline: Un servidor Model Context Protocol que permite a tu asistente de IA buscar en Library Genesis y resolver enlaces de descarga — en lenguaje natural.
+  tagline: Un servidor MCP en Go con tres herramientas — search, get_details, download — que permite a tu asistente de IA buscar en Library Genesis y resolver enlaces de descarga en lenguaje natural. Sin cuenta ni clave de API.
   image:
     dark: ../../../assets/logo-dark.svg
     light: ../../../assets/logo-light.svg

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: LibGen MCP
-description: Open source Model Context Protocol server for Library Genesis — search books and resolve download links from your AI assistant.
+description: "Open-source MCP server in Go for Library Genesis: three tools to search and download books, papers and more from your AI assistant — no account required."
 head:
   - tag: title
     content: "LibGen MCP — MCP server for Library Genesis book & paper search"
@@ -50,7 +50,7 @@ head:
         ]
       }
 hero:
-  tagline: A Model Context Protocol server that lets your AI assistant search Library Genesis and resolve download links — in plain language.
+  tagline: A Go MCP server with three tools — search, get_details, download — that lets your AI assistant search Library Genesis and resolve download links in plain language. No account or API key.
   image:
     dark: ../../assets/logo-dark.svg
     light: ../../assets/logo-light.svg


### PR DESCRIPTION
Applies the **on-site** fixes surfaced by the GEO audit (full report kept in `plan/GEO-AUDIT-REPORT.md`, gitignored). GEO score was **69/100** — on-page ≈90 (Excellent), capped by off-page authority for a days-old project. These address the on-page/schema items; off-page items remain manual.

## Fixes
- **Schema — real bug:** `SoftwareApplication.releaseNotes` pointed at the **v1.0.0** tag while `softwareVersion` is 1.1.0. Now **derived from the `VERSION` file** so it never lags. Also **removed `screenshot`** (it reused the OG banner, not a real product shot; kept `image`).
- **Metadata / disambiguation:** expanded the site + homepage description (EN/ES) to ~150 chars and front-loaded the differentiators — **"MCP server in Go", "three tools", "no account"** — to fight the **namesake collision** (two other `libgen-mcp` TypeScript repos own the SERP/directories, flagged as the #1 issue by two audit passes).
- **Citability:** rewrote the homepage **hero tagline** (EN/ES) to lead with concrete facts (Go, the three tool names, no account/API key) instead of generic prose.
- **llms.txt correctness:** the Documentation links were relative `docs/*.md` — they **404 when llms.txt is fetched from its served URL** (`…/libgen-mcp/llms.txt`). Made them **absolute** (doc pages → rendered site, repo-only files → GitHub blob).

## Out of scope (manual / other repos)
Wikidata entity, aggregator submissions (mcp.so/PulseMCP/LobeHub/Docker MCP Catalog), Show HN / YouTube / GitHub stars, Bing WMT + IndexNow, and the hub `robots.txt` `Content-Signal` `ai-personalization` tweak (lives in the `jmrplens.github.io` repo). Captured in the 30-day plan in the report.

## Verification
`astro build` (13 pages, links valid; HTML confirms `releaseNotes=v1.1.0`, no `screenshot`, new EN/ES descriptions) · `go test ./...` · golangci · `make check-llms` (absolute links) · `check-md-tables` · eslint · `prettier --check` — all green.

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies on-site GEO audit fixes to improve structured data accuracy, search disambiguation, and link reliability. Fixes the schema version mismatch, removes a non-product screenshot, updates EN/ES descriptions and hero copy, and makes `llms.txt` doc links absolute.

- Bug Fixes
  - Schema: `SoftwareApplication.releaseNotes` now derived from `VERSION`; removed `screenshot` (kept `image`).
  - `llms.txt`: switched relative docs to absolute URLs (docs → site, repo files → GitHub), and linked the full reference on the docs site.

<sup>Written for commit 5e2003926e7ee34e08eece162a07e4139e1b6b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

