### PR TITLE
fix: restore randombook downloads and diagnose unusable mirrors

### DIFF
--- a/internal/libgen/source_randombook.go
+++ b/internal/libgen/source_randombook.go
@@ -236,11 +236,10 @@ func (s randombookSource) resolveViaDownloadAPI(ctx context.Context, mirror, id 
 	base := normalizeMirrorBase(mirror)
 	endpoint := base + randombookDownloadPath + url.QueryEscape(id)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpoint, http.NoBody)
+	req, err := s.newRequest(ctx, http.MethodHead, endpoint)
 	if err != nil {
 		return "", fmt.Errorf("randombook: building download probe for %q: %w", base, err)
 	}
-	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := s.client().Do(req)
 	if err != nil {
@@ -271,11 +270,10 @@ func (s randombookSource) resolveViaMirror(ctx context.Context, mirror, md5 stri
 	base := normalizeMirrorBase(mirror)
 	endpoint := base + "/ads.php?md5=" + url.QueryEscape(md5)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
+	req, err := s.newRequest(ctx, http.MethodGet, endpoint)
 	if err != nil {
 		return "", fmt.Errorf("randombook: building ads request for %q: %w", base, err)
 	}
-	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := s.client().Do(req)
 	if err != nil {
@@ -304,11 +302,10 @@ func (s randombookSource) resolveViaMirror(ctx context.Context, mirror, md5 stri
 // or non-200 status is returned as-is; a decode failure is wrapped in
 // ErrLayoutChanged since the private API could have changed shape.
 func (s randombookSource) getJSON(ctx context.Context, endpoint string, out any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
+	req, err := s.newRequest(ctx, http.MethodGet, endpoint)
 	if err != nil {
 		return fmt.Errorf("randombook: building request: %w", err)
 	}
-	req.Header.Set("User-Agent", userAgent)
 
 	resp, err := s.client().Do(req)
 	if err != nil {
@@ -323,6 +320,18 @@ func (s randombookSource) getJSON(ctx context.Context, endpoint string, out any)
 		return fmt.Errorf("%w: randombook: decoding %q: %w", ErrLayoutChanged, endpoint, decErr)
 	}
 	return nil
+}
+
+// newRequest builds a request carrying the package's shared User-Agent. Callers
+// wrap the returned error with their own context, so the message stays specific
+// to the endpoint being built.
+func (s randombookSource) newRequest(ctx context.Context, method, endpoint string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	return req, nil
 }
 
 // base returns the configured API base URL (trailing slash trimmed) or the

--- a/internal/libgen/source_randombook.go
+++ b/internal/libgen/source_randombook.go
@@ -137,7 +137,7 @@ func (s randombookSource) Resolve(ctx context.Context, it Item) (Resolved, error
 
 	var lastErr error
 	for _, mirror := range mirrors {
-		fileURL, rerr := s.resolveViaMirror(ctx, mirror, it.MD5)
+		fileURL, rerr := s.resolveMirror(ctx, mirror, id, it.MD5)
 		if rerr != nil {
 			lastErr = rerr
 			continue
@@ -190,6 +190,68 @@ func (s randombookSource) lookupMirrors(ctx context.Context, id string) ([]strin
 		return nil, fmt.Errorf("randombook: no mirror hostnames for id %q", id)
 	}
 	return rec.Result.List, nil
+}
+
+// randombookDownloadPath is the mirror route the site's own UI opens to serve a
+// file. It takes the numeric randombook id — not the md5, and not the opaque
+// "?l=" landing-page token — and answers with the file bytes through a 302 to the
+// family's file host.
+//
+// Verified live on 2026-07-24: the "?l=" token route returns HTTP 400 even when
+// called from inside a real browser session with genuine cookies and same-origin,
+// so it is deliberately not used; the id route needs no token, cookie or session
+// at all, and the bytes it serves hash to the item's md5.
+const randombookDownloadPath = "/api/download?id="
+
+// resolveMirror resolves a single discovered mirror to a streamable URL. It
+// prefers the site's own download API and falls back to the classic ads.php link
+// chain, which older libgen hosts may still serve. When both fail the ads.php
+// error is returned (wrapping the API error for context) so existing diagnoses
+// like ErrMirrorClientRendered stay detectable with errors.Is.
+func (s randombookSource) resolveMirror(ctx context.Context, mirror, id, md5 string) (string, error) {
+	fileURL, apiErr := s.resolveViaDownloadAPI(ctx, mirror, id)
+	if apiErr == nil {
+		return fileURL, nil
+	}
+	fileURL, adsErr := s.resolveViaMirror(ctx, mirror, md5)
+	if adsErr == nil {
+		return fileURL, nil
+	}
+	return "", fmt.Errorf("%w (download API: %w)", adsErr, apiErr)
+}
+
+// resolveViaDownloadAPI returns a mirror's direct download URL for a numeric
+// randombook id, after a cheap HEAD probe confirming the mirror is reachable and
+// implements the route.
+//
+// The endpoint is GET-only, so a HEAD following the mirror's redirect comes back
+// 405 (Allow: GET); that still proves the host is alive and serving the route,
+// which is all this probe decides. A 404 means the mirror does not implement the
+// route at all (an older, classic libgen host), so the caller falls back to the
+// ads.php chain. HEAD does not validate the id — an unknown id fails only on the
+// GET — but id validity does not vary between mirrors, so it is not worth a
+// full-body request here: the endpoint ignores Range and would stream the whole
+// file.
+func (s randombookSource) resolveViaDownloadAPI(ctx context.Context, mirror, id string) (string, error) {
+	base := normalizeMirrorBase(mirror)
+	endpoint := base + randombookDownloadPath + url.QueryEscape(id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpoint, http.NoBody)
+	if err != nil {
+		return "", fmt.Errorf("randombook: building download probe for %q: %w", base, err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := s.client().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("randombook: probing %q: %w", base, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode >= http.StatusInternalServerError {
+		return "", fmt.Errorf("randombook: mirror %q serves no download API (HTTP %d)", base, resp.StatusCode)
+	}
+	return endpoint, nil
 }
 
 // resolveViaMirror runs the LibGen link chain against a single freshly discovered

--- a/internal/libgen/source_randombook.go
+++ b/internal/libgen/source_randombook.go
@@ -1,12 +1,15 @@
 package libgen
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -32,6 +35,17 @@ const randombookMaxBody = 1 << 20 // 1 MiB
 // Note on the API shape: links-by-id returns both a "list" of mirror hostnames
 // and a "links" array. The "links" entries are opaque per-request tokens to
 // landing pages, not direct files, so only "list" (the mirror hostnames) is used.
+//
+// Note on candidate hosts (verified 2026-07-23): the API's "list" is not
+// guaranteed to contain genuine libgen.li-family hosts — it has been observed
+// consistently returning a fixed set of non-family hosts (e.g. libgen.net,
+// libgen.me, libgen.xyz — client-rendered SPAs with no server-side ads.php route
+// — and annas-archive.gl, which uses an unrelated /md5/<hash> scheme and is
+// out of scope per the project's Anna's Archive decision). Resolve therefore
+// only attempts hosts matching the libgen.<tld> shape (randombookHostRe); other
+// hosts are skipped without a request, and a libgen.<tld> host that answers with
+// a client-rendered shell instead of the classic ads.php page is reported with a
+// distinct, diagnosable error (see resolveViaMirror).
 type randombookSource struct {
 	// apiBase overrides the randombook API endpoint (defaults to
 	// randombookAPIBase); tests set it to a local httptest server.
@@ -43,6 +57,38 @@ type randombookSource struct {
 
 // Compile-time assertion that randombookSource satisfies the DownloadSource contract.
 var _ DownloadSource = randombookSource{}
+
+// randombookHostRe matches a bare libgen.<tld> hostname (no path/query), the only
+// shape resolveViaMirror's ads.php/get.php scraping is designed for. It mirrors
+// the convention in internal/mirrors.mirrorHostRe. A discovered candidate that
+// does not match — e.g. an unrelated aggregator domain — is skipped rather than
+// scraped, since the technique does not apply to it.
+var randombookHostRe = regexp.MustCompile(`^https?://libgen\.[a-z]{2,6}/?$`)
+
+// errMirrorClientRendered reports that a libgen-family host answered with a
+// client-rendered application shell (no server-rendered ads.php content) rather
+// than the classic ads.php page resolveViaMirror scrapes. It is distinct from a
+// generic ExtractGetLink failure so a site-wide frontend migration is
+// diagnosable from logs/errors rather than looking like a one-off missing link.
+var errMirrorClientRendered = errors.New("randombook: mirror serves a client-rendered page, not the classic ads.php content")
+
+// nuxtShellMarker is a substring reliably present in a Nuxt single-page-app's
+// server-sent HTML shell (the mount point the client-side JS hydrates into) but
+// never in a classic server-rendered ads.php page.
+const nuxtShellMarker = `id="__nuxt"`
+
+// filterLibgenFamily returns the subset of mirrors matching randombookHostRe, in
+// order. Candidates outside the libgen.<tld> shape are dropped before any request
+// is made, since resolveViaMirror's scraping technique does not apply to them.
+func filterLibgenFamily(mirrors []string) []string {
+	out := make([]string, 0, len(mirrors))
+	for _, m := range mirrors {
+		if randombookHostRe.MatchString(strings.TrimSpace(m)) {
+			out = append(out, m)
+		}
+	}
+	return out
+}
 
 // randombookByIDResponse is the subset of the by-id API record consulted here. A
 // nil Result means the md5 is not indexed by randombook.
@@ -83,6 +129,10 @@ func (s randombookSource) Resolve(ctx context.Context, it Item) (Resolved, error
 	mirrors, err := s.lookupMirrors(ctx, id)
 	if err != nil {
 		return Resolved{}, err
+	}
+	mirrors = filterLibgenFamily(mirrors)
+	if len(mirrors) == 0 {
+		return Resolved{}, fmt.Errorf("randombook: no usable mirrors discovered for md5 %q", it.MD5)
 	}
 
 	var lastErr error
@@ -180,6 +230,9 @@ func (s randombookSource) resolveViaMirror(ctx context.Context, mirror, md5 stri
 	}
 	link, err := ExtractGetLink(body)
 	if err != nil {
+		if bytes.Contains(body, []byte(nuxtShellMarker)) {
+			return "", fmt.Errorf("randombook: mirror %q: %w", base, errMirrorClientRendered)
+		}
 		return "", fmt.Errorf("randombook: mirror %q: %w", base, err)
 	}
 	return base + "/" + link, nil

--- a/internal/libgen/source_randombook.go
+++ b/internal/libgen/source_randombook.go
@@ -65,12 +65,12 @@ var _ DownloadSource = randombookSource{}
 // scraped, since the technique does not apply to it.
 var randombookHostRe = regexp.MustCompile(`^https?://libgen\.[a-z]{2,6}/?$`)
 
-// errMirrorClientRendered reports that a libgen-family host answered with a
+// ErrMirrorClientRendered reports that a libgen-family host answered with a
 // client-rendered application shell (no server-rendered ads.php content) rather
 // than the classic ads.php page resolveViaMirror scrapes. It is distinct from a
 // generic ExtractGetLink failure so a site-wide frontend migration is
 // diagnosable from logs/errors rather than looking like a one-off missing link.
-var errMirrorClientRendered = errors.New("randombook: mirror serves a client-rendered page, not the classic ads.php content")
+var ErrMirrorClientRendered = errors.New("randombook: mirror serves a client-rendered page, not the classic ads.php content")
 
 // nuxtShellMarker is a substring reliably present in a Nuxt single-page-app's
 // server-sent HTML shell (the mount point the client-side JS hydrates into) but
@@ -231,7 +231,7 @@ func (s randombookSource) resolveViaMirror(ctx context.Context, mirror, md5 stri
 	link, err := ExtractGetLink(body)
 	if err != nil {
 		if bytes.Contains(body, []byte(nuxtShellMarker)) {
-			return "", fmt.Errorf("randombook: mirror %q: %w", base, errMirrorClientRendered)
+			return "", fmt.Errorf("randombook: mirror %q: %w", base, ErrMirrorClientRendered)
 		}
 		return "", fmt.Errorf("randombook: mirror %q: %w", base, err)
 	}

--- a/internal/libgen/source_randombook_test.go
+++ b/internal/libgen/source_randombook_test.go
@@ -408,7 +408,13 @@ func TestRandombookClientRenderedMirror(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reading SPA shell fixture: %v", err)
 	}
-	spaMirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// The mirror serves no download API, so Resolve falls back to the ads.php
+	// chain — the path whose diagnosis this test pins.
+	spaMirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/download" {
+			http.NotFound(w, r)
+			return
+		}
 		_, _ = w.Write(shell)
 	}))
 	t.Cleanup(spaMirror.Close)
@@ -430,7 +436,13 @@ func TestRandombookClientRenderedMirror(t *testing.T) {
 // ExtractGetLink failure, not ErrMirrorClientRendered — the two diagnoses must
 // not be conflated.
 func TestRandombookOrdinaryMissingLink(t *testing.T) {
-	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// The mirror serves no download API, so Resolve falls back to the ads.php
+	// chain — the path whose diagnosis this test pins.
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/download" {
+			http.NotFound(w, r)
+			return
+		}
 		_, _ = w.Write([]byte("<html><body>no download link here</body></html>"))
 	}))
 	t.Cleanup(plain.Close)
@@ -475,5 +487,127 @@ func TestRandombookRealCapturedCandidates(t *testing.T) {
 		if got[i] != w {
 			t.Errorf("filtered mirrors[%d] = %q, want %q", i, got[i], w)
 		}
+	}
+}
+
+// TestRandombookDownloadAPISkipsDeadMirror verifies the real-world candidate mix
+// observed on 2026-07-24, where randombook offers three libgen.<tld> hosts and
+// only some are reachable: an unreachable mirror must be skipped in favor of the
+// next one rather than failing the whole source.
+func TestRandombookDownloadAPISkipsDeadMirror(t *testing.T) {
+	payload := []byte("%PDF-1.5 second-mirror payload")
+	want := md5Hex(payload)
+
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/download" || r.URL.Query().Get("id") != "123" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer live.Close()
+
+	// A closed listener's address stands in for a mirror that is down: dialing it
+	// fails at the transport level, exactly as libgen.me did when observed.
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadAddr := dead.Listener.Addr().String()
+	dead.Close()
+
+	const deadHost, liveHost = "libgen.dead", "libgen.live"
+	httpClient := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			switch addr {
+			case deadHost + ":80":
+				addr = deadAddr
+			case liveHost + ":80":
+				addr = live.Listener.Addr().String()
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}}
+
+	links := fmt.Sprintf(`{"result":{"list":["http://%s","http://%s"]},"isError":false}`, deadHost, liveHost)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+
+	s := randombookSource{apiBase: apiBase, http: httpClient}
+	res, err := s.Resolve(context.Background(), Item{MD5: want})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if wantURL := "http://" + liveHost + "/api/download?id=123"; res.FileURL != wantURL {
+		t.Fatalf("FileURL = %q, want the live mirror %q", res.FileURL, wantURL)
+	}
+}
+
+// TestRandombookResolvesViaDownloadAPI verifies the source resolves an item
+// through the mirror's own /api/download?id=<numeric id> endpoint — the
+// mechanism the site itself uses (verified live 2026-07-24) — instead of
+// scraping ads.php, which the current libgen.<tld> candidates no longer serve.
+// A HEAD probe selects a live mirror, and the resolved URL is streamed end to
+// end to prove it serves the file and passes md5 verification.
+func TestRandombookResolvesViaDownloadAPI(t *testing.T) {
+	payload := []byte("%PDF-1.5 randombook download-api payload")
+	want := md5Hex(payload)
+
+	var headSeen atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/download", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("id") != "123" {
+			http.NotFound(w, r)
+			return
+		}
+		// The live endpoint is GET-only; a HEAD reaches it through the mirror's
+		// 302 and comes back 405, which still proves the mirror is alive.
+		if r.Method == http.MethodHead {
+			headSeen.Store(true)
+			w.Header().Set("Allow", "GET")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="book.pdf"`)
+		_, _ = w.Write(payload)
+	})
+	mirror := httptest.NewServer(mux)
+	defer mirror.Close()
+
+	const fakeHost = "libgen.test"
+	fakeMirror := "http://" + fakeHost
+	httpClient := clientToHost(fakeHost+":80", mirror.Listener.Addr().String())
+
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, fakeMirror)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+
+	s := randombookSource{apiBase: apiBase, http: httpClient}
+	res, err := s.Resolve(context.Background(), Item{MD5: want})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	wantURL := fakeMirror + "/api/download?id=123"
+	if res.FileURL != wantURL {
+		t.Fatalf("FileURL = %q, want %q", res.FileURL, wantURL)
+	}
+	if !res.VerifyMD5 {
+		t.Error("VerifyMD5 = false, want true (md5-keyed)")
+	}
+	if !headSeen.Load() {
+		t.Error("no HEAD probe was issued to select a live mirror")
+	}
+
+	// The file-streaming path uses c.dl (not c.http), so both need the redirect.
+	c := newTestClient(staticMirrors{})
+	c.http = httpClient
+	c.dl = httpClient
+	c.sources = []DownloadSource{s}
+	dl, err := c.Download(context.Background(), want, t.TempDir(), "", nil)
+	if err != nil {
+		t.Fatalf("Download() via randombook error = %v", err)
+	}
+	if !dl.Verified {
+		t.Error("Verified = false, want true")
 	}
 }

--- a/internal/libgen/source_randombook_test.go
+++ b/internal/libgen/source_randombook_test.go
@@ -400,7 +400,7 @@ func TestRandombookSkipsNonFamilyHosts(t *testing.T) {
 // answers ads.php with a client-rendered application shell (captured live from a
 // real migrated mirror, testdata/randombook_spa_shell.html) instead of the
 // classic server-rendered ads.php page, resolveViaMirror reports the distinct
-// errMirrorClientRendered diagnosis rather than the generic ExtractGetLink
+// ErrMirrorClientRendered diagnosis rather than the generic ExtractGetLink
 // failure — so a site-wide frontend migration is distinguishable in logs/errors
 // from an ordinary missing-link parse failure.
 func TestRandombookClientRenderedMirror(t *testing.T) {
@@ -420,14 +420,14 @@ func TestRandombookClientRenderedMirror(t *testing.T) {
 
 	s := randombookSource{apiBase: apiBase, http: httpClient}
 	_, err = s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"})
-	if !errors.Is(err, errMirrorClientRendered) {
-		t.Fatalf("err = %v, want wrapping errMirrorClientRendered (client-rendered SPA shell)", err)
+	if !errors.Is(err, ErrMirrorClientRendered) {
+		t.Fatalf("err = %v, want wrapping ErrMirrorClientRendered (client-rendered SPA shell)", err)
 	}
 }
 
 // TestRandombookOrdinaryMissingLink verifies that a libgen-family mirror serving
 // an ordinary (non-SPA) page with no get.php link still reports the generic
-// ExtractGetLink failure, not errMirrorClientRendered — the two diagnoses must
+// ExtractGetLink failure, not ErrMirrorClientRendered — the two diagnoses must
 // not be conflated.
 func TestRandombookOrdinaryMissingLink(t *testing.T) {
 	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -442,7 +442,7 @@ func TestRandombookOrdinaryMissingLink(t *testing.T) {
 
 	s := randombookSource{apiBase: apiBase, http: httpClient}
 	_, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"})
-	if errors.Is(err, errMirrorClientRendered) {
+	if errors.Is(err, ErrMirrorClientRendered) {
 		t.Fatal("an ordinary missing-link page must not be misdiagnosed as a client-rendered shell")
 	}
 	if err == nil {

--- a/internal/libgen/source_randombook_test.go
+++ b/internal/libgen/source_randombook_test.go
@@ -4,11 +4,28 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 )
+
+// clientToHost returns an http.Client whose transport redirects any dial to
+// fakeHost to the given real address, so a test can present a libgen.<tld>-shaped
+// mirror hostname (as randombookHostRe requires) while actually talking to a local
+// httptest server, which only ever listens on a 127.0.0.1:port address.
+func clientToHost(fakeHost, realAddr string) *http.Client {
+	return &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == fakeHost {
+				addr = realAddr
+			}
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}}
+}
 
 // randombookByIDFixture loads the captured randombook by-id JSON response.
 func randombookByIDFixture(t *testing.T) string {
@@ -69,15 +86,21 @@ func TestRandombookResolvesViaMirror(t *testing.T) {
 	})
 	defer mirror.Close()
 
-	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, mirror.URL)
+	// Present a libgen.<tld>-shaped hostname (as randombookHostRe now requires of
+	// any candidate Resolve attempts) and redirect it to the httptest server.
+	const fakeHost = "libgen.test"
+	fakeMirror := "http://" + fakeHost
+	httpClient := clientToHost(fakeHost+":80", mirror.Listener.Addr().String())
+
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, fakeMirror)
 	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
 
-	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
+	s := randombookSource{apiBase: apiBase, http: httpClient}
 	res, err := s.Resolve(context.Background(), Item{MD5: want})
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)
 	}
-	wantURL := mirror.URL + "/get.php?md5=" + want + "&key=TESTKEY123"
+	wantURL := fakeMirror + "/get.php?md5=" + want + "&key=TESTKEY123"
 	if res.FileURL != wantURL {
 		t.Errorf("FileURL = %q, want %q", res.FileURL, wantURL)
 	}
@@ -86,7 +109,10 @@ func TestRandombookResolvesViaMirror(t *testing.T) {
 	}
 
 	// Prove the resolved URL is actually downloadable and verifies end to end.
+	// The file-streaming path uses c.dl (not c.http), so both need the redirect.
 	c := newTestClient(staticMirrors{})
+	c.http = httpClient
+	c.dl = httpClient
 	c.sources = []DownloadSource{s}
 	dl, err := c.Download(context.Background(), want, t.TempDir(), "", nil)
 	if err != nil {
@@ -107,25 +133,6 @@ func TestRandombookNotIndexed(t *testing.T) {
 	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
 	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
 		t.Fatal("Resolve() for a non-indexed md5 should return an error")
-	}
-}
-
-// TestRandombookNoWorkingMirror verifies that when mirrors are discovered but none
-// serves a usable get.php key, Resolve returns an error (fall-through) rather than
-// a bogus URL.
-func TestRandombookNoWorkingMirror(t *testing.T) {
-	// A mirror whose ads.php carries no get.php link: ExtractGetLink fails on it.
-	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("<html><body>no download link here</body></html>"))
-	}))
-	defer dead.Close()
-
-	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, dead.URL)
-	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
-
-	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
-	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
-		t.Fatal("Resolve() with no working mirror should return an error")
 	}
 }
 
@@ -319,5 +326,154 @@ func TestRandombookParsesLinksFixture(t *testing.T) {
 	}
 	if len(mirrors) == 0 || mirrors[0] != "https://libgen.net" {
 		t.Errorf("mirrors = %v, want first == %q", mirrors, "https://libgen.net")
+	}
+}
+
+// TestFilterLibgenFamily verifies filterLibgenFamily keeps only bare
+// libgen.<tld> hostnames (the shape resolveViaMirror's ads.php scraping
+// targets) and drops any candidate outside that shape — in particular the
+// annas-archive.* hosts randombook.org has been observed to mix into its
+// candidate list, which use an unrelated URL scheme entirely.
+func TestFilterLibgenFamily(t *testing.T) {
+	in := []string{
+		"https://libgen.net",
+		"https://libgen.me",
+		"https://libgen.xyz",
+		"https://annas-archive.gl",
+		"not a url",
+		"https://evil.example.com",
+	}
+	got := filterLibgenFamily(in)
+	want := []string{"https://libgen.net", "https://libgen.me", "https://libgen.xyz"}
+	if len(got) != len(want) {
+		t.Fatalf("filterLibgenFamily(%v) = %v, want %v", in, got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("filterLibgenFamily()[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+// TestFilterLibgenFamily_AllFiltered verifies an all-non-family candidate list
+// filters down to empty, rather than falling back to trying any of them.
+func TestFilterLibgenFamily_AllFiltered(t *testing.T) {
+	got := filterLibgenFamily([]string{"https://annas-archive.gl", "https://annas-archive.pk"})
+	if len(got) != 0 {
+		t.Errorf("filterLibgenFamily() = %v, want empty", got)
+	}
+}
+
+// TestRandombookSkipsNonFamilyHosts verifies Resolve never attempts a
+// non-libgen-family candidate (e.g. annas-archive.gl) at all: with only such
+// candidates discovered, it fails fast with the same "no usable mirrors"
+// message used for a structurally empty list, and never issues a single request
+// to the non-family host — proving the host is filtered out before any network
+// call, not merely tried-and-failed.
+func TestRandombookSkipsNonFamilyHosts(t *testing.T) {
+	var hit atomic.Bool
+	nonFamily := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(nonFamily.Close)
+
+	// Present it as a fake annas-archive.gl-shaped candidate via the DialContext
+	// redirect trick, so the ONLY way resolveViaMirror could reach it is if the
+	// family filter failed to exclude it.
+	const fakeHost = "annas-archive.gl"
+	httpClient := clientToHost(fakeHost+":80", nonFamily.Listener.Addr().String())
+
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, "http://"+fakeHost)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+
+	s := randombookSource{apiBase: apiBase, http: httpClient}
+	if _, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"}); err == nil {
+		t.Fatal("Resolve() with only a non-family candidate should fail")
+	}
+	if hit.Load() {
+		t.Error("resolveViaMirror issued a request to a non-family host; it should have been filtered out before any request")
+	}
+}
+
+// TestRandombookClientRenderedMirror verifies that when a libgen-family mirror
+// answers ads.php with a client-rendered application shell (captured live from a
+// real migrated mirror, testdata/randombook_spa_shell.html) instead of the
+// classic server-rendered ads.php page, resolveViaMirror reports the distinct
+// errMirrorClientRendered diagnosis rather than the generic ExtractGetLink
+// failure — so a site-wide frontend migration is distinguishable in logs/errors
+// from an ordinary missing-link parse failure.
+func TestRandombookClientRenderedMirror(t *testing.T) {
+	shell, err := os.ReadFile("testdata/randombook_spa_shell.html")
+	if err != nil {
+		t.Fatalf("reading SPA shell fixture: %v", err)
+	}
+	spaMirror := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(shell)
+	}))
+	t.Cleanup(spaMirror.Close)
+
+	const fakeHost = "libgen.test"
+	httpClient := clientToHost(fakeHost+":80", spaMirror.Listener.Addr().String())
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, "http://"+fakeHost)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+
+	s := randombookSource{apiBase: apiBase, http: httpClient}
+	_, err = s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"})
+	if !errors.Is(err, errMirrorClientRendered) {
+		t.Fatalf("err = %v, want wrapping errMirrorClientRendered (client-rendered SPA shell)", err)
+	}
+}
+
+// TestRandombookOrdinaryMissingLink verifies that a libgen-family mirror serving
+// an ordinary (non-SPA) page with no get.php link still reports the generic
+// ExtractGetLink failure, not errMirrorClientRendered — the two diagnoses must
+// not be conflated.
+func TestRandombookOrdinaryMissingLink(t *testing.T) {
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("<html><body>no download link here</body></html>"))
+	}))
+	t.Cleanup(plain.Close)
+
+	const fakeHost = "libgen.test"
+	httpClient := clientToHost(fakeHost+":80", plain.Listener.Addr().String())
+	links := fmt.Sprintf(`{"result":{"list":[%q]},"isError":false}`, "http://"+fakeHost)
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), links)
+
+	s := randombookSource{apiBase: apiBase, http: httpClient}
+	_, err := s.Resolve(context.Background(), Item{MD5: "87a4ebdaf21fa6cc70009a3dd63194ee"})
+	if errors.Is(err, errMirrorClientRendered) {
+		t.Fatal("an ordinary missing-link page must not be misdiagnosed as a client-rendered shell")
+	}
+	if err == nil {
+		t.Fatal("Resolve() with no get.php link should fail")
+	}
+}
+
+// TestRandombookRealCapturedCandidates guards against a regression in the
+// real-world candidate mix: the captured links-by-id fixture carries the exact
+// hosts randombook.org has been observed returning (three libgen.* SPA-migrated
+// hosts plus one annas-archive.gl entry). filterLibgenFamily must keep exactly
+// the three libgen.* hosts, so Resolve knows which are even worth attempting.
+func TestRandombookRealCapturedCandidates(t *testing.T) {
+	body, err := os.ReadFile("testdata/randombook_links.json")
+	if err != nil {
+		t.Fatalf("reading links fixture: %v", err)
+	}
+	apiBase := randombookAPIServer(t, randombookByIDFixture(t), string(body))
+	s := randombookSource{apiBase: apiBase, http: http.DefaultClient}
+	mirrors, err := s.lookupMirrors(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("lookupMirrors() error = %v", err)
+	}
+	got := filterLibgenFamily(mirrors)
+	want := []string{"https://libgen.net", "https://libgen.me", "https://libgen.xyz"}
+	if len(got) != len(want) {
+		t.Fatalf("filterLibgenFamily(lookupMirrors()) = %v, want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("filtered mirrors[%d] = %q, want %q", i, got[i], w)
+		}
 	}
 }

--- a/internal/libgen/testdata/randombook_spa_shell.html
+++ b/internal/libgen/testdata/randombook_spa_shell.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Libgen</title>
+<meta name="description" content>
+<link rel="icon" type="image/x-icon" href="/icons/favicon.ico">
+<link rel="stylesheet" href="/_nuxt/entry.C4mfbyBf.css">
+<link rel="modulepreload" as="script" crossorigin href="/_nuxt/entry.DpkGC0ve.js">
+<link rel="prefetch" as="style" crossorigin href="/_nuxt/default.CNXtga5L.css">
+<link rel="prefetch" as="script" crossorigin href="/_nuxt/default.DjKyR0FO.js">
+<link rel="prefetch" as="script" crossorigin href="/_nuxt/_plugin-vue_export-helper.DlAUqK2U.js">
+<link rel="prefetch" as="style" crossorigin href="/_nuxt/error-404.JekaaCis.css">
+<link rel="prefetch" as="script" crossorigin href="/_nuxt/error-404.C7L-RpWx.js">
+<link rel="prefetch" as="script" crossorigin href="/_nuxt/vue.-sixQ7xP.Byn7iXIF.js">
+<link rel="prefetch" as="style" crossorigin href="/_nuxt/error-500.CNP9nqm1.css">
+<link rel="prefetch" as="script" crossorigin href="/_nuxt/error-500.BWhw16z_.js">
+<script type="module" src="/_nuxt/entry.DpkGC0ve.js" crossorigin></script>
+<script id="unhead:payload" type="application/json">{"title":"Libgen"}</script></head><body><div id="__nuxt"></div><script type="application/json" id="__NUXT_DATA__" data-ssr="false">[{"_errors":1,"serverRendered":2,"data":3,"state":4,"once":5},{},false,{},{},["Set"]]</script>
+<script>window.__NUXT__={};window.__NUXT__.config={public:{theme:"antic",persistedState:{storage:"cookies",debug:false,cookieOptions:{}}},app:{baseURL:"/",buildAssetsDir:"/_nuxt/",cdnURL:""}}</script></body></html>

--- a/test/e2e/live_test.go
+++ b/test/e2e/live_test.go
@@ -317,6 +317,33 @@ var randombookProbeQueries = []string{"python", "history", "science", "chemistry
 // requires the failure to be one of the KNOWN, diagnosed classes below. An
 // error outside that set fails the test, so a new, unrecognized failure mode
 // is caught here instead of discovered by chance later.
+// syntheticMD5NeverIndexed is a well-formed but unallocated md5 (all zeros) that
+// no real book can carry, guaranteeing a deterministic "not indexed" miss from
+// the live randombook.org API — unlike the mirror-resolution outcome, which
+// depends on the live mirror ecosystem's current state and cannot be forced on
+// demand, the not-indexed miss is reliably reproducible against the real API on
+// every run.
+const syntheticMD5NeverIndexed = "00000000000000000000000000000000"
+
+// TestE2ERandombookNotIndexedIsClean verifies, against the live randombook.org
+// API, that an md5 it cannot possibly have indexed yields a clean "not indexed"
+// error — not a transport error, not ErrLayoutChanged, and not a hang — so the
+// by-id lookup's normal-miss path is deterministically exercised on every run,
+// independent of the live mirror ecosystem's current state.
+func TestE2ERandombookNotIndexedIsClean(t *testing.T) {
+	env := requireLive(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	_, err := env.client.DownloadItem(ctx, libgen.Item{MD5: syntheticMD5NeverIndexed, Source: "randombook"}, t.TempDir(), "")
+	if err == nil {
+		t.Fatal("DownloadItem for a synthetic, never-allocated md5 unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "not indexed") {
+		t.Fatalf("want a clean \"not indexed\" miss for an unallocated md5, got: %v", err)
+	}
+}
+
 func TestE2ERandombookClassifiedOutcome(t *testing.T) {
 	env := requireLive(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)

--- a/test/e2e/live_test.go
+++ b/test/e2e/live_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -290,4 +291,118 @@ func hasDownloadLink(results []libgen.Result) bool {
 		}
 	}
 	return false
+}
+
+// randombookProbeQueries are search queries likely to surface distinct real
+// books, tried in order until one yields an md5 to probe randombook with —
+// making the test robust to randombook.org's per-book coverage gaps rather
+// than to any code defect.
+var randombookProbeQueries = []string{"python", "history", "science", "chemistry", "physics"}
+
+// TestE2ERandombookClassifiedOutcome exercises the randombook download source
+// end to end against the live randombook.org API and whatever mirrors it
+// currently discovers, restricting the download to source=randombook so no
+// other source in the chain can mask its behavior.
+//
+// This is the test that would have caught the bug found in this package on
+// 2026-07-23: randombook.org was observed returning mirror hostnames
+// resolveViaMirror cannot use (three libgen.<tld> hosts migrated to a
+// client-rendered SPA frontend, plus an unrelated annas-archive.gl host using
+// a different URL scheme entirely) — and the code surfaced that as a bare,
+// unclassified "HTTP 404" indistinguishable from ordinary live flakiness.
+// Nothing in the e2e suite caught it; it was found only by chance while
+// reading an unrelated LLM-eval transcript.
+//
+// The test therefore does not merely tolerate a download failure: on error, it
+// requires the failure to be one of the KNOWN, diagnosed classes below. An
+// error outside that set fails the test, so a new, unrecognized failure mode
+// is caught here instead of discovered by chance later.
+func TestE2ERandombookClassifiedOutcome(t *testing.T) {
+	env := requireLive(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	md5 := firstRandombookProbeMD5(t, ctx, env)
+	res, err := env.client.DownloadItem(ctx, libgen.Item{MD5: md5, Source: "randombook"}, t.TempDir(), "")
+	if err == nil {
+		assertRandombookDownloadOK(t, md5, res)
+		return
+	}
+	skipRandombookDiagnosedError(t, md5, err)
+}
+
+// firstRandombookProbeMD5 searches randombookProbeQueries in order and returns
+// the first valid md5 found, so the caller has a real book to probe randombook
+// with. It skips (never fails) on a live search error or if no query yields any
+// md5-carrying result, since that reflects live-data/site conditions, not the
+// randombook code under test.
+func firstRandombookProbeMD5(t *testing.T, ctx context.Context, env *liveEnv) string {
+	t.Helper()
+	for _, q := range randombookProbeQueries {
+		page, _, err := env.client.Search(ctx, libgen.SearchParams{Query: q, Topics: []string{"nonfiction"}})
+		if err != nil {
+			t.Skipf("search(%q) failed live: %v", q, err)
+		}
+		for i := range page.Results {
+			if md5Re.MatchString(page.Results[i].MD5) {
+				return page.Results[i].MD5
+			}
+		}
+		pace()
+	}
+	t.Skip("could not find a book with a valid md5 to probe randombook with")
+	return ""
+}
+
+// assertRandombookDownloadOK verifies the best-case outcome: a genuine
+// libgen-family mirror was currently available and served the classic ads.php
+// flow, so the file must be a real, MD5-verified randombook download.
+func assertRandombookDownloadOK(t *testing.T, md5 string, res *libgen.DownloadResult) {
+	t.Helper()
+	if res.Path == "" {
+		t.Fatal("DownloadItem succeeded but returned no path")
+	}
+	if !res.Verified {
+		t.Error("randombook download succeeded but was not MD5-verified")
+	}
+	if res.Source != "randombook" {
+		t.Errorf("Source = %q, want %q", res.Source, "randombook")
+	}
+	t.Logf("randombook served a real download: md5=%s bytes=%d", md5, res.SizeBytes)
+}
+
+// skipRandombookDiagnosedError classifies a randombook download failure into
+// one of the known, diagnosed outcome classes and SKIPs with a clear reason.
+// An error outside that set is NOT a recognized live-data condition: it FAILS
+// the test, so a new, unclassified failure mode is caught here rather than
+// discovered by chance later (see the package doc comment above this test).
+func skipRandombookDiagnosedError(t *testing.T, md5 string, err error) {
+	t.Helper()
+	switch {
+	case strings.Contains(err.Error(), "not indexed"):
+		// A normal, expected miss for this particular book: randombook's
+		// catalog does not cover everything.
+		t.Skipf("md5 %s not indexed by randombook.org (normal per-book miss): %v", md5, err)
+	case strings.Contains(err.Error(), "no usable mirrors discovered"):
+		// Every discovered candidate was outside the libgen.<tld> family (see
+		// filterLibgenFamily in internal/libgen), so nothing was even
+		// attempted — a diagnosed, expected outcome given randombook.org's
+		// current candidate mix.
+		t.Skipf("randombook discovered no libgen-family mirror candidates for md5 %s: %v", md5, err)
+	case errors.Is(err, libgen.ErrMirrorClientRendered):
+		// A libgen-family host answered, but with its client-rendered SPA
+		// shell instead of the classic ads.php page — diagnosed and
+		// monitorable (see ErrMirrorClientRendered's doc comment).
+		t.Skipf("randombook's only libgen-family mirror candidate has migrated to a client-rendered frontend: %v", err)
+	case strings.Contains(err.Error(), "requesting") || strings.Contains(err.Error(), "returned HTTP"):
+		// A transport-level failure reaching randombook.org itself or a
+		// discovered mirror (network flakiness), consistent with the suite's
+		// SKIP-not-fail philosophy.
+		t.Skipf("randombook.org API or a discovered mirror was unreachable live: %v", err)
+	default:
+		// Anything else is an UNRECOGNIZED failure class: fail loudly rather
+		// than silently tolerating it, so a future regression of this kind is
+		// caught here instead of by chance in an unrelated eval run.
+		t.Fatalf("randombook download failed with an unclassified error (update this test's classification if this is a legitimate new outcome): %v", err)
+	}
 }

--- a/test/e2e/live_test.go
+++ b/test/e2e/live_test.go
@@ -299,24 +299,6 @@ func hasDownloadLink(results []libgen.Result) bool {
 // than to any code defect.
 var randombookProbeQueries = []string{"python", "history", "science", "chemistry", "physics"}
 
-// TestE2ERandombookClassifiedOutcome exercises the randombook download source
-// end to end against the live randombook.org API and whatever mirrors it
-// currently discovers, restricting the download to source=randombook so no
-// other source in the chain can mask its behavior.
-//
-// This is the test that would have caught the bug found in this package on
-// 2026-07-23: randombook.org was observed returning mirror hostnames
-// resolveViaMirror cannot use (three libgen.<tld> hosts migrated to a
-// client-rendered SPA frontend, plus an unrelated annas-archive.gl host using
-// a different URL scheme entirely) — and the code surfaced that as a bare,
-// unclassified "HTTP 404" indistinguishable from ordinary live flakiness.
-// Nothing in the e2e suite caught it; it was found only by chance while
-// reading an unrelated LLM-eval transcript.
-//
-// The test therefore does not merely tolerate a download failure: on error, it
-// requires the failure to be one of the KNOWN, diagnosed classes below. An
-// error outside that set fails the test, so a new, unrecognized failure mode
-// is caught here instead of discovered by chance later.
 // syntheticMD5NeverIndexed is a well-formed but unallocated md5 (all zeros) that
 // no real book can carry, guaranteeing a deterministic "not indexed" miss from
 // the live randombook.org API — unlike the mirror-resolution outcome, which
@@ -344,6 +326,24 @@ func TestE2ERandombookNotIndexedIsClean(t *testing.T) {
 	}
 }
 
+// TestE2ERandombookClassifiedOutcome exercises the randombook download source
+// end to end against the live randombook.org API and whatever mirrors it
+// currently discovers, restricting the download to source=randombook so no
+// other source in the chain can mask its behavior.
+//
+// This is the test that would have caught the bug found in this package on
+// 2026-07-23: randombook.org was observed returning mirror hostnames
+// resolveViaMirror cannot use (three libgen.<tld> hosts migrated to a
+// client-rendered SPA frontend, plus an unrelated annas-archive.gl host using
+// a different URL scheme entirely) — and the code surfaced that as a bare,
+// unclassified "HTTP 404" indistinguishable from ordinary live flakiness.
+// Nothing in the e2e suite caught it; it was found only by chance while
+// reading an unrelated LLM-eval transcript.
+//
+// The test therefore does not merely tolerate a download failure: on error, it
+// requires the failure to be one of the KNOWN, diagnosed classes below. An
+// error outside that set fails the test, so a new, unrecognized failure mode
+// is caught here instead of discovered by chance later.
 func TestE2ERandombookClassifiedOutcome(t *testing.T) {
 	env := requireLive(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)


### PR DESCRIPTION
## Summary

Makes the `randombook` download source work again. It has two parts: stop attempting candidates the scraping technique never applied to (and diagnose the ones that look right but aren't), and then actually download through the route those mirrors really serve.

## The bug

randombook.org's mirror-discovery API has been observed consistently returning a fixed set of candidate hosts that `resolveViaMirror`'s ads.php/get.php scraping was never designed for: three `libgen.net`/`.me`/`.xyz` hosts that have migrated to a client-rendered (Nuxt) frontend with no server-rendered ads.php content, and `annas-archive.gl`, which uses an unrelated `/md5/<hash>` scheme. Every candidate list sampled across several real books returned exactly this mix, so every randombook resolution was silently failing — masked by the download chain falling through to the next source, and by nothing in the e2e suite exercising this path at all.

## The fix, part 1 — stop guessing, start diagnosing

`Resolve` filters candidates to the `libgen.<tld>` shape before attempting any of them (generic, not a hardcoded host list — mirrors the existing `internal/mirrors` convention), and a libgen-family host that answers with a client-rendered shell instead of the classic ads.php page is reported with a distinct, diagnosable error (`ErrMirrorClientRendered`) rather than a generic "no get.php link" message that reads like ordinary flakiness.

That made the failure honest, but the source still could not complete a single download.

## The fix, part 2 — download through the route the mirrors actually serve

Those SPA-migrated mirrors do serve files; they just do it through the route their own UI uses:

```
GET https://libgen.<tld>/api/download?id=<numeric randombook id>
  -> 302 -> https://libgen.download/api/download?id=<id>
  -> 200  content-disposition: attachment; filename="<title>.pdf"
          application/octet-stream
```

No token, no cookie, no session, no JavaScript. The numeric id is already fetched during mirror discovery (`/api/search/by-id`), so this needs no extra lookup. The bytes it serves hash to the item's md5, so `VerifyMD5` stays on.

`Resolve` now prefers that route and falls back to the ads.php chain for older hosts that still serve it, so the part-1 diagnosis is preserved for that path. A cheap `HEAD` picks a reachable mirror — the endpoint is GET-only, so the probe comes back `405`, which still proves the host is alive; a `404` means the mirror doesn't implement the route and the ads.php fallback runs. A full-body probe was rejected because the endpoint ignores `Range` and would stream the entire file.

Worth recording for whoever touches this next: the opaque `?l=` landing-page token that these mirrors also hand out is **not** the download mechanism. It returns HTTP 400 even when called from inside a real browser session with genuine cookies and same-origin, so it is deliberately unused.

## Test coverage

- Unit tests (captured real fixtures, including the actual SPA-shell HTML): host filtering excludes non-family hosts without a single request; client-rendered detection stays distinct from an ordinary missing-link page; the real captured candidate mix filters correctly.
- New unit tests for the id route: the happy path resolves and streams end to end with md5 verification, a mirror that is down is skipped in favour of the next one, and mirrors without the route fall back to ads.php.
- Live e2e drives a real download restricted to `source=randombook` and classifies the outcome into the known, diagnosed classes — an error outside that set fails the test instead of being silently tolerated. A second, fully deterministic e2e test exercises the "not indexed" miss with a synthetic md5 the live API can never have indexed.

Verified against the live site: the classified-outcome test now completes a genuine download (`bytes=1627783`, md5 verified) where before this branch it could only skip with a diagnosed failure.

## Quality

`go test ./...` green; `-race` clean on internal/libgen; `golangci-lint` clean; godoc audit clean; coverage 99.5% (minimum 85); gocognit ≤15.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced random-book mirror discovery by filtering to supported `libgen.*`-style hosts.
  - Added clearer classification for mirrors that serve client-rendered pages instead of the expected classic layout.
  - Reduced wasted attempts by failing early when no eligible mirrors remain and by preferring a mirror “download/API” route when available.
- **Bug Fixes**
  - Improved mirror resolution and link extraction fallbacks for atypical mirror responses.
  - Better handling of dead mirrors during download selection and verification.
- **Tests**
  - Expanded unit, integration, and end-to-end coverage, including new SPA-shell fixture and classified error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->