### PR TITLE
chore(lobehub): add LobeHub Marketplace manifest + publish tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,12 @@ jobs:
           git checkout main
           bash scripts/update-server-json-sha.sh dist/checksums.txt "${VERSION}"
           git add server.json
+          [ -f lhm.plugin.json ] && git add lhm.plugin.json
           if git diff --cached --quiet; then
-            echo "::notice::No server.json changes to commit"
+            echo "::notice::No manifest changes to commit"
             exit 0
           fi
-          git commit -m "chore: pin server.json for v${VERSION}"
+          git commit -m "chore: pin server.json + stamp lhm.plugin.json for v${VERSION}"
           git push origin main
 
   docker:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
         format-md-tables check-md-tables \
         godoc-audit godoc-check \
         gen-llms check-llms audit-tokens \
-        install-tools release-check check-server-json check-mcpb-manifest mcpb sonar clean help \
+        install-tools release-check check-server-json check-mcpb-manifest check-lhm-manifest \
+        mcpb publish-lobehub sonar clean help \
         build-linux-amd64 build-linux-arm64 build-darwin-amd64 \
         build-darwin-arm64 build-windows-amd64 build-windows-arm64
 
@@ -188,8 +189,34 @@ check-mcpb-manifest: ## Verify mcpb/manifest.json parses and matches the VERSION
 	fi; \
 	echo "mcpb/manifest.json version matches VERSION ($$VF)"
 
+check-lhm-manifest: ## Verify lhm.plugin.json parses and matches the VERSION file
+	@jq empty lhm.plugin.json && echo "lhm.plugin.json: valid JSON"
+	@LV=$$(jq -r '.version' lhm.plugin.json); VF=$$(cat VERSION | tr -d '[:space:]'); \
+	if [ "$$LV" != "$$VF" ]; then \
+		echo "FAIL: lhm.plugin.json version ($$LV) != VERSION ($$VF)"; exit 1; \
+	fi; \
+	echo "lhm.plugin.json version matches VERSION ($$VF)"
+
 mcpb: ## Build the .mcpb Claude Desktop bundle (needs GoReleaser artifacts in dist/)
 	bash scripts/build-mcpb.sh $(VERSION)
