### PR TITLE
docs: trim README config, add Docker recipes, and refresh positioning metadata

### DIFF
--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "./plugin.schema.json",
   "name": "libgen-mcp",
   "version": "1.2.0",
-  "description": "MCP server in Go to search, download and read books, papers, comics and more from Library Genesis — four focused tools (search, get_details, download, read), one static binary, no account required.",
+  "description": "MCP server in Go to search, download and read books, papers, comics and more from Library Genesis — plus opt-in open-access discovery (arXiv, Crossref, OpenLibrary). Four focused tools (search, get_details, download, read), one static binary, no account required.",
   "author": {
     "name": "José Manuel Requena Plens",
     "url": "https://github.com/jmrplens"
@@ -26,7 +26,12 @@
     "books",
     "ebooks",
     "research-papers",
-    "doi"
+    "doi",
+    "read",
+    "open-access",
+    "arxiv",
+    "pdf",
+    "epub"
   ],
   "mcpServers": "./mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -206,43 +206,47 @@ Alongside the four tools, the server registers four MCP **prompts** — reusable
 
 ## Configuration
 
-**It works out of the box — zero configuration, no account.** Every variable below is optional. Common setups (add these as `env` entries in your MCP client config, or `-e NAME=value` with Docker):
+**It works out of the box — zero configuration, no account.** Every variable is optional. Only three settings change what the server _does_ — everything else is a tuning knob that already works by default. Add these as `env` entries in your MCP client config, or as `-e NAME=value` with Docker:
 
 - **Enable open-access articles (Unpaywall):** `LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com` — disabled by default; the Unpaywall API needs a contact email. Without it, DOIs still resolve via Sci-Hub.
