### PR TITLE
chore(deploy): add fly.toml for the public HTTP deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
 
 [![GitHub Release](https://img.shields.io/github/v/release/jmrplens/libgen-mcp?style=flat&logo=github&label=Release)](https://github.com/jmrplens/libgen-mcp/releases/latest)
+[![Live on Fly.io](https://img.shields.io/badge/Live-Fly.io-8b5cf6?style=flat&logo=flydotio&logoColor=white)](https://libgen-mcp.fly.dev/health)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux%20%7C%20macOS-amd64%20%26%20arm64-lightgrey?style=flat&logo=windows-terminal&logoColor=white)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,46 @@
+# fly.toml — Fly.io deployment for libgen-mcp (public, no auth required)
+#
+# Deploy: fly deploy
+# Logs:   fly logs
+# Status: fly status
+# Health: curl https://<app-name>.fly.dev/health
+# MCP:    https://<app-name>.fly.dev/
+#
+# libgen-mcp needs NO credentials or token — Library Genesis is public. This is
+# an open streamable-HTTP endpoint. Because a hosted server cannot write to the
+# client's disk, HTTP mode puts the download tool in remote mode: it returns a
+# direct link (a resource_link) for the client to fetch, instead of saving a file.
+
+app = "libgen-mcp"
+primary_region = "cdg"
+
+kill_signal = "SIGTERM"
+kill_timeout = 10
+
+[build]
+  dockerfile = "Dockerfile"
+  [build.args]
+    VERSION = "1.2.0"
+
+# libgen-mcp takes a single --http <addr> flag (unlike gitlab-mcp-server's
+# --http/--http-addr split). Override the Dockerfile ENTRYPOINT args to serve
+# streamable HTTP on the internal port. --http implies remote-download mode.
+[experimental]
+  cmd = ["--http", "0.0.0.0:8080"]
+
+[env]
+  LIBGEN_MCP_LOG_LEVEL = "info"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/health"


### PR DESCRIPTION
## What

Adds the `fly.toml` used to deploy libgen-mcp as a public **streamable-HTTP** endpoint on Fly.io.

**Live:** https://libgen-mcp.fly.dev/ — open, **no auth** (Library Genesis needs no credentials). `/health` returns `200`.

### Notes
- CMD override `["--http", "0.0.0.0:8080"]` — libgen-mcp takes a single `--http <addr>` flag.
- In `--http` mode the `download` tool is in **remote mode**: it returns a link (a `resource_link`) instead of saving a file, since a hosted server can't write to the client's disk.
- Single machine, **scale-to-zero** (`auto_stop_machines = "stop"`, `min_machines_running = 0`) → cost ~pennies/month.
- `/health` HTTP check.

Verified live: `initialize` → `libgen-mcp 1.2.0`; `tools/list` → 3 tools with the remote-mode note on `download`; a live `search` returned 25 real results from `libgen.li`.

Redeploy: `fly deploy --remote-only --ha=false`.

No secrets in this file; the deploy token lives outside the repo.

## Summary by Sourcery

Add Fly.io configuration to deploy libgen-mcp as a public streamable HTTP endpoint with health checks and scale-to-zero settings.

Deployment:
- Introduce fly.toml to configure libgen-mcp Fly.io app, HTTP service, region, and Docker build settings.
- Configure the app to run in HTTP mode with remote download behavior, HTTPS enforcement, and automatic start/stop with zero minimum machines.
- Add HTTP health check on /health for monitoring the deployed service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fly.toml` to deploy `libgen-mcp` as a public, no-auth streamable HTTP endpoint on Fly.io with health checks and scale-to-zero. Adds a README badge linking to the live `/health` check.

- **New Features**
  - Runs `--http 0.0.0.0:8080`; exposes `/health` (README badge links to it).
  - `download` runs in remote mode and returns a `resource_link`.
  - Single machine; scale-to-zero; HTTPS enforced.
  - Build args/env: `VERSION=1.2.0`, region `cdg`, `LIBGEN_MCP_LOG_LEVEL=info`.

<sup>Written for commit feb520cafa6dfebeeb51bcdae0898232f246c91c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