+
+## publish-lobehub: publish the current version to the LobeHub Marketplace.
+## Reads lhm.plugin.json (version kept in sync by scripts/update-server-json-sha.sh
+## on each release) and posts it via the @lobehub/market-cli. Requires a one-time
+## interactive `lhm login` + `lhm github connect` first — LobeHub has no
+## non-interactive publish path, so this cannot run in CI.
+publish-lobehub:
+	@command -v node >/dev/null || { echo "ERROR: Node.js >= 22 is required"; exit 1; }
+	@NODE_MAJOR=$$(node -v | sed 's/^v\([0-9]*\).*/\1/'); \
+	if [ "$$NODE_MAJOR" -lt 22 ]; then echo "ERROR: Node.js >= 22 is required (found $$(node -v))"; exit 1; fi
+	@command -v jq >/dev/null || { echo "ERROR: jq is required"; exit 1; }
+	@VER=$$(tr -d '[:space:]' < VERSION); \
+	MVER=$$(jq -r '.version' lhm.plugin.json); \
+	if [ "$$VER" != "$$MVER" ]; then \
+		echo "ERROR: VERSION ($$VER) != lhm.plugin.json version ($$MVER); run a release stamp first"; exit 1; \
+	fi; \
+	echo "Publishing jmrplens-libgen-mcp v$$VER to LobeHub..."; \
+	npx -y @lobehub/market-cli plugin publish --dir "$(CURDIR)"
 
 sonar: ## Run the SonarCloud scanner locally (needs sonar-scanner + SONAR_TOKEN)
 	@command -v sonar-scanner >/dev/null || { echo "sonar-scanner not installed"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-1f9cf0?style=flat&logo=cursor&logoColor=white)](https://cursor.directory/plugins/libgen-mcp)
 [![libgen-mcp MCP server](https://glama.ai/mcp/servers/jmrplens/libgen-mcp/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/libgen-mcp)
 [![smithery badge](https://smithery.ai/badge/jmrp/libgen-mcp)](https://smithery.ai/servers/jmrp/libgen-mcp)
+[![MCP Badge](https://lobehub.com/badge/mcp/jmrplens-libgen-mcp)](https://lobehub.com/mcp/jmrplens-libgen-mcp)
 [![Live on Fly.io](https://img.shields.io/badge/Live-Fly.io-8b5cf6?style=flat&logo=flydotio&logoColor=white)](https://libgen-mcp.fly.dev/health)
 
 </p>

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -1,0 +1,20 @@
+{
+  "identifier": "jmrplens-libgen-mcp",
+  "name": "Library Genesis MCP Server",
+  "version": "1.2.0",
+  "description": "Model Context Protocol server that lets your AI assistant search and download books, research papers, comics, magazines and standards from Library Genesis. One static Go binary; stdio or streamable-HTTP transport; multi-source downloads with automatic mirror discovery and failover. No account, API key or token required.",
+  "author": "José M. Requena Plens",
+  "authorUrl": "https://github.com/jmrplens",
+  "tags": [
+    "library-genesis",
+    "libgen",
+    "books",
+    "research-papers",
+    "download",
+    "mcp",
+    "go",
+    "self-hosted",
+    "search",
+    "sci-hub"
+  ]
+}

--- a/scripts/update-server-json-sha.sh
+++ b/scripts/update-server-json-sha.sh
@@ -59,3 +59,14 @@ done <"$CHECKSUMS_FILE"
 
 total=$(jq '.packages | length' "$SERVER_JSON")
 echo "Updated $updated of $total package entries"
+
+# 5. Stamp the LobeHub Marketplace manifest version (if present). The actual
+# publish to LobeHub is a manual step (`make publish-lobehub`) — the CLI has no
+# non-interactive auth — but the version is kept in sync here on every release.
+LHM_JSON="lhm.plugin.json"
+if [[ -f "$LHM_JSON" ]]; then
+  jq --arg v "$VERSION" '.version = $v' "$LHM_JSON" >tmp.$$.json && mv tmp.$$.json "$LHM_JSON"
+  echo "$LHM_JSON version set to $VERSION"
+else
+  echo "NOTE: $LHM_JSON not found, skipping LobeHub manifest update"
+fi


### PR DESCRIPTION
## What

Mirrors the sibling `gitlab-mcp-server` LobeHub setup for libgen-mcp:

- **`lhm.plugin.json`** — the LobeHub Marketplace manifest (identifier `jmrplens-libgen-mcp`), stamped to the current `VERSION` (1.2.0).
- **`scripts/update-server-json-sha.sh`** — now also stamps `lhm.plugin.json`'s `version` on each release, so the manifest never lags behind `VERSION`.
- **`release.yml`** — commits `lhm.plugin.json` back alongside `server.json` after a release.
- **`Makefile`**:
  - `make publish-lobehub` — publishes the current version via `@lobehub/market-cli plugin publish` (needs Node ≥ 22 + a **one-time interactive `lhm login` + `lhm github connect`**; LobeHub has no non-interactive publish path, so this can't run in CI).
  - `make check-lhm-manifest` — verifies the manifest parses and its version matches `VERSION`.

## Notes
- Publishing to LobeHub is a **manual** step (browser OIDC auth) — the release only keeps the manifest version in sync.
- Verified: `make check-lhm-manifest` passes; the stamp step updates the manifest; `make publish-lobehub` resolves to the correct CLI invocation.

## Summary by Sourcery

Add LobeHub Marketplace support and keep its manifest version in sync with releases.

New Features:
- Introduce a LobeHub Marketplace manifest file for the project.
- Add a make target to publish the current version to the LobeHub Marketplace.

Enhancements:
- Add a make target to validate the LobeHub manifest version against the VERSION file.
- Extend the release stamping script to update the LobeHub manifest version when present.
- Update the release workflow to commit the LobeHub manifest alongside server.json when manifests change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a LobeHub Marketplace manifest and a lightweight, manual publish flow. Keeps the manifest in sync on release and surfaces the listing in the README.

- **New Features**
  - Added `lhm.plugin.json` (id `jmrplens-libgen-mcp`), version stamped from `VERSION`.
  - Release script stamps the manifest on each release, and workflow commits it with `server.json`.
  - New Makefile targets: `publish-lobehub` (uses `@lobehub/market-cli`) and `check-lhm-manifest`.
  - README: added LobeHub Marketplace badge linking to the listing.

- **Migration**
  - One-time setup: run `lhm login` and `lhm github connect`, then use `make publish-lobehub`.
  - Requires Node ≥ 22 and `jq`.

<sup>Written for commit c8d0f27881ed845f7eca21f8a199a69f332f72dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

