### PR TITLE
fix: untrack stray godoc_tool binary + gitignore all cmd/ binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /probe
 /server
 /eval
+/gen_llms
+/godoc_tool
+/audit_tokens
+/format_md_tables
 /dist/
 coverage.out
 coverage.internal.out


### PR DESCRIPTION
## What

A compiled **`godoc_tool`** binary (Mach-O executable) was accidentally committed in #22 — a `go build ./cmd/godoc_tool/` artifact left in the repo root and staged by `git add -A`.

- `git rm --cached godoc_tool` — removes the ~MB binary from tracking.
- `.gitignore`: adds `/gen_llms`, `/godoc_tool`, `/audit_tokens`, `/format_md_tables`. (`/libgen-mcp`, `/probe`, `/server`, `/eval` were already ignored, which is why only these four could leak.)

Now every `cmd/` build artifact is ignored, so this can't recur.

## Verification
- `git check-ignore` confirms all eight cmd binaries are ignored.
- No binaries remain tracked; `go build ./...` still passes.

## Summary by Sourcery

Stop tracking an accidentally committed godoc_tool binary and ensure all cmd build artifacts are ignored.

Bug Fixes:
- Remove the previously committed godoc_tool binary from version control.

Build:
- Extend .gitignore to exclude all cmd/ build output binaries such as gen_llms, godoc_tool, audit_tokens, and format_md_tables.

Chores:
- Clean up the repository by untracking stray compiled binaries from the root directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove accidentally committed `godoc_tool` binary and update `.gitignore` to ignore all `cmd/` build artifacts, preventing stray binaries from being tracked.

- **Bug Fixes**
  - Removed tracked `godoc_tool` Mach-O binary.
  - Added `/gen_llms`, `/godoc_tool`, `/audit_tokens`, `/format_md_tables` to `.gitignore` (remaining `cmd/` binaries).

<sup>Written for commit 04fb509f826cc9199f3011f51adf90d6e3851dad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