-- **Choose where files land:** `LIBGEN_MCP_DOWNLOAD_DIR=/path/to/downloads` (default `~/Downloads`; the `download` tool's `path` argument overrides per call).
-- **Pin one mirror** (skip auto-discovery): `LIBGEN_MIRROR=https://libgen.li`.
-- **Restrict sources** (e.g. books only, no article sources): `LIBGEN_MCP_SOURCES=libgen,randombook`.
-- **Cap download size / concurrency:** `LIBGEN_MCP_MAX_DOWNLOAD_BYTES=1073741824` (1 GiB), `LIBGEN_MCP_MAX_CONCURRENT_DOWNLOADS=1`.
+- **Discover open access by default:** `LIBGEN_MCP_OPEN_ACCESS=true` — makes `search`'s open-access discovery (arXiv/Crossref/OpenLibrary) on for every call; otherwise a call opts in per request with `include_open_access: true`.
+- **Always return a link instead of saving:** `LIBGEN_MCP_REMOTE_DOWNLOADS=true` — makes `download` return a `resource_link` instead of writing a file, for a hosted or remote stdio deployment whose disk the client can't reach (`--http` implies it).
 
-Full reference and tuning knobs (rate limits, retry/stall schedules, Sci-Hub hosts) are in the **[configuration guide](https://jmrplens.github.io/libgen-mcp/configuration/)**.
+Every other setting — download location, mirror pinning, source allow-list, rate limits, retry/stall schedules, Sci-Hub hosts, `read` limits, cache sizing, the enrichment kill-switch — is a tuning knob with a sensible default. See the full **[configuration reference](https://jmrplens.github.io/libgen-mcp/configuration/)** (also in [docs/configuration.md](docs/configuration.md)).
 
-### Environment variables
+## Run with Docker
 
-Every variable is optional; an empty or unset value uses the default. A present-but-invalid numeric value is an error rather than a silent fallback.
+The published image runs on **stdio by default** — the correct mode for MCP clients. The `-e` flags above combine freely; see the [configuration reference](https://jmrplens.github.io/libgen-mcp/configuration/) for the full list.
 
-| Variable                                | Default                                                  | Description                                                                                                                                                                                                                                                                                                                                             |
-| --------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `LIBGEN_MIRROR`                         | _(auto-discovery)_                                       | Force a specific mirror, e.g. `https://libgen.li`. Skips auto-discovery. Must be an `http(s)` URL.                                                                                                                                                                                                                                                      |
-| `LIBGEN_MCP_DOWNLOAD_DIR`               | `~/Downloads`                                            | Default destination directory for `download` (created if missing, checked for writability).                                                                                                                                                                                                                                                             |
-| `LIBGEN_MCP_TIMEOUT`                    | `30s`                                                    | Per-request HTTP timeout (Go duration, e.g. `45s`, `1m`). Range `(0, 10m]`.                                                                                                                                                                                                                                                                             |
-| `LIBGEN_MCP_LOG_LEVEL`                  | `info`                                                   | Log level: `debug`, `info`, `warn`, or `error`.                                                                                                                                                                                                                                                                                                         |
-| `LIBGEN_MCP_RATE_RPS`                   | `1`                                                      | Allowed outbound requests per second. Range `(0, 20]`.                                                                                                                                                                                                                                                                                                  |
-| `LIBGEN_MCP_RATE_BURST`                 | `1`                                                      | Maximum rate-limiter burst. Range `[1, 100]`.                                                                                                                                                                                                                                                                                                           |
-| `LIBGEN_MCP_MAX_DOWNLOAD_BYTES`         | `0` _(no limit)_                                         | Maximum download size in bytes. Range `[0, 50 GiB]`; `0` disables the ceiling.                                                                                                                                                                                                                                                                          |
-| `LIBGEN_MCP_MAX_CONCURRENT_DOWNLOADS`   | `2`                                                      | Simultaneous downloads allowed. Range `[1, 16]`.                                                                                                                                                                                                                                                                                                        |
-| `LIBGEN_MCP_RETRY_ATTEMPTS`             | `3`                                                      | Passes over the mirror list for page requests (search / details / link resolution), with backoff; does not govern file downloads. Range `[1, 10]`.                                                                                                                                                                                                      |
-| `LIBGEN_MCP_DOWNLOAD_START_RETRY_WAITS` | `5s,5s,5s,10s,10s,10s,15s`                               | Staged waits between attempts to get a download to _begin_ (resolve / connect / first byte). `N` waits = `N+1` attempts (~60 s by default). Comma-separated Go durations; each in `(0, 10m]`; at most 20.                                                                                                                                               |
-| `LIBGEN_MCP_DOWNLOAD_STALL_TIMEOUT`     | `60s`                                                    | Progress-resetting stall window while streaming: a download is cut only if _no_ bytes arrive for this long, so a slow-but-progressing transfer is never killed. Range `(0, 1h]`.                                                                                                                                                                        |
-| `LIBGEN_MCP_UNPAYWALL_EMAIL`            | _(unset — unpaywall disabled)_                           | Contact email for the Unpaywall API (DOI lookups). The API rejects requests without one, so an unset value disables the `unpaywall` source entirely (and hides it from the download tool's `source` schema). Set your own address to enable it.                                                                                                         |
-| `LIBGEN_MCP_SCIHUB_HOSTS`               | `sci-hub.ee,sci-hub.se,sci-hub.st,sci-hub.ru,sci-hub.wf` | Ordered, comma-separated Sci-Hub mirror hosts (bare host, no scheme). Tried in order until one serves.                                                                                                                                                                                                                                                  |
-| `LIBGEN_MCP_SOURCES`                    | _(all enabled)_                                          | Comma-separated allow-list of download sources: `unpaywall`, `scihub`, `libgen`, `randombook`.                                                                                                                                                                                                                                                          |
-| `LIBGEN_MCP_REMOTE_DOWNLOADS`           | `false`                                                  | Force `download` to always return a link (a `resource_link` + `resolved` object) instead of saving a file — the same behavior `--http` uses. Set it for a **hosted stdio** deployment (e.g. behind `mcp-proxy` on a catalog) whose disk the client can't reach. `--http` implies it; this covers the stdio-hosted case. Accepts `1`/`true`/`0`/`false`. |
-| `LIBGEN_MCP_READ_MAX_CHARS`             | `6000`                                                   | Max characters `read` returns per call when a call omits `max_chars`. Range `[500, 200000]`.                                                                                                                                                                                                                                                            |
-| `LIBGEN_MCP_READ_DEFAULT_PAGES`         | `5`                                                      | Default max PDF pages per `read` call when a call omits `max_pages`. Range `[1, 200]`.                                                                                                                                                                                                                                                                  |
-| `LIBGEN_MCP_READ_CACHE_BYTES`           | `536870912` (512 MiB)                                    | Total-size cap of the `read` tool's server-side temp-file cache; least-recently-used files are evicted past it. Range `[1 MiB, 50 GiB]`.                                                                                                                                                                                                                |
-| `LIBGEN_MCP_READ_CACHE_TTL`             | `10m`                                                    | How long an unreferenced `read` temp file lingers before eviction. Go duration, range `[1s, 24h]`.                                                                                                                                                                                                                                                      |
-| `LIBGEN_MCP_ENRICH`                     | `true`                                                   | Deployment kill-switch for `get_details`' opt-in `enrich` metadata (Crossref/OpenLibrary). Set `false` to forbid enrichment entirely, regardless of the per-call `enrich` flag. Accepts `1`/`true`/`0`/`false`.                                                                                                                                         |
-| `LIBGEN_MCP_OPEN_ACCESS`                | `false`                                                  | Deployment default for `search`'s opt-in open-access discovery (arXiv/Crossref/OpenLibrary). Default `false` means a call only federates OA when it passes `include_open_access: true`; set `true` to make OA on by default while each call can still opt out with `include_open_access: false`. Accepts `1`/`true`/`0`/`false`.                        |
+Plain (stdio, zero config):
+
+```bash
+docker run -i --rm ghcr.io/jmrplens/libgen-mcp:latest
+```
+
+Enable open-access articles via Unpaywall:
+
+```bash
+docker run -i --rm -e LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com ghcr.io/jmrplens/libgen-mcp:latest
+```
+
+Turn on open-access discovery by default:
+
+```bash
+docker run -i --rm -e LIBGEN_MCP_OPEN_ACCESS=true ghcr.io/jmrplens/libgen-mcp:latest
+```
+
+Save downloads to a host folder (mount a volume, point the download dir at it):
+
+```bash
+docker run -i --rm -e LIBGEN_MCP_DOWNLOAD_DIR=/downloads -v "$HOME/Downloads:/downloads" ghcr.io/jmrplens/libgen-mcp:latest
+```
+
+Serve streamable HTTP instead of stdio:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/jmrplens/libgen-mcp:latest --http :8080
+```
 
 ## Multi-source downloads
 

--- a/lhm.plugin.json
+++ b/lhm.plugin.json
@@ -2,7 +2,7 @@
   "identifier": "jmrplens-libgen-mcp",
   "name": "Library Genesis MCP Server",
   "version": "1.2.0",
-  "description": "Model Context Protocol server that lets your AI assistant search and download books, research papers, comics, magazines and standards from Library Genesis. One static Go binary; stdio or streamable-HTTP transport; multi-source downloads with automatic mirror discovery and failover. No account, API key or token required.",
+  "description": "Model Context Protocol server that lets your AI assistant search, download and read books, research papers, comics, magazines and standards from Library Genesis — and, opt-in, discover open-access literature from arXiv, Crossref and OpenLibrary. Four focused tools (search, get_details, download, read); one static Go binary; stdio or streamable-HTTP transport; multi-source downloads with automatic mirror discovery and failover. No account, API key or token required.",
   "author": "José M. Requena Plens",
   "authorUrl": "https://github.com/jmrplens",
   "tags": [
@@ -15,6 +15,12 @@
     "go",
     "self-hosted",
     "search",
-    "sci-hub"
+    "sci-hub",
+    "read",
+    "open-access",
+    "arxiv",
+    "pdf",
+    "epub",
+    "unpaywall"
   ]
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.jmrplens/libgen-mcp",
   "title": "Library Genesis MCP Server",
-  "description": "Search Library Genesis, fetch metadata and download options, and download books and papers.",
+  "description": "Search Library Genesis and open-access sources, get details, download, and read books and papers.",
   "version": "1.2.0",
   "repository": {
     "url": "https://github.com/jmrplens/libgen-mcp",

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -78,7 +78,25 @@ La instalación recomendada es el **binario precompilado**: un único ejecutable
     	docker pull ghcr.io/jmrplens/libgen-mcp:latest
     	```
 
-    	La imagen se ejecuta en stdio por defecto; para el transporte HTTP en streaming pasa `--http 0.0.0.0:8080` (y publica el puerto). En modo HTTP se expone además un endpoint `GET /health`:
+    	La imagen se ejecuta en **stdio por defecto** — el modo correcto para clientes MCP, así que `docker run -i --rm ghcr.io/jmrplens/libgen-mcp:latest` (como lo usan los botones de un clic y `claude mcp add`) funciona sin configuración. Monta un volumen con permisos de escritura para las descargas y apunta `LIBGEN_MCP_DOWNLOAD_DIR` a él; el contenedor se ejecuta como usuario sin privilegios, por lo que el directorio del host debe ser escribible por el UID `10001`:
+
+    	```bash
+    	docker run -i --rm \
+    	  -v "$HOME/Downloads:/downloads" \
+    	  -e LIBGEN_MCP_DOWNLOAD_DIR=/downloads \
+    	  ghcr.io/jmrplens/libgen-mcp:latest
+    	```
+
+    	Pasa las variables que cambian el comportamiento de la misma forma — se combinan libremente. Activa los artículos de acceso abierto mediante Unpaywall, o habilita el descubrimiento de acceso abierto por defecto (consulta la [referencia de configuración](/libgen-mcp/es/configuration/) para la lista completa):
+
+    	```bash
+    	docker run -i --rm \
+    	  -e LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com \
+    	  -e LIBGEN_MCP_OPEN_ACCESS=true \
+    	  ghcr.io/jmrplens/libgen-mcp:latest
+    	```
+
+    	Para el transporte HTTP en streaming pasa `--http 0.0.0.0:8080` y publica el puerto; en modo HTTP se expone además un endpoint `GET /health`:
 
     	```bash
     	docker run --rm -p 8080:8080 \
@@ -86,8 +104,6 @@ La instalación recomendada es el **binario precompilado**: un único ejecutable
     	  -e LIBGEN_MCP_DOWNLOAD_DIR=/downloads \
     	  ghcr.io/jmrplens/libgen-mcp:latest --http 0.0.0.0:8080
     	```
-
-    	Monta un volumen con permisos de escritura para las descargas y apunta `LIBGEN_MCP_DOWNLOAD_DIR` a él; el contenedor se ejecuta como usuario sin privilegios, por lo que el directorio del host debe ser escribible por el UID `10001`.
     </TabItem>
     <TabItem label="go install">
     	Si ya tienes Go 1.26 o posterior y prefieres compilar desde el código fuente:

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -87,6 +87,15 @@ The recommended install is the **prebuilt binary**: a single static executable w
     	  ghcr.io/jmrplens/libgen-mcp:latest
     	```
 
+    	Pass behavior-changing flags the same way — they combine freely. Enable open-access articles via Unpaywall, or turn on open-access discovery by default (see the [configuration reference](/libgen-mcp/configuration/) for the full list):
+
+    	```bash
+    	docker run -i --rm \
+    	  -e LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com \
+    	  -e LIBGEN_MCP_OPEN_ACCESS=true \
+    	  ghcr.io/jmrplens/libgen-mcp:latest
+    	```
+
     	For the streamable HTTP transport instead, pass `--http 0.0.0.0:8080` and publish the port; HTTP mode also exposes a `GET /health` readiness endpoint:
 
     	```bash


### PR DESCRIPTION
## Summary

Reduces README friction, adds copy-paste Docker recipes, refreshes the registry/positioning metadata to reflect the four-tool + open-access surface, and audits the docs.

## README configuration — less noise

The README's Configuration section showed a 20+ row environment-variable table that buried users in options that already work by default. It now shows only the three settings that actually change what the server does:

- `LIBGEN_MCP_UNPAYWALL_EMAIL` — enables the Unpaywall open-access article source.
- `LIBGEN_MCP_OPEN_ACCESS` — makes `search`'s open-access discovery on by default.
- `LIBGEN_MCP_REMOTE_DOWNLOADS` — makes `download` return a link instead of saving a file.

Everything else (download location, mirror pinning, source allow-list, rate limits, retry/stall schedules, Sci-Hub hosts, `read` limits, cache sizing, the enrichment kill-switch) is a tuning knob with a sensible default and now lives only in the full reference — `docs/configuration.md` and the configuration page on the site, which already document all 20 variables in English and Spanish. Nothing was removed from the full reference.

## Copy-paste Docker recipes

Adds a `Run with Docker` section with ready-to-run `docker run` commands: plain (zero config), with Unpaywall, with open-access on by default, saving downloads to a host folder (volume mount), and the HTTP/remote server. Mirrored into the site's getting-started page (EN + ES).

## Positioning / registry metadata

- **server.json** (MCP Registry): description now covers the four tools + open-access.
- **GitHub repo**: description and topics updated to four tools, `read`, and open-access discovery.
- **lhm.plugin.json** (LobeHub) and **.plugin/plugin.json**: descriptions and keywords updated to the four-tool + open-access surface (version fields left for the release tooling).

## Docs audit

Verified tool count is consistently "four tools" everywhere user-facing (no stale "three tools" outside historical planning docs), token-footprint figure consistent, README relative links resolve, EN/ES site parity holds, tracked markdown clean, and the site builds with all internal links valid.

## Note — branding images (not changed)

The banner/OG/social PNGs (`assets/banner.png`, `og.png`, `social.png`) still read "Search & download from Library Genesis" and don't mention reading or open-access. They're not inaccurate, but they understate the current positioning. There is no image source in the repo to regenerate them from, so updating them is left to a design pass.

## Quality

`go build ./...` green (no code changed); llms.txt, server.json, and mcpb manifest checks pass; tracked markdown clean; site builds EN+ES with i18n parity and prettier clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed README config to spotlight the three behavior‑changing env vars and added copy‑paste Docker run recipes (stdio, Unpaywall, open‑access default, volume mount, HTTP). Updated registry/plugin metadata (`server.json`, `.plugin/plugin.json`, `lhm.plugin.json`) to reflect four tools + open‑access, mirrored Docker steps on the site (EN/ES), and audited docs for consistent messaging and valid links; no code changes.

<sup>Written for commit fbcd9c31bd1af223e4a2b5c32d764de4381db42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

