### PR TITLE
test: cover the temp-dir failure path and drop dead clamp code

### DIFF
--- a/internal/discovery/arxiv.go
+++ b/internal/discovery/arxiv.go
@@ -20,7 +20,6 @@ var arxivBase = "https://export.arxiv.org"
 // results, defaulting to arxivDefaultLimit when the caller passes a non-positive
 // value.
 const (
-	arxivMinLimit     = 1
 	arxivMaxLimit     = 50
 	arxivDefaultLimit = 10
 )
@@ -87,8 +86,6 @@ func clampArxivLimit(limit int) int {
 	switch {
 	case limit <= 0:
 		return arxivDefaultLimit
-	case limit < arxivMinLimit:
-		return arxivMinLimit
 	case limit > arxivMaxLimit:
 		return arxivMaxLimit
 	default:

--- a/internal/discovery/crossref.go
+++ b/internal/discovery/crossref.go
@@ -21,7 +21,6 @@ var crossrefBase = "https://api.crossref.org"
 // rows, defaulting to crossrefDefaultLimit when the caller passes a non-positive
 // value.
 const (
-	crossrefMinLimit     = 1
 	crossrefMaxLimit     = 50
 	crossrefDefaultLimit = 10
 )
@@ -103,8 +102,6 @@ func clampCrossrefLimit(limit int) int {
 	switch {
 	case limit <= 0:
 		return crossrefDefaultLimit
-	case limit < crossrefMinLimit:
-		return crossrefMinLimit
 	case limit > crossrefMaxLimit:
 		return crossrefMaxLimit
 	default:

--- a/internal/discovery/openlibrary.go
+++ b/internal/discovery/openlibrary.go
@@ -20,7 +20,6 @@ var openLibraryBase = "https://openlibrary.org"
 // most this many docs, defaulting to openLibraryDefaultLimit when the caller passes
 // a non-positive value.
 const (
-	openLibraryMinLimit     = 1
 	openLibraryMaxLimit     = 50
 	openLibraryDefaultLimit = 10
 )
@@ -97,8 +96,6 @@ func clampOpenLibraryLimit(limit int) int {
 	switch {
 	case limit <= 0:
 		return openLibraryDefaultLimit
-	case limit < openLibraryMinLimit:
-		return openLibraryMinLimit
 	case limit > openLibraryMaxLimit:
 		return openLibraryMaxLimit
 	default:

--- a/internal/libgen/fetchtemp_test.go
+++ b/internal/libgen/fetchtemp_test.go
@@ -198,11 +198,13 @@ func TestFetchToTemp_TempDirCreateError(t *testing.T) {
 
 	c := newFetchTempClient(staticMirrors{})
 	path, release, err := c.FetchToTemp(context.Background(), Item{MD5: "0123456789abcdef0123456789abcdef"})
-	// Assert it is specifically the mkdir failure, so a future download/cache error
-	// occurring before the MkdirTemp call cannot masquerade as this coverage.
+	// Assert it is specifically the temp-dir creation failure (os.MkdirTemp fails to
+	// stat the missing TMPDIR base), so a future download/cache error occurring
+	// before the MkdirTemp call cannot masquerade as this coverage. The path in the
+	// error is the unwritable TMPDIR base we set above.
 	var pathErr *os.PathError
-	if !errors.As(err, &pathErr) || pathErr.Op != "mkdir" {
-		t.Fatalf("want an *os.PathError with Op=mkdir (temp-dir creation), got %v", err)
+	if !errors.As(err, &pathErr) || !strings.Contains(pathErr.Path, "no/such/dir") {
+		t.Fatalf("want an *os.PathError from MkdirTemp under the missing TMPDIR, got %v", err)
 	}
 	if path != "" {
 		t.Errorf("path = %q, want empty on error", path)

--- a/internal/libgen/fetchtemp_test.go
+++ b/internal/libgen/fetchtemp_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -182,4 +183,28 @@ func TestFetchToTemp_ConcurrentLoserDiscardsDownload(t *testing.T) {
 	if err != nil || string(data) != string(payload) {
 		t.Errorf("cached file content mismatch (err=%v)", err)
 	}
+}
+
+// TestFetchToTemp_TempDirCreateError verifies that when the per-fetch temp
+// directory cannot be created (an unwritable TMPDIR), FetchToTemp surfaces the
+// os.MkdirTemp error and returns a non-nil no-op release, rather than panicking
+// or proceeding without a directory. The identifier is a cache miss so the fast
+// path does not short-circuit before the MkdirTemp call.
+func TestFetchToTemp_TempDirCreateError(t *testing.T) {
+	// Point TMPDIR at a path that does not exist and cannot be created under, so
+	// os.MkdirTemp("", …) fails deterministically.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "no", "such", "dir"))
+
+	c := newFetchTempClient(staticMirrors{})
+	path, release, err := c.FetchToTemp(context.Background(), Item{MD5: "0123456789abcdef0123456789abcdef"})
+	if err == nil {
+		t.Fatal("FetchToTemp should fail when the temp directory cannot be created")
+	}
+	if path != "" {
+		t.Errorf("path = %q, want empty on error", path)
+	}
+	if release == nil {
+		t.Fatal("release must be non-nil even on error")
+	}
+	release() // must be safe to call
 }

--- a/internal/libgen/fetchtemp_test.go
+++ b/internal/libgen/fetchtemp_test.go
@@ -2,6 +2,7 @@ package libgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -197,8 +198,11 @@ func TestFetchToTemp_TempDirCreateError(t *testing.T) {
 
 	c := newFetchTempClient(staticMirrors{})
 	path, release, err := c.FetchToTemp(context.Background(), Item{MD5: "0123456789abcdef0123456789abcdef"})
-	if err == nil {
-		t.Fatal("FetchToTemp should fail when the temp directory cannot be created")
+	// Assert it is specifically the mkdir failure, so a future download/cache error
+	// occurring before the MkdirTemp call cannot masquerade as this coverage.
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) || pathErr.Op != "mkdir" {
+		t.Fatalf("want an *os.PathError with Op=mkdir (temp-dir creation), got %v", err)
 	}
 	if path != "" {
 		t.Errorf("path = %q, want empty on error", path)


### PR DESCRIPTION
## Summary

Squeezes the last reachable coverage out of the tree (SonarCloud was at 99.5%, 17 uncovered lines). Two genuine gains; the rest are documented as unreachable rather than papered over.

- **`internal/libgen/fetchtemp.go` → 100%**: added a test that forces `os.MkdirTemp` to fail (an unwritable `TMPDIR` on a cache miss), covering `FetchToTemp`'s temp-dir-creation error path.
- **`internal/discovery` → 100%**: the three limit clamps had a `case limit < minLimit` arm that was dead code — `minLimit` is `1`, so the preceding `case limit <= 0` already catches everything below it. Removed the dead arm and the now-unused `*MinLimit` constant in `arxiv.go`, `crossref.go`, and `openlibrary.go`. Behavior is identical (a non-positive limit still yields the default).

## Left uncovered (genuinely unreachable, not gamed)

The remaining lines cannot be covered without bypassing a dependency or changing production code purely for coverage, so they're left alone: the elicit helpers' type-assertion guards (the go-sdk validates the elicitation content against the requested schema, so a malformed accept is rejected upstream and never reaches the guard), deferred `recover()` panic bodies, a `json.Marshal` error branch on a plain struct that cannot fail, defensive dead returns after loops that always return, an empty no-op release body, and the non-Darwin `diskspace_other.go` (not exercised on the CI platform).

## Quality

`go test ./...` green; `-race` clean; `golangci-lint` clean; `make cover-check` 99.6%; godoc audit clean; no behavior change.

## Summary by Sourcery

Improve test coverage for temporary directory error handling and remove redundant limit-clamping code in discovery clients.

Enhancements:
- Remove unreachable minimum-limit branches and associated constants from arXiv, Crossref, and OpenLibrary discovery limit clamping without changing behavior.

Tests:
- Add a test ensuring FetchToTemp correctly surfaces temp-directory creation failures and returns a safe no-op release function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves test coverage and removes dead code without changing behavior. Adds a test in `internal/libgen` that forces `os.MkdirTemp` to fail, asserts an `*os.PathError` from `MkdirTemp` whose path includes the missing `TMPDIR` base, and ensures `FetchToTemp` returns a non-nil no-op release; removes unreachable below-minimum branches and unused `*MinLimit` constants in `internal/discovery` (`arxiv`, `crossref`, `openlibrary`).

<sup>Written for commit 0ff627dc7b06fe6659452170c05d7ec2af28c565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search limit handling so zero or negative limits use the provider’s default result count across arXiv, Crossref, and Open Library.
  * Preserved maximum limit safeguards and support for valid positive limits.

* **Tests**
  * Added coverage for failures when temporary fetch directories cannot be created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->