### PR TITLE
feat(cmd): audit_tokens + README docs link, token footprint & config quick-start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
         lint golangci-lint govulncheck analyze fmt tidy vet \
         format-md-tables check-md-tables \
         godoc-audit godoc-check \
-        gen-llms check-llms \
+        gen-llms check-llms audit-tokens \
         install-tools release-check check-server-json check-mcpb-manifest mcpb sonar clean help \
         build-linux-amd64 build-linux-arm64 build-darwin-amd64 \
         build-darwin-arm64 build-windows-amd64 build-windows-arm64
@@ -158,6 +158,9 @@ gen-llms: ## Generate llms.txt and llms-full.txt from the registered tools
 
 check-llms: ## Fail if llms.txt/llms-full.txt are stale or structurally invalid (CI mode)
 	go run ./cmd/gen_llms/ --check
+
+audit-tokens: ## Report the LLM context-window footprint (tokens) of the tool definitions
+	go run ./cmd/audit_tokens/
 
 # ─── Tools / Release ────────────────────────────────────────────────────────
 install-tools: ## Install golangci-lint and govulncheck

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ You talk to your AI assistant; it does the searching and fetching. You don't nee
 
 > "Find me the latest edition of _Clean Code_." · "Download that paper by its DOI." · "Search comics for _Watchmen_ and grab the CBR."
 
+**📖 Full documentation, install guides & configuration reference → [jmrplens.github.io/libgen-mcp](https://jmrplens.github.io/libgen-mcp/)** (also in [Español](https://jmrplens.github.io/libgen-mcp/es/)). Light context footprint: the three tools add **~1,900 tokens** to a request (`make audit-tokens`), and no account, API key, or token is required.
+
 ---
 
 ## Install
@@ -146,7 +148,19 @@ Download a file to a local directory. Provide `md5` for a book **or** `doi` for 
 
 If both `md5` and `doi` are given, article sources are tried first, then book sources.
 
-## Environment variables
+## Configuration
+
+**It works out of the box — zero configuration, no account.** Every variable below is optional. Common setups (add these as `env` entries in your MCP client config, or `-e NAME=value` with Docker):
+
+- **Enable open-access articles (Unpaywall):** `LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com` — disabled by default; the Unpaywall API needs a contact email. Without it, DOIs still resolve via Sci-Hub.
+- **Choose where files land:** `LIBGEN_MCP_DOWNLOAD_DIR=/path/to/downloads` (default `~/Downloads`; the `download` tool's `path` argument overrides per call).
+- **Pin one mirror** (skip auto-discovery): `LIBGEN_MIRROR=https://libgen.li`.
+- **Restrict sources** (e.g. books only, no article sources): `LIBGEN_MCP_SOURCES=libgen,randombook`.
+- **Cap download size / concurrency:** `LIBGEN_MCP_MAX_DOWNLOAD_BYTES=1073741824` (1 GiB), `LIBGEN_MCP_MAX_CONCURRENT_DOWNLOADS=1`.
+
+Full reference and tuning knobs (rate limits, retry/stall schedules, Sci-Hub hosts) are in the **[configuration guide](https://jmrplens.github.io/libgen-mcp/configuration/)**.
+
+### Environment variables
 
 Every variable is optional; an empty or unset value uses the default. A present-but-invalid numeric value is an error rather than a silent fallback.
 

--- a/cmd/audit_tokens/main.go
+++ b/cmd/audit_tokens/main.go
@@ -1,0 +1,130 @@
+// Command audit_tokens measures the LLM context-window footprint of libgen-mcp's
+// MCP tool definitions. It builds an in-memory MCP server, lists the tools over a
+// real tools/list round-trip, serializes each tool definition to JSON, and counts
+// tokens with the cl100k_base tokenizer (see countTokens), falling back to a
+// bytes/4 heuristic. This is the fixed context cost every request pays for having
+// libgen-mcp loaded — useful for judging how "cheap" the server is to keep on.
+//
+// The full tool surface is measured (all download sources enabled), so the number
+// is deterministic and represents the upper bound.
+//
+// Usage:
+//
+//	go run ./cmd/audit_tokens/
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/jmrplens/libgen-mcp/internal/config"
+	"github.com/jmrplens/libgen-mcp/internal/libgen"
+	"github.com/jmrplens/libgen-mcp/internal/mirrors"
+	"github.com/jmrplens/libgen-mcp/internal/tools"
+)
+
+func main() {
+	if err := run(os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "audit_tokens:", err)
+		os.Exit(1)
+	}
+}
+
+// toolTokenInfo is the serialized-size estimate for one MCP tool definition.
+type toolTokenInfo struct {
+	Name   string
+	Tokens int
+	Bytes  int
+}
+
+// run builds the in-memory server, lists its tools, and writes the token report
+// to w. Construction is offline: config.Load and mirrors.NewManager do no network
+// I/O, and no tool is called.
+func run(w io.Writer) error {
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = &config.Config{}
+	}
+	// Measure the full tool surface regardless of the ambient environment: the
+	// download tool's source enum shrinks when sources are disabled (e.g. unpaywall
+	// without an email), so enable everything for a deterministic upper-bound count.
+	cfg.Sources = nil
+	if cfg.UnpaywallEmail == "" {
+		cfg.UnpaywallEmail = "audit@example.com"
+	}
+
+	mgr, err := mirrors.NewManager(cfg)
+	if err != nil {
+		return fmt.Errorf("create mirror manager: %w", err)
+	}
+	client := libgen.New(mgr, cfg)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "audit-tokens", Version: "0.0.1"}, nil)
+	tools.Register(server, client, cfg)
+
+	st, ct := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	serverSession, err := server.Connect(ctx, st, nil)
+	if err != nil {
+		return fmt.Errorf("server connect: %w", err)
+	}
+	defer func() { _ = serverSession.Wait() }()
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "audit-tokens-client", Version: "0.0.1"}, nil)
+	session, err := mcpClient.Connect(ctx, ct, nil)
+	if err != nil {
+		return fmt.Errorf("client connect: %w", err)
+	}
+	defer func() { _ = session.Close() }()
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list tools: %w", err)
+	}
+
+	infos, totalTokens, totalBytes, err := measureTools(result.Tools)
+	if err != nil {
+		return err
+	}
+	writeReport(w, infos, totalTokens, totalBytes)
+	return nil
+}
+
+// measureTools serializes each tool definition to JSON and counts its tokens,
+// returning the per-tool breakdown and the totals.
+func measureTools(toolsList []*mcp.Tool) (infos []toolTokenInfo, totalTokens, totalBytes int, err error) {
+	for _, t := range toolsList {
+		if t == nil {
+			continue
+		}
+		data, marshalErr := json.Marshal(t)
+		if marshalErr != nil {
+			return nil, 0, 0, fmt.Errorf("marshal tool %q: %w", t.Name, marshalErr)
+		}
+		tk := countTokens(data)
+		infos = append(infos, toolTokenInfo{Name: t.Name, Tokens: tk, Bytes: len(data)})
+		totalTokens += tk
+		totalBytes += len(data)
+	}
+	return infos, totalTokens, totalBytes, nil
+}
+
+// writeReport renders the token footprint as an aligned table plus a one-line
+// summary of the total context cost of loading the server.
+func writeReport(w io.Writer, infos []toolTokenInfo, totalTokens, totalBytes int) {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "TOOL\tBYTES\tTOKENS")
+	for _, in := range infos {
+		fmt.Fprintf(tw, "%s\t%d\t%d\n", in.Name, in.Bytes, in.Tokens)
+	}
+	fmt.Fprintf(tw, "TOTAL (%d tools)\t%d\t%d\n", len(infos), totalBytes, totalTokens)
+	_ = tw.Flush()
+	fmt.Fprintf(w, "\nLoading libgen-mcp adds ~%d tokens of context (cl100k_base) for its %d tool definitions.\n",
+		totalTokens, len(infos))
+}

