### PR TITLE
docs(site): add LLM eval results page (EN/ES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You talk to your AI assistant; it does the searching and fetching. You don't nee
 
 > "Find me the latest edition of _Clean Code_." · "Download that paper by its DOI." · "Search comics for _Watchmen_ and grab the CBR."
 
-**📖 Full documentation, install guides & configuration reference → [jmrplens.github.io/libgen-mcp](https://jmrplens.github.io/libgen-mcp/)** (also in [Español](https://jmrplens.github.io/libgen-mcp/es/)). Light context footprint: the three tools add **~1,900 tokens** to a request (`make audit-tokens`), and no account, API key, or token is required.
+**📖 Full documentation, install guides & configuration reference → [jmrplens.github.io/libgen-mcp](https://jmrplens.github.io/libgen-mcp/)** (also in [Español](https://jmrplens.github.io/libgen-mcp/es/)). Light context footprint: the three tools add **~1,900 tokens** to a request (`make audit-tokens`), and no account, API key, or token is required. It's also verified against a **real LLM** — see the [eval results](https://jmrplens.github.io/libgen-mcp/eval-results/).
 
 ---
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -334,6 +334,11 @@ export default defineConfig({
 							label: "Architecture",
 							translations: { es: "Arquitectura" },
 						},
+						{
+							slug: "eval-results",
+							label: "LLM eval results",
+							translations: { es: "Resultados del eval con LLM" },
+						},
 					],
 				},
 			],

--- a/site/src/content/docs/es/eval-results.mdx
+++ b/site/src/content/docs/es/eval-results.mdx
@@ -1,0 +1,107 @@
+---
+title: Resultados del eval con LLM
+description: "Cómo se prueba libgen-mcp contra un LLM real: un arnés controlado conduce a Claude sobre MCP contra el sitio en vivo, evaluando selección de herramienta, argumentos, descargas, reintentos y progreso en 16 escenarios."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+libgen-mcp incluye un **arnés de evaluación controlado y guiado por un LLM**
+(`cmd/eval`) que va más allá de los tests unitarios y e2e: conecta un **modelo de
+lenguaje real** (Claude Haiku) a un **servidor libgen-mcp real** por el protocolo
+MCP y comprueba que el modelo realmente _usa bien las herramientas_ contra el
+sitio **en vivo** de Library Genesis — la herramienta correcta, los argumentos
+correctos, una recuperación sensata ante fallos y un manejo correcto de la salida
+estructurada.
+
+## Cómo funciona
+
+Para cada escenario, el arnés:
+
+1. Aplica el entorno propio del escenario y construye un servidor libgen-mcp
+   fresco en proceso con las tres herramientas registradas.
+2. Envía el prompt en lenguaje natural del escenario más las definiciones de las
+   herramientas al modelo (hasta cuatro turnos).
+3. Ejecuta cada llamada de herramienta del modelo **contra el servidor real**
+   (mirrors reales, descargas reales) y le devuelve los resultados.
+4. Evalúa la transcripción: el nombre de la herramienta, la forma de los
+   argumentos y si la respuesta MCP real está bien formada — nunca el contenido
+   exacto del catálogo, que cambia con el tiempo.
+
+Cada escenario devuelve **PASS**, **FAIL** o **SKIP**. Un SKIP significa que el
+modelo hizo lo correcto pero un mirror en vivo no estaba disponible (p. ej. un
+host rotatorio de Sci-Hub o un fallo de descubrimiento de mirror fresco) — una
+condición de red, nunca un fallo del modelo.
+
+<Aside type="note">
+	El arnés está detrás del build tag `eval` y solo se ejecuta con
+	`LIBGEN_EVAL=1` y una `ANTHROPIC_API_KEY`. Gasta tokens reales de la API y
+	hace descargas reales, así que nunca corre en CI — es una comprobación de
+	calidad bajo demanda.
+</Aside>
+
+## Escenarios
+
+Dieciséis escenarios (S1–S15, más una variante S6b) cubren búsqueda, detalles,
+descargas, selección de fuente, recuperación de errores, progreso y — de forma
+importante — prompts **sin guía** que no dan pistas al modelo, para comprobar si
+la superficie de herramientas es lo bastante auto-descriptiva para que un LLM la
+use sin ayuda.
+
+| ID  | Qué comprueba                                                                                                                                                                            |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S1  | Búsqueda de libro: topic nonfiction, columnas título/autor, primer resultado con md5 de 32-hex                                                                                           |
+| S2  | Búsqueda de artículo: topic articles, al menos un resultado con DOI válido                                                                                                               |
+| S3  | Búsqueda de estándares (SKIP si el mirror devuelve 0)                                                                                                                                    |
+| S4  | `get_details` sobre un md5 tomado de un resultado de búsqueda previo                                                                                                                     |
+| S5  | Descarga de libro por md5: ruta guardada + tamaño no nulo                                                                                                                                |
+| S6  | Descarga **eligiendo fuente**: el modelo pone `source:"scihub"` para un DOI de artículo de pago                                                                                          |
+| S6b | Descarga eligiendo fuente de libro: el modelo pone `source:"randombook"` para un md5                                                                                                     |
+| S7  | Artículo de acceso abierto por DOI vía unpaywall (necesita email de contacto)                                                                                                            |
+| S8  | Ambiguo "encuéntrame un buen libro" — pasa si el modelo pide aclaración o la herramienta lo rechaza                                                                                      |
+| S9  | **Reintentos de arranque**: Sci-Hub apuntado a un host muerto; el schedule escalonado debe agotarse y devolver el error accionable "could not start", y el modelo no debe fabricar éxito |
+| S10 | **Búsqueda de libro sin guía** ("quiero leer _Dune_…") — el modelo forma una búsqueda desde una petición simple, sin pistas de colección/campos                                          |
+| S11 | **Búsqueda de cómics sin guía** ("encuentra la novela gráfica _Watchmen_") — el modelo debe descubrir la colección correcta sin ayuda                                                    |
+| S12 | **Descarga de libro sin guía** ("descarga _Clean Code_…") — el modelo busca y descarga por un md5 que descubrió, eligiendo la fuente él mismo                                            |
+| S13 | **Descarga de artículo sin guía** ("dame un PDF de _Hallmarks of Cancer_") — el modelo debe descubrir que los artículos van por DOI, no por md5                                          |
+| S14 | **Progreso de descarga** — se adjunta un token de progreso; las notificaciones deben llegar al cliente de punta a punta durante una descarga en vivo                                     |
+| S15 | **Tabla ordenada con enlaces** — una petición grande y ordenada; el modelo debe fijar un tamaño de página grande + orden e incluir los enlaces de descarga en su respuesta               |
+
+## Últimos resultados
+
+En las corridas en vivo más recientes (API real + mirrors reales), **todos los
+escenarios pasan**, con `S6b` en SKIP cuando el descubrimiento de mirror fresco de
+randombook no está disponible — una condición de mirror en vivo, no un fallo del
+modelo.
+
+| ID  | Resultado | Evidencia                                                                  |
+| --- | --------- | -------------------------------------------------------------------------- |
+| S1  | ✅ PASS   | búsqueda nonfiction, 25 resultados, primer md5 válido                      |
+| S2  | ✅ PASS   | búsqueda articles, resultado con DOI válido                                |
+| S3  | ✅ PASS   | búsqueda standards, 25 resultados                                          |
+| S4  | ✅ PASS   | `get_details` devolvió un registro File/Edition                            |
+| S5  | ✅ PASS   | descargó un libro vía `libgen` (MD5-verificado)                            |
+| S6  | ✅ PASS   | el modelo puso `source:"scihub"`; descargó ~6,4 MB                         |
+| S6b | ⏭️ SKIP   | el modelo puso `source:"randombook"` correctamente; el mirror devolvió 404 |
+| S7  | ✅ PASS   | descargó un DOI vía `unpaywall`                                            |
+| S8  | ✅ PASS   | el modelo pidió aclaración en vez de adivinar                              |
+| S9  | ✅ PASS   | reintentos agotados; error accionable; sin éxito fabricado                 |
+| S10 | ✅ PASS   | eligió `topics:[fiction]` sin ayuda                                        |
+| S11 | ✅ PASS   | eligió `topics:[comics]` sin ayuda                                         |
+| S12 | ✅ PASS   | buscó y descargó por md5 vía `libgen`                                      |
+| S13 | ✅ PASS   | buscó → encontró el DOI → descargó vía `scihub`                            |
+| S14 | ✅ PASS   | recibió 18 notificaciones de progreso, final `982888/982888`               |
+| S15 | ✅ PASS   | página ordenada de 50; el modelo incluyó los enlaces en su respuesta       |
+
+## Cómo ejecutarlo
+
+```sh
+# Todos los escenarios (API + mirrors + descargas reales)
+LIBGEN_EVAL=1 ANTHROPIC_API_KEY=… make eval
+
+# Un subconjunto, conservando los archivos descargados
+LIBGEN_EVAL=1 ANTHROPIC_API_KEY=… go run -tags eval ./cmd/eval --only S1,S9,S14 --keep-downloads
+```
+
+El proceso sale con código ≠ 0 si algún escenario **falla** o **da error** (los
+SKIP y PASS no). Consulta [`cmd/eval/README.md`](https://github.com/jmrplens/libgen-mcp/blob/main/cmd/eval/README.md)
+para la documentación completa del arnés.

--- a/site/src/content/docs/eval-results.mdx
+++ b/site/src/content/docs/eval-results.mdx
@@ -1,0 +1,101 @@
+---
+title: LLM eval results
+description: "How libgen-mcp is tested against a real LLM: a gated harness drives Claude over MCP against the live site, grading tool selection, arguments, downloads, retries and progress across 16 scenarios."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+libgen-mcp ships a **gated, LLM-driven evaluation harness** (`cmd/eval`) that goes
+beyond unit and end-to-end tests: it connects a **real language model** (Claude
+Haiku) to a **real libgen-mcp server** over the MCP protocol and checks that the
+model actually _uses the tools correctly_ against the **live** Library Genesis
+site — the right tool, the right arguments, sensible recovery on failure, and
+correct handling of the structured output.
+
+## How it works
+
+For each scenario the harness:
+
+1. Applies any per-scenario environment, then builds a fresh in-process
+   libgen-mcp server with the three tools registered.
+2. Sends the scenario's natural-language prompt plus the tool definitions to the
+   model (up to four turns).
+3. Executes every tool call the model makes **against the real server** (real
+   mirrors, real downloads) and feeds the results back.
+4. Grades the transcript: the tool name, the argument shape, and whether the
+   real MCP response is well-formed — never exact catalog content, which drifts.
+
+Each scenario returns **PASS**, **FAIL**, or **SKIP**. A SKIP means the model did
+the right thing but a live mirror was unavailable (e.g. a rotating Sci-Hub host or
+a fresh-mirror miss) — a network condition, never a model failure.
+
+<Aside type="note">
+	The harness is behind the `eval` build tag and only runs with `LIBGEN_EVAL=1`
+	and an `ANTHROPIC_API_KEY`. It spends real API tokens and performs real
+	downloads, so it never runs in CI — it is an on-demand quality check.
+</Aside>
+
+## Scenarios
+
+Sixteen scenarios (S1–S15, plus a S6b variant) cover search, details, downloads,
+source selection, error recovery, progress, and — importantly — **unguided**
+prompts that give the model no hints, testing whether the tool surface is
+self-describing enough for an LLM to use unaided.
+
+| ID  | What it checks                                                                                                                                                                        |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S1  | Book search: nonfiction topic, title/author columns, first result has a 32-hex md5                                                                                                    |
+| S2  | Article search: articles topic, at least one result with a valid DOI                                                                                                                  |
+| S3  | Standards search (SKIPs if the mirror returns 0)                                                                                                                                      |
+| S4  | `get_details` on an md5 taken from a prior search result                                                                                                                              |
+| S5  | Book download by md5: saved path + non-zero size                                                                                                                                      |
+| S6  | Download **choosing a source**: model sets `source:"scihub"` for a paywalled article DOI                                                                                              |
+| S6b | Download choosing a book source: model sets `source:"randombook"` for an md5                                                                                                          |
+| S7  | Open-access article by DOI via unpaywall (needs a contact email)                                                                                                                      |
+| S8  | Ambiguous "find me a good book" — passes if the model clarifies or the tool rejects it                                                                                                |
+| S9  | **Start-retries**: Sci-Hub pinned to a dead host; the staged retry schedule must exhaust and surface the actionable "could not start" error, and the model must not fabricate success |
+| S10 | **Unguided book search** ("I want to read _Dune_…") — model forms a search from a bare request, no collection/field hints                                                             |
+| S11 | **Unguided comics search** ("find the graphic novel _Watchmen_") — model must discover the right collection unaided                                                                   |
+| S12 | **Unguided book download** ("download _Clean Code_…") — model searches, then downloads by an md5 it discovered, choosing the source itself                                            |
+| S13 | **Unguided article download** ("get me a PDF of _Hallmarks of Cancer_") — model must discover articles are keyed by DOI, not md5                                                      |
+| S14 | **Download progress** — a progress token is attached; progress notifications must reach the client end to end during a live download                                                  |
+| S15 | **Ordered table with links** — a large sorted request; the model must set a big page size + ordering and include the results' download links in its answer                            |
+
+## Latest results
+
+Across the most recent live runs (real API + real mirrors), **every scenario
+passes**, with `S6b` skipping when the randombook fresh-mirror lookup is
+unavailable — a live-mirror condition, not a model failure.
+
+| ID  | Result  | Evidence                                                                  |
+| --- | ------- | ------------------------------------------------------------------------- |
+| S1  | ✅ PASS | nonfiction search, 25 results, first md5 valid                            |
+| S2  | ✅ PASS | articles search, result with a valid DOI                                  |
+| S3  | ✅ PASS | standards search, 25 results                                              |
+| S4  | ✅ PASS | `get_details` returned a File/Edition record                              |
+| S5  | ✅ PASS | downloaded a book via `libgen` (MD5-verified)                             |
+| S6  | ✅ PASS | model set `source:"scihub"`; downloaded ~6.4 MB                           |
+| S6b | ⏭️ SKIP | model set `source:"randombook"` correctly; live mirror returned 404       |
+| S7  | ✅ PASS | downloaded a DOI via `unpaywall`                                          |
+| S8  | ✅ PASS | model asked to clarify instead of guessing                                |
+| S9  | ✅ PASS | start-retries exhausted; actionable error surfaced; no fabricated success |
+| S10 | ✅ PASS | picked `topics:[fiction]` unaided                                         |
+| S11 | ✅ PASS | picked `topics:[comics]` unaided                                          |
+| S12 | ✅ PASS | searched, then downloaded by md5 via `libgen`                             |
+| S13 | ✅ PASS | searched → found DOI → downloaded via `scihub`                            |
+| S14 | ✅ PASS | received 18 progress notifications, final `982888/982888`                 |
+| S15 | ✅ PASS | ordered page of 50; model surfaced the download links in its answer       |
+
+## Running it yourself
+
+```sh
+# All scenarios (real API + mirrors + downloads)
+LIBGEN_EVAL=1 ANTHROPIC_API_KEY=… make eval
+
+# A subset, and keep the downloaded files
+LIBGEN_EVAL=1 ANTHROPIC_API_KEY=… go run -tags eval ./cmd/eval --only S1,S9,S14 --keep-downloads
+```
+
+The process exits non-zero if any scenario **fails** or **errors** (SKIPs and
+PASSes do not). See [`cmd/eval/README.md`](https://github.com/jmrplens/libgen-mcp/blob/main/cmd/eval/README.md)
+for the full harness documentation.


### PR DESCRIPTION
Adds the **LLM eval results** doc you asked for — on the web docs (EN + ES), so it's discoverable and citable.

A new Reference page documenting the gated LLM-driven eval harness (`cmd/eval`):
- **What it is** — a real language model (Claude Haiku) driven over MCP against a real libgen-mcp server and the **live** Library Genesis site, checking tool selection / arguments / recovery / structured output.
- **How it grades** — PASS / FAIL / SKIP (SKIP = model did the right thing but a live mirror was down).
- **The 16 scenarios** (S1–S15 + S6b) — search, details, downloads, source selection, retries, progress, and the **unguided** prompts that test whether the tool surface is self-describing.
- **Latest results** — every scenario passes; `S6b` skips when the randombook fresh-mirror lookup is unavailable (a live-mirror condition).
- **How to run it** yourself.

Also adds the sidebar entry (EN/ES) and a README link to the page.

## Verification
`astro check` (0 errors/warnings) · `astro build` (15 pages, all internal links valid) · `prettier` · `check-md-tables` — green.

https://claude.ai/code/session_01YXhvERFuVEkTSgK1Je4J9g

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an EN/ES Reference page for LLM evaluation results, documenting the `cmd/eval` harness with latest live-run outcomes and how to run it. Also links it from the README and adds a sidebar entry so it’s easy to find and cite.

- **New Features**
  - New EN/ES docs pages for the gated LLM eval harness (`cmd/eval`): overview, grading (PASS/FAIL/SKIP), 16 scenarios, latest results (all pass; `S6b` may SKIP on live-mirror miss), and run instructions.
  - Sidebar entry added in `site/astro.config.mjs` (EN/ES).
  - README now links to the eval results page.

<sup>Written for commit 70b1dd8ec3b887eb9a3cdd605acd48d8e2108548. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

