### PR TITLE
docs: add Smithery badge + organize badges into two rows; add Smithery to JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,20 @@
 <p align="center">
 
 [![GitHub Release](https://img.shields.io/github/v/release/jmrplens/libgen-mcp?style=flat&logo=github&label=Release)](https://github.com/jmrplens/libgen-mcp/releases/latest)
-[![Live on Fly.io](https://img.shields.io/badge/Live-Fly.io-8b5cf6?style=flat&logo=flydotio&logoColor=white)](https://libgen-mcp.fly.dev/health)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux%20%7C%20macOS-amd64%20%26%20arm64-lightgrey?style=flat&logo=windows-terminal&logoColor=white)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=coverage)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
 [![Go Reference](https://pkg.go.dev/badge/github.com/jmrplens/libgen-mcp.svg)](https://pkg.go.dev/github.com/jmrplens/libgen-mcp)
+
+</p>
+
+<p align="center">
+
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-1f9cf0?style=flat&logo=cursor&logoColor=white)](https://cursor.directory/plugins/libgen-mcp)
 [![libgen-mcp MCP server](https://glama.ai/mcp/servers/jmrplens/libgen-mcp/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/libgen-mcp)
+[![smithery badge](https://smithery.ai/badge/jmrp/libgen-mcp)](https://smithery.ai/servers/jmrp/libgen-mcp)
+[![Live on Fly.io](https://img.shields.io/badge/Live-Fly.io-8b5cf6?style=flat&logo=flydotio&logoColor=white)](https://libgen-mcp.fly.dev/health)
 
 </p>
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -158,6 +158,7 @@ const jsonLd = JSON.stringify({
 				repositoryUrl,
 				"https://cursor.directory/plugins/libgen-mcp",
 				"https://glama.ai/mcp/servers/jmrplens/libgen-mcp",
+				"https://smithery.ai/servers/jmrp/libgen-mcp",
 				"https://registry.modelcontextprotocol.io/v0/servers?search=io.github.jmrplens/libgen-mcp",
 			],
 		},


### PR DESCRIPTION
## What

- **README badges** reorganized into two centered rows (the flat single row was getting crowded at 10 badges):
  - **Row 1 — project status:** Release, License, Platform, Quality Gate, Coverage, Go Reference.
  - **Row 2 — available on / live:** Cursor Directory, Glama, **Smithery** (new), Live on Fly.io.
  - All badges stay visible — kept out of a `<details>` dropdown on purpose, since hiding the directory/hosting badges would hurt discoverability (GEO).
- **New Smithery badge:** `smithery.ai/servers/jmrp/libgen-mcp`.
- **Astro JSON-LD:** added the Smithery listing URL to the `SoftwareApplication` `sameAs` set, next to Cursor, Glama and the MCP registry, so the structured metadata reflects the new listing.

## Verification
- markdownlint clean on README (repo config).
- `astro.config.mjs` unchanged by prettier (well-formatted); Docs Site build validates the config.

## Summary by Sourcery

Reorganize README badges into two centered rows and add Smithery as a new listing, updating site metadata to reference the Smithery server URL.

Enhancements:
- Include the Smithery server listing URL in the Astro JSON-LD sameAs array for the SoftwareApplication metadata.

Documentation:
- Restructure README badges into two centered rows separating project status and availability listings.
- Add Smithery badge and link to the libgen-mcp listing in the README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized README badges into two centered rows and added a Smithery badge linking to https://smithery.ai/servers/jmrp/libgen-mcp to improve readability and discoverability. Updated the docs site's JSON-LD to include the Smithery URL in SoftwareApplication sameAs.

<sup>Written for commit 7eb14244263bda2a498669ca73ccc5b9905a8dd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