--- a/cmd/audit_tokens/main_test.go
+++ b/cmd/audit_tokens/main_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestCountTokens checks the tokenizer path returns a positive, sane count and
+// that empty input yields zero.
+func TestCountTokens(t *testing.T) {
+	if n := countTokens([]byte("")); n != 0 {
+		t.Errorf("empty input: got %d tokens, want 0", n)
+	}
+	n := countTokens([]byte("the quick brown fox jumps over the lazy dog"))
+	if n <= 0 || n > 20 {
+		t.Errorf("token count %d is out of the expected range for a short sentence", n)
+	}
+}
+
+// TestMeasureTools sums per-tool tokens/bytes and skips nils.
+func TestMeasureTools(t *testing.T) {
+	list := []*mcp.Tool{
+		{Name: "a", Description: "does a thing"},
+		nil,
+		{Name: "b", Description: "does another thing"},
+	}
+	infos, totalTokens, totalBytes, err := measureTools(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("got %d tool infos, want 2 (nil skipped)", len(infos))
+	}
+	if totalTokens <= 0 || totalBytes <= 0 {
+		t.Errorf("totals should be positive: tokens=%d bytes=%d", totalTokens, totalBytes)
+	}
+	sumT, sumB := 0, 0
+	for _, in := range infos {
+		sumT += in.Tokens
+		sumB += in.Bytes
+	}
+	if sumT != totalTokens || sumB != totalBytes {
+		t.Errorf("totals (%d/%d) do not match the per-tool sum (%d/%d)", totalTokens, totalBytes, sumT, sumB)
+	}
+}
+
+// TestWriteReport renders a table with a TOTAL row and the summary line.
+func TestWriteReport(t *testing.T) {
+	var b bytes.Buffer
+	writeReport(&b, []toolTokenInfo{{Name: "search", Tokens: 100, Bytes: 400}}, 100, 400)
+	out := b.String()
+	for _, want := range []string{"TOOL", "TOKENS", "search", "TOTAL (1 tools)", "adds ~100 tokens"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunEndToEnd exercises the real registration path: it builds the in-memory
+// server, lists the 3 tools, and asserts a positive footprint is reported.
+func TestRunEndToEnd(t *testing.T) {
+	var b bytes.Buffer
+	if err := run(&b); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	out := b.String()
+	for _, want := range []string{"search", "get_details", "download", "TOTAL (3 tools)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/audit_tokens/tokens.go
+++ b/cmd/audit_tokens/tokens.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/tiktoken-go/tokenizer"
+)
+
+// Token counting is audit-only: it lives here with its sole consumer
+// (cmd/audit_tokens) rather than in a runtime package — the MCP server itself
+// never tokenizes anything.
+
+var (
+	defaultCodec tokenizer.Codec
+	codecOnce    sync.Once
+)
+
+// tokenCodec lazily initializes the cl100k_base tokenizer on first use. If
+// initialization fails (e.g. a corrupt vocabulary), it returns nil and
+// countTokens falls back to the bytes/4 heuristic.
+func tokenCodec() tokenizer.Codec {
+	codecOnce.Do(func() {
+		defaultCodec, _ = tokenizer.Get(tokenizer.Cl100kBase)
+	})
+	return defaultCodec
+}
+
+// countTokens returns the token count for data using the cl100k_base tokenizer
+// (the GPT-4 / GPT-3.5 encoding, a good proxy across modern LLMs). It falls back
+// to the bytes/4 heuristic when the tokenizer is unavailable.
+func countTokens(data []byte) int {
+	codec := tokenCodec()
+	if codec == nil {
+		return len(data) / 4
+	}
+	ids, _, err := codec.Encode(string(data))
+	if err != nil {
+		return len(data) / 4
+	}
+	return len(ids)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.26
 require (
 	github.com/google/jsonschema-go v0.4.3
 	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/tiktoken-go/tokenizer v0.8.1
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
 )
 
 require (
+	github.com/dlclark/regexp2/v2 v2.5.1 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
+github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -10,6 +12,8 @@ github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
 github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
+github.com/tiktoken-go/tokenizer v0.8.1 h1:4obDoB6/dhdBt9xMweX4nww5cjdOq/nYF4ecwPq2+mg=
+github.com/tiktoken-go/tokenizer v0.8.1/go.mod h1:eLA0t6nGvn9mDc7gt90qt7pMat+gE9ViqwQ6l9B+tA4=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=


### PR DESCRIPTION
Three of the follow-ups discussed, plus context for the rest.

## `cmd/audit_tokens` (new)
Measures the **LLM context-window footprint** of libgen-mcp's tool definitions — the fixed cost every request pays for having the server loaded. Builds an in-memory server, lists the tools over a real `tools/list` round-trip, serializes each definition to JSON, and counts tokens with the `cl100k_base` tokenizer (bytes/4 fallback). Ported from the sibling `gitlab-mcp-server`.

```
TOOL             BYTES  TOKENS
download         2511   559
get_details      1470   336
search           4551   993
TOTAL (3 tools)  8532   1888
```

`make audit-tokens` runs it. New dep: `github.com/tiktoken-go/tokenizer` (dev/CLI only; govulncheck clean).

## README
- **Prominent docs-site link** up top (EN + ES) — the web docs were only linked deep in the body.
- **Token-footprint line** (~1,900 tokens) so users can see how cheap the server is to keep loaded.
- **Configuration quick-start** with copy-paste recipes (enable Unpaywall via email, download dir, pin a mirror, restrict sources, size/concurrency caps) above the full env-var table.

## Verification
`go test ./...` · `make golangci-lint` · `govulncheck` (no vulns) · `check-md-tables` · `check-llms` · `cover-check` **98.7%** — all green. New tests cover the tokenizer, the per-tool measurement, the report, and the end-to-end registration path.

---
**Related (not in this PR):** the LLM-eval **results doc** for the web docs is coming as a separate PR (site pages EN/ES). The competitor comparison and the nginx v1.1.0 deploy were done out-of-band (summarized in chat).

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI to audit the LLM context-window footprint of our MCP tool definitions and updates the README with a prominent docs link, token footprint, and a configuration quick-start. The audit reports ~1,900 tokens for the 3 tools and is available via a Makefile target.

- **New Features**
  - `cmd/audit_tokens`: builds an in-memory server, lists tools, serializes to JSON, and counts tokens using cl100k_base (bytes/4 fallback).
  - Makefile target `audit-tokens` to run the report.
  - README: adds docs-site link (EN/ES), token-footprint line, and a configuration quick-start with common env vars.
  - Tests for tokenizer, per-tool measurement, report, and end-to-end registration.

- **Dependencies**
  - Added `github.com/tiktoken-go/tokenizer` (CLI/dev only).

<sup>Written for commit 0adabe472d21066fb0459670582958fc53ccc44e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

