### PR TITLE
ci(release): deploy to Fly.io on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,3 +190,56 @@ jobs:
         run: |
           cosign sign --yes \
             docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
+
+  # Deploy the tagged release to the public Fly.io instance
+  # (https://libgen-mcp.fly.dev/). Skips silently when FLY_API_TOKEN is not
+  # configured, so a fork or a token-less setup never fails the release.
+  fly-deploy:
+    name: Fly.io Deploy
+    runs-on: ubuntu-latest
+    needs: [release, docker]
+    if: ${{ github.repository == 'jmrplens/libgen-mcp' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Check FLY_API_TOKEN
+        id: check
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          if [ -z "${FLY_API_TOKEN}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::FLY_API_TOKEN not set — skipping Fly.io deployment."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract version
+        if: steps.check.outputs.skip == 'false'
+        id: version
+        run: echo "version=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_OUTPUT"
+
+      - name: Install flyctl
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          curl -L https://fly.io/install.sh | sh
+          echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
+
+      - name: Deploy to Fly.io
+        if: steps.check.outputs.skip == 'false'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          fly deploy --remote-only \
+            --config fly.toml \
+            --build-arg VERSION=${{ steps.version.outputs.version }} \
+            --build-arg COMMIT=${{ github.sha }} \
+            --image-label v${{ steps.version.outputs.version }} \
+            --ha=false \
+            --strategy immediate
+
+      - name: Verify deployment health
+        if: steps.check.outputs.skip == 'false'
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: fly status --config fly.toml


### PR DESCRIPTION
## What

Adds a **`fly-deploy`** job to the release workflow so every tagged release also updates the public Fly.io instance at **https://libgen-mcp.fly.dev/** — mirroring `gitlab-mcp-server`.

- Runs after `release` + `docker` (`needs: [release, docker]`).
- `fly deploy --remote-only --config fly.toml` — rebuilds from `fly.toml`, stamps `VERSION`/`COMMIT`, single machine (`--ha=false`), `--strategy immediate`, then `fly status` to verify.
- **Skips silently** (with a `::warning::`) when the `FLY_API_TOKEN` secret is absent, so forks and token-less setups never fail the release. Guarded to `jmrplens/libgen-mcp`.

## Requires
- The `FLY_API_TOKEN` **Actions secret** must hold a valid Fly deploy token for the deploy step to run (otherwise the job skips). See the deploy note in the PR discussion.

## Verification
- `release.yml` parses as valid YAML; jobs are now `release`, `docker`, `fly-deploy`.
- `actions/checkout@v7` consistent with the other jobs.
- No secrets in the workflow; the token is referenced only via `secrets.FLY_API_TOKEN`.

## Summary by Sourcery

Add an automated Fly.io deployment step to the release workflow for tagged releases of the main repository.

CI:
- Introduce a fly-deploy job in the release GitHub Actions workflow that runs after release and docker jobs to deploy the tagged image to Fly.io.
- Ensure the Fly.io deployment job only runs for the main repository and skips gracefully with a warning when FLY_API_TOKEN is not configured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates deploying each tagged release to Fly.io, updating https://libgen-mcp.fly.dev. Adds a `fly-deploy` job that runs after `release` and `docker` and skips safely when secrets are missing.

- **New Features**
  - Deploys to Fly.io using `flyctl` (`--remote-only`, `--config fly.toml`), passes VERSION/COMMIT, uses single machine (`--ha=false`) with immediate strategy, then verifies with `fly status`.
  - Runs only for `jmrplens/libgen-mcp` after `release` and `docker`.
  - Skips with a warning when `FLY_API_TOKEN` is not set.

- **Migration**
  - Add a `FLY_API_TOKEN` GitHub secret with a valid Fly deploy token to enable deployments.

<sup>Written for commit b983d3ecc98fbf493d4fee823e539e31e953abfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

