### PR TITLE
fix(discovery): tighten external source usage across providers

### DIFF
--- a/docs/how-search-works.md
+++ b/docs/how-search-works.md
@@ -84,8 +84,10 @@ argument to hand to `download`:
 - **`crossref`** — the result carries a DOI. Download it with `download`'s `doi` argument.
 - **`arxiv`** — the result carries a direct `pdf_url`. Fetch that URL; `download` takes no
   arXiv identifier.
-- **`openlibrary`** — the result carries an `isbn` and a title, and no file at all.
-  OpenLibrary is a catalog, not a repository: use those to run a better-targeted `search`.
+- **`openlibrary`** — the result carries an `isbn` and a title. OpenLibrary is mainly a
+  catalog, not a repository, so use those to run a better-targeted `search` — unless the book
+  is publicly readable, in which case it also carries an `archive_url` you can read directly on
+  the Internet Archive.
 
 ```mermaid
 flowchart LR

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -114,9 +114,12 @@ Each hit carries at least one actionable identifier, depending on its `origin`:
 - **`pdf_url` (arxiv always; crossref when a direct PDF link is published)** — a
   directly-fetchable open-access PDF; fetch it yourself (it is not a Library Genesis
   download, so `download`/`read` do not resolve it).
-- **`isbn`/`title` (openlibrary)** — OpenLibrary is a keyless *query resolver*, not a
-  download source: it never carries a `pdf_url` and is never marked `open_access: true`.
-  Use its canonical `isbn` or `title` to refine a follow-up Library Genesis `search`.
+- **`isbn`/`title` (openlibrary)** — OpenLibrary is mainly a keyless *query resolver*: use
+  its canonical `isbn` or `title` to refine a follow-up Library Genesis `search`. The one
+  exception is a publicly readable book — one OpenLibrary reports as freely readable in full
+  on the Internet Archive — which additionally carries an `archive_url` (a
+  `https://archive.org/details/<id>` page you can read directly) and is marked
+  `open_access: true`.
 
 Hits are deduped against each other (by normalized DOI, then by title+year) and against the
 `results` on the same page, so nothing appears twice. All four providers are keyless — no

--- a/internal/discovery/annas.go
+++ b/internal/discovery/annas.go
@@ -42,8 +42,12 @@ type AnnasProvider struct {
 	http *http.Client
 }
 
-// NewAnnas builds a provider searching the given Anna's Archive mirrors.
-func NewAnnas(m MirrorLister) *AnnasProvider { return &AnnasProvider{mirrors: m} }
+// NewAnnas builds a provider searching the given Anna's Archive mirrors, equipped
+// with its own bounded http.Client (via newDiscoveryClient) so a stalled mirror can
+// never hang a search on the timeout-less http.DefaultClient.
+func NewAnnas(m MirrorLister) *AnnasProvider {
+	return &AnnasProvider{mirrors: m, http: newDiscoveryClient()}
+}
 
 // Name reports the origin label stamped on this provider's results.
 func (p *AnnasProvider) Name() string { return "annas" }
@@ -53,6 +57,11 @@ func (p *AnnasProvider) Name() string { return "annas" }
 // none answers, so a federated search is never failed by this provider. Only a
 // context error propagates.
 func (p *AnnasProvider) Search(ctx context.Context, query string, limit int) ([]DiscoveryResult, error) {
+	// Bound the whole call the same way arXiv/Crossref/OpenLibrary do, so trying
+	// several mirrors in sequence can never outlive the discovery budget.
+	ctx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	defer cancel()
+
 	httpClient := p.http
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/internal/discovery/annas_test.go
+++ b/internal/discovery/annas_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // staticMirrors is a MirrorLister over a fixed list, pointing the provider at a
@@ -89,6 +90,43 @@ func TestAnnasProviderSearchesFirstReachableMirror(t *testing.T) {
 	}
 	if p.Name() != "annas" {
 		t.Errorf("Name() = %q, want annas", p.Name())
+	}
+}
+
+// TestAnnasProviderBoundedClient verifies NewAnnas equips the provider with a
+// bounded http.Client (non-nil, with a timeout) rather than leaving it to fall back
+// on the timeout-less http.DefaultClient, so a stalled mirror can never hang a
+// federated search indefinitely.
+func TestAnnasProviderBoundedClient(t *testing.T) {
+	p := NewAnnas(staticMirrors{})
+	if p.http == nil {
+		t.Fatal("NewAnnas left http nil, want a bounded client")
+	}
+	if p.http.Timeout <= 0 {
+		t.Errorf("NewAnnas client timeout = %v, want a positive bound", p.http.Timeout)
+	}
+}
+
+// TestAnnasProviderSearchHonorsContextDeadline verifies Search threads its context
+// through the mirror request: a mirror that blocks until the caller's short deadline
+// expires makes Search return the context error rather than hanging, the same
+// bounded behavior arXiv/Crossref/OpenLibrary give. It also exercises the per-call
+// timeout wiring, since the request is issued under the deadline-bearing context.
+func TestAnnasProviderSearchHonorsContextDeadline(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // block until the client's context expires
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	got, err := NewAnnas(staticMirrors{srv.URL}).Search(ctx, "q", 3)
+	if err == nil {
+		t.Fatal("Search() error = nil, want a context deadline error")
+	}
+	if got != nil {
+		t.Errorf("Search() = %v, want nil results on a deadline error", got)
 	}
 }
 

--- a/internal/discovery/arxiv.go
+++ b/internal/discovery/arxiv.go
@@ -102,12 +102,13 @@ type atomFeed struct {
 }
 
 type atomEntry struct {
-	ID        string       `xml:"id"`
-	Title     string       `xml:"title"`
-	Published string       `xml:"published"`
-	Authors   []atomAuthor `xml:"author"`
-	DOI       string       `xml:"doi"`
-	Links     []atomLink   `xml:"link"`
+	ID         string       `xml:"id"`
+	Title      string       `xml:"title"`
+	Published  string       `xml:"published"`
+	Authors    []atomAuthor `xml:"author"`
+	DOI        string       `xml:"doi"`
+	JournalRef string       `xml:"journal_ref"`
+	Links      []atomLink   `xml:"link"`
 }
 
 type atomAuthor struct {
@@ -137,8 +138,9 @@ func parseArxivFeed(body []byte) []DiscoveryResult {
 
 // arxivEntryToResult maps one Atom entry onto a DiscoveryResult: whitespace-collapsed
 // title, "; "-joined author names, the publication year from <published>, the
-// arxiv:doi when present, and a directly-fetchable PDF URL. Origin is "arxiv" and
-// OpenAccess is always true.
+// arxiv:doi when present, the arxiv:journal_ref (the venue the preprint appeared in)
+// when present, and a directly-fetchable PDF URL. Origin is "arxiv" and OpenAccess
+// is always true.
 func arxivEntryToResult(e atomEntry) DiscoveryResult {
 	names := make([]string, 0, len(e.Authors))
 	for _, a := range e.Authors {
@@ -156,6 +158,7 @@ func arxivEntryToResult(e atomEntry) DiscoveryResult {
 		Authors:    strings.Join(names, "; "),
 		Year:       year,
 		DOI:        strings.TrimSpace(e.DOI),
+		Venue:      strings.Join(strings.Fields(e.JournalRef), " "),
 		PDFURL:     arxivPDFURL(e),
 		OpenAccess: true,
 	}

--- a/internal/discovery/arxiv_test.go
+++ b/internal/discovery/arxiv_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 // arxivFeedFixture is a realistic two-entry arXiv Atom feed: the first entry
-// carries an arxiv:doi and an explicit pdf link; the second has neither, so its
-// PDF URL must be reconstructed from the abstract id. Both carry author names and
-// a <published> date the parser reads the year from.
+// carries an arxiv:doi, an arxiv:journal_ref and an explicit pdf link; the second
+// has none of those, so its PDF URL must be reconstructed from the abstract id and
+// its Venue stays empty. Both carry author names and a <published> date the parser
+// reads the year from.
 const arxivFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
   <entry>
@@ -23,6 +24,7 @@ const arxivFeedFixture = `<?xml version="1.0" encoding="UTF-8"?>
     <author><name>Jane Doe</name></author>
     <author><name>John Smith</name></author>
     <arxiv:doi>10.1000/xyz123</arxiv:doi>
+    <arxiv:journal_ref>Phys. Rev. Lett. 100, 012345 (2021)</arxiv:journal_ref>
     <link href="http://arxiv.org/abs/2101.00001v1" rel="alternate" type="text/html"/>
     <link title="pdf" href="http://arxiv.org/pdf/2101.00001v1" rel="related" type="application/pdf"/>
   </entry>
@@ -92,9 +94,16 @@ func TestArxiv_ParsesEntries(t *testing.T) {
 		t.Errorf("first Origin/OpenAccess = %q/%v, want arxiv/true", first.Origin, first.OpenAccess)
 	}
 
+	if first.Venue != "Phys. Rev. Lett. 100, 012345 (2021)" {
+		t.Errorf("first.Venue = %q, want the arxiv:journal_ref", first.Venue)
+	}
+
 	second := got[1]
 	if second.DOI != "" {
 		t.Errorf("second.DOI = %q, want empty (no arxiv:doi)", second.DOI)
+	}
+	if second.Venue != "" {
+		t.Errorf("second.Venue = %q, want empty (no journal_ref)", second.Venue)
 	}
 }
 

--- a/internal/discovery/crossref.go
+++ b/internal/discovery/crossref.go
@@ -29,6 +29,19 @@ const (
 // PDF; a link carrying it supplies the result's PDFURL.
 const crossrefPDFType = "application/pdf"
 
+// crossrefCreativeCommonsHost is the host every Creative Commons license URL
+// carries; a license whose URL contains it is a defensible open-access signal,
+// unlike the proprietary publisher licenses paywalled works also advertise.
+const crossrefCreativeCommonsHost = "creativecommons.org"
+
+// crossrefTextMiningApplications are the link intended-application values that
+// require a subscription and 403 for anonymous users; a PDF link marked with one
+// of them is neither a usable full-text link nor an open-access signal.
+var crossrefTextMiningApplications = map[string]bool{
+	"text-mining":         true,
+	"similarity-checking": true,
+}
+
 // CrossrefProvider is a keyless open-access discovery source backed by the Crossref
 // works-search endpoint. Its limiter and http.Client are self-contained, so it
 // never shares state with libgen's enrichment client.
@@ -87,7 +100,13 @@ func (p *CrossrefProvider) Search(ctx context.Context, query string, limit int) 
 // with select= and appending the polite-pool mailto when a contact email is set.
 func (p *CrossrefProvider) buildURL(query string, limit int) string {
 	params := url.Values{}
-	params.Set("query", query)
+	// query.bibliographic is Crossref's citation-oriented field query: it scores
+	// title/author/container/year together, giving far better hits for a known
+	// reference than the generic query= free-text search. The select= projection
+	// keeps "link" (not the invalid subfield "intended-application", which Crossref
+	// rejects): selecting "link" already returns full Resource Link objects, each
+	// carrying its intended-application, so the PDF-link chooser can read it.
+	params.Set("query.bibliographic", query)
 	params.Set("rows", strconv.Itoa(clampCrossrefLimit(limit)))
 	params.Set("select", "DOI,title,author,issued,license,link")
 	if p.email != "" {
@@ -123,8 +142,14 @@ type crossrefWorkItem struct {
 	Title   []string          `json:"title"`
 	Author  []crossrefAuthor  `json:"author"`
 	Issued  crossrefIssued    `json:"issued"`
-	License []json.RawMessage `json:"license"`
+	License []crossrefLicense `json:"license"`
 	Link    []crossrefLink    `json:"link"`
+}
+
+// crossrefLicense is the subset of a Crossref license entry read here: only the URL
+// matters, since a Creative Commons URL is the open-access signal.
+type crossrefLicense struct {
+	URL string `json:"URL"`
 }
 
 type crossrefAuthor struct {
@@ -139,6 +164,10 @@ type crossrefIssued struct {
 type crossrefLink struct {
 	URL         string `json:"URL"`
 	ContentType string `json:"content-type"`
+	// IntendedApplication is Crossref's audience marker for the link: "unspecified"
+	// is the reader-facing full-text link, whereas "text-mining" and
+	// "similarity-checking" require a subscription and 403 for anonymous users.
+	IntendedApplication string `json:"intended-application"`
 }
 
 // parseCrossrefWorks decodes a Crossref works envelope into DiscoveryResults,
@@ -158,18 +187,37 @@ func parseCrossrefWorks(body []byte) []DiscoveryResult {
 
 // crossrefItemToResult maps one Crossref work item onto a DiscoveryResult: the
 // first title, "; "-joined "Given Family" author names, the issued year, the DOI,
-// a directly-fetchable PDF URL from the links, and OpenAccess heuristically true
-// when the work advertises any license.
+// a usable full-text PDF URL from the links, and OpenAccess set by a defensible
+// heuristic (a Creative Commons license or a usable free full-text link).
 func crossrefItemToResult(item crossrefWorkItem) DiscoveryResult {
+	pdf := crossrefPDFURL(item.Link)
 	return DiscoveryResult{
 		Origin:     "crossref",
 		Title:      firstNonEmpty(item.Title),
 		Authors:    crossrefAuthors(item.Author),
 		Year:       crossrefYear(item.Issued),
 		DOI:        strings.TrimSpace(item.DOI),
-		PDFURL:     crossrefPDFURL(item.Link),
-		OpenAccess: len(item.License) > 0,
+		PDFURL:     pdf,
+		OpenAccess: crossrefOpenAccess(item.License, pdf),
 	}
+}
+
+// crossrefOpenAccess is the open-access heuristic: a work is treated as open access
+// when it carries a Creative Commons license (its URL contains creativecommons.org)
+// OR when it exposes a usable free full-text link (a non-empty pdf, which
+// crossrefPDFURL only ever fills from anonymous-usable links). It deliberately does
+// NOT treat the mere presence of a license as OA, since paywalled works routinely
+// advertise proprietary publisher licenses.
+func crossrefOpenAccess(licenses []crossrefLicense, usablePDF string) bool {
+	if usablePDF != "" {
+		return true
+	}
+	for _, l := range licenses {
+		if strings.Contains(strings.ToLower(l.URL), crossrefCreativeCommonsHost) {
+			return true
+		}
+	}
+	return false
 }
 
 // crossrefAuthors joins author records as "Given Family" with "; ", skipping any
@@ -197,10 +245,14 @@ func crossrefYear(issued crossrefIssued) string {
 	return ""
 }
 
-// crossrefPDFURL returns the first link whose content-type marks a PDF, or "".
+// crossrefPDFURL returns a usable full-text PDF link, or "". It only ever returns a
+// link whose intended-application is anonymous-usable ("unspecified" or unset):
+// text-mining and similarity-checking links 403 for anonymous users, so surfacing
+// one would hand the caller a link it cannot fetch. When a work exposes only such
+// restricted links, "" is returned rather than a link that would fail.
 func crossrefPDFURL(links []crossrefLink) string {
 	for _, l := range links {
-		if l.ContentType == crossrefPDFType && l.URL != "" {
+		if l.ContentType == crossrefPDFType && l.URL != "" && !crossrefTextMiningApplications[l.IntendedApplication] {
 			return l.URL
 		}
 	}

--- a/internal/discovery/crossref_test.go
+++ b/internal/discovery/crossref_test.go
@@ -106,6 +106,124 @@ func TestCrossref_ParsesItems(t *testing.T) {
 	}
 }
 
+// crossrefPaywalledFixture is a single-item works response for a paywalled work
+// that nonetheless carries a (non-Creative-Commons) publisher license and only a
+// text-mining full-text link — the anonymous-hostile combination the OA heuristic
+// must NOT mislabel as open access. It must map to OpenAccess=false with an empty
+// PDFURL: the license is not a CC URL and the only PDF link is intended for
+// text-mining (which 403s for anonymous users), so neither OA signal holds.
+const crossrefPaywalledFixture = `{
+  "message": {
+    "items": [
+      {
+        "DOI": "10.1000/paywalled",
+        "title": ["A Closed Access Study"],
+        "author": [{"given": "Paywall", "family": "Publisher"}],
+        "issued": {"date-parts": [[2022]]},
+        "license": [{"URL": "https://www.elsevier.com/tdm/userlicense/1.0/"}],
+        "link": [
+          {"URL": "http://example.org/tdm.pdf", "content-type": "application/pdf", "intended-application": "text-mining"}
+        ]
+      }
+    ]
+  }
+}`
+
+// crossrefLinkPreferenceFixture is a single-item works response whose work carries
+// two application/pdf links: one intended for text-mining (403s for anonymous
+// users) and one intended-application "unspecified" (the reader-facing link). The
+// parser must pick the unspecified link as the PDFURL and treat the work as open
+// access on the strength of that usable full-text link.
+const crossrefLinkPreferenceFixture = `{
+  "message": {
+    "items": [
+      {
+        "DOI": "10.1000/twolinks",
+        "title": ["Two Links"],
+        "issued": {"date-parts": [[2023]]},
+        "link": [
+          {"URL": "http://example.org/tdm.pdf", "content-type": "application/pdf", "intended-application": "text-mining"},
+          {"URL": "http://example.org/reader.pdf", "content-type": "application/pdf", "intended-application": "unspecified"}
+        ]
+      }
+    ]
+  }
+}`
+
+// TestCrossref_PaywalledWithLicenseStaysClosed verifies the OA heuristic does not
+// treat a paywalled work as open access merely because it advertises a license: a
+// non-Creative-Commons license plus a text-mining-only PDF link must yield
+// OpenAccess=false and an empty PDFURL.
+func TestCrossref_PaywalledWithLicenseStaysClosed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(crossrefPaywalledFixture))
+	}))
+	defer srv.Close()
+	setCrossrefBase(t, srv.URL)
+
+	got, err := NewCrossref("").Search(context.Background(), "closed", 5)
+	if err != nil {
+		t.Fatalf("Search() error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search() returned %d results, want 1", len(got))
+	}
+	if got[0].OpenAccess {
+		t.Error("OpenAccess = true, want false (non-CC license + text-mining-only link)")
+	}
+	if got[0].PDFURL != "" {
+		t.Errorf("PDFURL = %q, want empty (only a text-mining link, which 403s)", got[0].PDFURL)
+	}
+}
+
+// TestCrossref_PrefersUnspecifiedLink verifies that when a work exposes both a
+// text-mining and an "unspecified" PDF link, the reader-facing unspecified link is
+// chosen and the presence of that usable full-text link marks the work open access.
+func TestCrossref_PrefersUnspecifiedLink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(crossrefLinkPreferenceFixture))
+	}))
+	defer srv.Close()
+	setCrossrefBase(t, srv.URL)
+
+	got, err := NewCrossref("").Search(context.Background(), "two links", 5)
+	if err != nil {
+		t.Fatalf("Search() error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("Search() returned %d results, want 1", len(got))
+	}
+	if got[0].PDFURL != "http://example.org/reader.pdf" {
+		t.Errorf("PDFURL = %q, want the unspecified reader link", got[0].PDFURL)
+	}
+	if !got[0].OpenAccess {
+		t.Error("OpenAccess = false, want true (has a usable unspecified full-text link)")
+	}
+}
+
+// TestCrossref_QueryBibliographic verifies the provider sends the query on the
+// query.bibliographic field (Crossref's citation-oriented field query) rather than
+// the generic query= parameter.
+func TestCrossref_QueryBibliographic(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = w.Write([]byte(crossrefItemsFixture))
+	}))
+	defer srv.Close()
+	setCrossrefBase(t, srv.URL)
+
+	if _, err := NewCrossref("").Search(context.Background(), "neural networks", 5); err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if got := gotQuery.Get("query.bibliographic"); got != "neural networks" {
+		t.Errorf("query.bibliographic = %q, want %q", got, "neural networks")
+	}
+	if _, ok := gotQuery["query"]; ok {
+		t.Error("generic query= present, want only query.bibliographic")
+	}
+}
+
 // TestCrossref_PolitePoolMailto verifies that a non-empty contact email is sent as
 // the polite-pool mailto query parameter, and that an empty email adds no mailto.
 func TestCrossref_PolitePoolMailto(t *testing.T) {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -39,6 +39,11 @@ type DiscoveryResult struct {
 	Year    string `json:"year,omitempty"`
 	DOI     string `json:"doi,omitempty"`
 	ISBN    string `json:"isbn,omitempty"`
+	// Venue is the publication venue when the source states one — currently arXiv's
+	// journal_ref (e.g. "Phys. Rev. Lett. 100, 012345 (2021)"), the bibliographic
+	// citation for a preprint that later appeared in a journal. It is a short
+	// citation string, never an abstract, so it stays cheap to carry.
+	Venue string `json:"venue,omitempty"`
 	// MD5 is the file digest when the provider is md5-keyed (Anna's Archive).
 	// Empty for the DOI-keyed open-access providers.
 	MD5 string `json:"md5,omitempty"`
@@ -46,9 +51,14 @@ type DiscoveryResult struct {
 	// compared with a catalog result on the two attributes people sort by. Both are
 	// as the provider states them — the size is a human string like "12.0MB", not a
 	// byte count — and both are empty when it states neither.
-	Extension  string `json:"extension,omitempty"`
-	Size       string `json:"size,omitempty"`
-	PDFURL     string `json:"pdf_url,omitempty"` // a directly-fetchable OA PDF when known
+	Extension string `json:"extension,omitempty"`
+	Size      string `json:"size,omitempty"`
+	PDFURL    string `json:"pdf_url,omitempty"` // a directly-fetchable OA PDF when known
+	// ArchiveURL is a free-to-read archive.org "details" page for a publicly
+	// readable book (surfaced by OpenLibrary when ebook_access is "public"). Empty
+	// for every other result, so it doubles as the "this book is freely readable"
+	// signal in the locator column.
+	ArchiveURL string `json:"archive_url,omitempty"`
 	OpenAccess bool   `json:"open_access"`
 }
 
@@ -75,11 +85,20 @@ func newDiscoveryClient() *http.Client {
 // other transport failure surfaces as an error the caller may choose to soften to
 // an empty result.
 func boundedGet(ctx context.Context, client *http.Client, rawURL string) (status int, body []byte, err error) {
+	return boundedGetUA(ctx, client, rawURL, discoveryUserAgent)
+}
+
+// boundedGetUA is boundedGet with an explicit User-Agent, letting a provider that
+// must identify itself differently — e.g. OpenLibrary, whose etiquette grants a
+// higher rate to a request carrying a contact email in its agent string — override
+// the default discovery agent. Its context and body-bounding semantics are
+// identical to boundedGet.
+func boundedGetUA(ctx context.Context, client *http.Client, rawURL, userAgent string) (status int, body []byte, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return 0, nil, err
 	}
-	req.Header.Set("User-Agent", discoveryUserAgent)
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, nil, err

--- a/internal/discovery/federate.go
+++ b/internal/discovery/federate.go
@@ -87,7 +87,7 @@ func isDuplicate(r DiscoveryResult, seenDOI, seenTitle, seenMD5 map[string]bool)
 // arxiv, crossref, openlibrary. email is the Crossref polite-pool mailto contact
 // (typically cfg.UnpaywallEmail); pass "" to omit it.
 func DefaultProviders(email string) []Provider {
-	return []Provider{NewArxiv(), NewCrossref(email), NewOpenLibrary()}
+	return []Provider{NewArxiv(), NewCrossref(email), NewOpenLibrary(email)}
 }
 
 // ExtraProviders returns every searcher consulted beyond the Library Genesis

--- a/internal/discovery/openlibrary.go
+++ b/internal/discovery/openlibrary.go
@@ -25,25 +25,56 @@ const (
 )
 
 // openLibraryFields is the projection requested from the search endpoint, trimming
-// the response to just the fields the resolver reads.
-const openLibraryFields = "title,author_name,first_publish_year,isbn,key"
+// the response to just the fields the resolver reads. Beyond the bibliographic
+// basics it asks for the availability signals (ebook_access, has_fulltext, ia,
+// cover_i) so a publicly readable book can be surfaced with a direct archive.org
+// link.
+const openLibraryFields = "title,author_name,first_publish_year,isbn,key,ebook_access,has_fulltext,ia,cover_i"
+
+// openLibraryPublicAccess is the ebook_access value OpenLibrary uses for a book that
+// is freely readable in full on the Internet Archive (as opposed to "borrowable",
+// "printdisabled" or "no_ebook").
+const openLibraryPublicAccess = "public"
+
+// openLibraryEmailRate (with a contact email) and openLibraryAnonRate (without) are
+// the inter-request intervals OpenLibrary's etiquette grants: an identified caller
+// may go faster (2 rps) than an anonymous one (1 rps). Each is the delay between
+// requests, so a smaller interval is the higher rate.
+// https://openlibrary.org/developers/api
+const (
+	openLibraryEmailRate = time.Second / 2 // 2 rps
+	openLibraryAnonRate  = time.Second     // 1 rps
+)
 
 // OpenLibraryProvider is a keyless query resolver that turns fuzzy title/author
 // queries into canonical identifiers (ISBN/title/year) which feed a Library Genesis
-// search. It is NOT a download source, so its results never carry a PDF URL and are
-// never marked open-access. Its limiter and http.Client are self-contained, so it
-// never shares state with libgen's client.
+// search. It is primarily a resolver, not a download source, so its results carry no
+// PDF URL; the one exception is a publicly readable book, which it surfaces with a
+// free-to-read archive.org link and marks open-access. Its limiter and http.Client
+// are self-contained, so it never shares state with libgen's client.
 type OpenLibraryProvider struct {
-	client  *http.Client
-	limiter *rate.Limiter
+	client    *http.Client
+	limiter   *rate.Limiter
+	userAgent string
 }
 
-// NewOpenLibrary constructs an OpenLibraryProvider with its own http.Client and a
-// rate limiter pacing requests to a polite 2 requests/second (burst 2).
-func NewOpenLibrary() *OpenLibraryProvider {
+// NewOpenLibrary constructs an OpenLibraryProvider with its own http.Client. When a
+// contact email is supplied it is advertised in the User-Agent and the limiter is
+// paced to OpenLibrary's identified allowance (2 rps); without one the provider
+// stays anonymous and drops to the unidentified allowance (1 rps), honoring
+// https://openlibrary.org/developers/api.
+func NewOpenLibrary(email string) *OpenLibraryProvider {
+	email = strings.TrimSpace(email)
+	ua := discoveryUserAgent
+	every := openLibraryAnonRate
+	if email != "" {
+		ua += " (mailto:" + email + ")"
+		every = openLibraryEmailRate
+	}
 	return &OpenLibraryProvider{
-		client:  newDiscoveryClient(),
-		limiter: rate.NewLimiter(rate.Every(time.Second), 2),
+		client:    newDiscoveryClient(),
+		limiter:   rate.NewLimiter(rate.Every(every), 2),
+		userAgent: ua,
 	}
 }
 
@@ -65,7 +96,7 @@ func (p *OpenLibraryProvider) Search(ctx context.Context, query string, limit in
 
 	rawURL := buildOpenLibraryURL(query, limit)
 
-	status, body, err := boundedGet(ctx, p.client, rawURL)
+	status, body, err := boundedGetUA(ctx, p.client, rawURL, p.userAgent)
 	if err != nil {
 		// Context errors propagate so the federation layer can tell "caller went
 		// away" from "source degraded"; everything else degrades to empty.
@@ -115,6 +146,19 @@ type openLibraryDoc struct {
 	FirstPublishYear int      `json:"first_publish_year"`
 	ISBN             []string `json:"isbn"`
 	Key              string   `json:"key"`
+	// EbookAccess is the availability tier ("public", "borrowable",
+	// "printdisabled", "no_ebook"); only "public" is freely readable in full.
+	EbookAccess string `json:"ebook_access"`
+	// HasFulltext reports whether OpenLibrary holds any full-text scan; it is
+	// requested for client display and gates the readable-book signal alongside
+	// EbookAccess.
+	HasFulltext bool `json:"has_fulltext"`
+	// IA holds the Internet Archive identifiers backing the book; the first one
+	// forms the archive.org "details" URL for a publicly readable copy.
+	IA []string `json:"ia"`
+	// CoverI is the OpenLibrary cover id, requested so a client can render a cover
+	// thumbnail (https://covers.openlibrary.org/b/id/<CoverI>-L.jpg).
+	CoverI int `json:"cover_i"`
 }
 
 // parseOpenLibraryDocs decodes an OpenLibrary search envelope into DiscoveryResults,
@@ -134,21 +178,40 @@ func parseOpenLibraryDocs(body []byte) []DiscoveryResult {
 
 // openLibraryDocToResult maps one OpenLibrary doc onto a DiscoveryResult: the title,
 // "; "-joined author names, the first-publish year, and the first ISBN (empty when
-// none). Origin is "openlibrary"; because this is a resolver and not a download
-// source, DOI/PDFURL stay empty and OpenAccess stays false.
+// none). Origin is "openlibrary". For most docs this is a resolver hit — DOI/PDFURL
+// stay empty and OpenAccess is false — but a publicly readable book (ebook_access
+// "public" with an Internet Archive id) additionally carries a free-to-read
+// archive.org link and is marked open-access.
 func openLibraryDocToResult(doc openLibraryDoc) DiscoveryResult {
 	year := ""
 	if doc.FirstPublishYear > 0 {
 		year = strconv.Itoa(doc.FirstPublishYear)
 	}
+	archiveURL := openLibraryArchiveURL(doc)
 	return DiscoveryResult{
 		Origin:     "openlibrary",
 		Title:      strings.TrimSpace(doc.Title),
 		Authors:    openLibraryAuthors(doc.AuthorName),
 		Year:       year,
 		ISBN:       firstNonEmpty(doc.ISBN),
-		OpenAccess: false,
+		ArchiveURL: archiveURL,
+		OpenAccess: archiveURL != "",
 	}
+}
+
+// openLibraryArchiveURL returns a free-to-read archive.org "details" URL when the
+// doc is a publicly readable book — ebook_access "public", full text held, and an
+// Internet Archive id present — and "" otherwise. The id is path-escaped so an odd
+// identifier cannot corrupt the URL.
+func openLibraryArchiveURL(doc openLibraryDoc) string {
+	if doc.EbookAccess != openLibraryPublicAccess || !doc.HasFulltext {
+		return ""
+	}
+	ia := firstNonEmpty(doc.IA)
+	if ia == "" {
+		return ""
+	}
+	return "https://archive.org/details/" + url.PathEscape(ia)
 }
 
 // openLibraryAuthors joins author names with "; ", skipping any entry that collapses

--- a/internal/discovery/openlibrary_test.go
+++ b/internal/discovery/openlibrary_test.go
@@ -5,8 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 // openLibraryDocsFixture is a realistic two-doc OpenLibrary search response. Doc A
@@ -52,7 +55,7 @@ func TestOpenLibrary_ResolvesDocs(t *testing.T) {
 	defer srv.Close()
 	setOpenLibraryBase(t, srv.URL)
 
-	got, err := NewOpenLibrary().Search(context.Background(), "go programming", 5)
+	got, err := NewOpenLibrary("").Search(context.Background(), "go programming", 5)
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil", err)
 	}
@@ -91,6 +94,126 @@ func TestOpenLibrary_ResolvesDocs(t *testing.T) {
 	}
 }
 
+// openLibraryPublicFixture is a two-doc response exercising the availability
+// fields: doc A is a publicly readable book (ebook_access "public", has_fulltext,
+// an ia id), so it must gain a free-to-read archive.org URL and OpenAccess=true;
+// doc B is only borrowable, so it must stay a plain resolver hit (no ArchiveURL,
+// OpenAccess=false).
+const openLibraryPublicFixture = `{
+  "docs": [
+    {
+      "title": "A Public Domain Classic",
+      "author_name": ["Some Author"],
+      "first_publish_year": 1890,
+      "ebook_access": "public",
+      "has_fulltext": true,
+      "ia": ["apublicdomainclassic00auth", "apublicdomainclassic00auth_djvu"],
+      "cover_i": 12345,
+      "key": "/works/OL1W"
+    },
+    {
+      "title": "A Borrowable Book",
+      "author_name": ["Other Author"],
+      "first_publish_year": 2010,
+      "ebook_access": "borrowable",
+      "has_fulltext": true,
+      "ia": ["aborrowablebook00auth"],
+      "key": "/works/OL2W"
+    }
+  ]
+}`
+
+// TestOpenLibrary_PublicBookArchiveURL verifies that a publicly readable book gains
+// a free-to-read archive.org URL and is marked open-access, while a merely
+// borrowable book stays a plain resolver hit.
+func TestOpenLibrary_PublicBookArchiveURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(openLibraryPublicFixture))
+	}))
+	defer srv.Close()
+	setOpenLibraryBase(t, srv.URL)
+
+	got, err := NewOpenLibrary("").Search(context.Background(), "public domain", 5)
+	if err != nil {
+		t.Fatalf("Search() error = %v, want nil", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("Search() returned %d results, want 2", len(got))
+	}
+	if got[0].ArchiveURL != "https://archive.org/details/apublicdomainclassic00auth" {
+		t.Errorf("public book ArchiveURL = %q, want the archive.org details URL", got[0].ArchiveURL)
+	}
+	if !got[0].OpenAccess {
+		t.Error("public book OpenAccess = false, want true (freely readable)")
+	}
+	if got[1].ArchiveURL != "" {
+		t.Errorf("borrowable book ArchiveURL = %q, want empty (not public)", got[1].ArchiveURL)
+	}
+	if got[1].OpenAccess {
+		t.Error("borrowable book OpenAccess = true, want false")
+	}
+}
+
+// TestOpenLibrary_AvailabilityFieldsRequested verifies the search request asks for
+// the availability projection (ebook_access, has_fulltext, ia, cover_i) so a
+// readable book can be recognized.
+func TestOpenLibrary_AvailabilityFieldsRequested(t *testing.T) {
+	var gotFields string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFields = r.URL.Query().Get("fields")
+		_, _ = w.Write([]byte(openLibraryDocsFixture))
+	}))
+	defer srv.Close()
+	setOpenLibraryBase(t, srv.URL)
+
+	if _, err := NewOpenLibrary("").Search(context.Background(), "q", 5); err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	for _, field := range []string{"ebook_access", "has_fulltext", "ia", "cover_i"} {
+		if !strings.Contains(gotFields, field) {
+			t.Errorf("fields projection %q missing %q", gotFields, field)
+		}
+	}
+}
+
+// TestOpenLibrary_UserAgentEtiquette verifies OpenLibrary etiquette: a configured
+// contact email is advertised in the User-Agent (unlocking the identified rate),
+// while an anonymous provider sends the bare discovery agent with no mailto.
+func TestOpenLibrary_UserAgentEtiquette(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.UserAgent()
+		_, _ = w.Write([]byte(openLibraryDocsFixture))
+	}))
+	defer srv.Close()
+	setOpenLibraryBase(t, srv.URL)
+
+	if _, err := NewOpenLibrary("dev@example.com").Search(context.Background(), "q", 5); err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if !strings.Contains(gotUA, "mailto:dev@example.com") {
+		t.Errorf("User-Agent = %q, want it to carry the contact email", gotUA)
+	}
+
+	if _, err := NewOpenLibrary("").Search(context.Background(), "q", 5); err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if strings.Contains(gotUA, "mailto:") {
+		t.Errorf("anonymous User-Agent = %q, want no mailto", gotUA)
+	}
+}
+
+// TestOpenLibrary_RateFromEmail verifies the limiter rate follows the etiquette: an
+// identified provider is paced to the 2 rps interval and an anonymous one to 1 rps.
+func TestOpenLibrary_RateFromEmail(t *testing.T) {
+	if got := NewOpenLibrary("dev@example.com").limiter.Limit(); got != rate.Every(openLibraryEmailRate) {
+		t.Errorf("identified limit = %v, want %v (2 rps)", got, rate.Every(openLibraryEmailRate))
+	}
+	if got := NewOpenLibrary("").limiter.Limit(); got != rate.Every(openLibraryAnonRate) {
+		t.Errorf("anonymous limit = %v, want %v (1 rps)", got, rate.Every(openLibraryAnonRate))
+	}
+}
+
 // TestOpenLibrary_FieldsAndLimit verifies that the request carries a fields
 // projection and that the limit is clamped before being sent: a non-positive limit
 // falls back to the default "10" and an over-large limit is clamped to "50", both
@@ -104,7 +227,7 @@ func TestOpenLibrary_FieldsAndLimit(t *testing.T) {
 	defer srv.Close()
 	setOpenLibraryBase(t, srv.URL)
 
-	if _, err := NewOpenLibrary().Search(context.Background(), "q", 0); err != nil {
+	if _, err := NewOpenLibrary("").Search(context.Background(), "q", 0); err != nil {
 		t.Fatalf("Search(limit=0) error = %v", err)
 	}
 	if gotQuery.Get("fields") == "" {
@@ -114,7 +237,7 @@ func TestOpenLibrary_FieldsAndLimit(t *testing.T) {
 		t.Errorf("limit=0 sent limit=%q, want default 10", got)
 	}
 
-	if _, err := NewOpenLibrary().Search(context.Background(), "q", 9999); err != nil {
+	if _, err := NewOpenLibrary("").Search(context.Background(), "q", 9999); err != nil {
 		t.Fatalf("Search(limit=9999) error = %v", err)
 	}
 	if got := gotQuery.Get("limit"); got != "50" {
@@ -132,7 +255,7 @@ func TestOpenLibrary_Non200ReturnsEmpty(t *testing.T) {
 	defer srv.Close()
 	setOpenLibraryBase(t, srv.URL)
 
-	got, err := NewOpenLibrary().Search(context.Background(), "anything", 5)
+	got, err := NewOpenLibrary("").Search(context.Background(), "anything", 5)
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil on non-200", err)
 	}
@@ -153,7 +276,7 @@ func TestOpenLibrary_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	got, err := NewOpenLibrary().Search(ctx, "go programming", 5)
+	got, err := NewOpenLibrary("").Search(ctx, "go programming", 5)
 	if err == nil {
 		t.Fatalf("Search() error = nil, want a context error")
 	}
@@ -165,7 +288,7 @@ func TestOpenLibrary_ContextCancelled(t *testing.T) {
 // TestOpenLibraryProvider_Name verifies the provider stamps the "openlibrary"
 // origin.
 func TestOpenLibraryProvider_Name(t *testing.T) {
-	if got := NewOpenLibrary().Name(); got != "openlibrary" {
+	if got := NewOpenLibrary("").Name(); got != "openlibrary" {
 		t.Errorf("Name() = %q, want %q", got, "openlibrary")
 	}
 }
@@ -181,7 +304,7 @@ func TestOpenLibrary_TransportErrorReturnsEmpty(t *testing.T) {
 	srv.Close() // close so the address refuses connections
 	setOpenLibraryBase(t, base)
 
-	got, err := NewOpenLibrary().Search(context.Background(), "go programming", 5)
+	got, err := NewOpenLibrary("").Search(context.Background(), "go programming", 5)
 	if err != nil {
 		t.Fatalf("Search() error = %v, want nil on a transport error", err)
 	}
@@ -207,7 +330,7 @@ func TestOpenLibrary_ContextDeadlineDuringRequest(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	got, err := NewOpenLibrary().Search(ctx, "go programming", 5)
+	got, err := NewOpenLibrary("").Search(ctx, "go programming", 5)
 	if err == nil {
 		t.Fatal("Search() error = nil, want a context deadline error")
 	}

--- a/internal/libgen/client.go
+++ b/internal/libgen/client.go
@@ -63,6 +63,11 @@ type Client struct {
 	// tolerate a higher rate, so enrichment must never be starved by (or starve) the
 	// mirror budget.
 	enrichLimiter *rate.Limiter
+	// olLimiter governs the OpenLibrary enrichment hops specifically. OpenLibrary
+	// asks callers to stay within 1 req/s unidentified or up to ~3 req/s with a
+	// contact email (https://openlibrary.org/developers/api), a tighter budget than
+	// Crossref's, so it gets its own limiter rather than sharing enrichLimiter.
+	olLimiter *rate.Limiter
 	// enrichEmail is the contact address advertised to Crossref's polite pool via
 	// the User-Agent mailto. It reuses cfg.UnpaywallEmail and may be empty.
 	enrichEmail string
@@ -216,12 +221,19 @@ func New(m MirrorLister, cfg *config.Config, opts ...Option) *Client {
 	// non-positive value so the channel never becomes an unbuffered (deadlocking)
 	// zero-capacity semaphore.
 	maxConcurrent := max(cfg.MaxConcurrentDownloads, 1)
+	// OpenLibrary's etiquette grants a higher rate to identified callers; pick the
+	// enrichment OL rate from whether a contact email is configured.
+	olRPS := openLibraryEnrichAnonRPS
+	if strings.TrimSpace(cfg.UnpaywallEmail) != "" {
+		olRPS = openLibraryEnrichRPS
+	}
 	c := &Client{
 		mirrors:          m,
 		http:             &http.Client{Timeout: cfg.Timeout},
 		dl:               &http.Client{},
 		limiter:          rate.NewLimiter(rate.Limit(cfg.RateRPS), cfg.RateBurst),
 		enrichLimiter:    rate.NewLimiter(5, 5),
+		olLimiter:        rate.NewLimiter(rate.Limit(olRPS), openLibraryEnrichBurst),
 		enrichEmail:      cfg.UnpaywallEmail,
 		retry:            cfg.RetryAttempts,
 		backoffBase:      defaultBackoffBase,

--- a/internal/libgen/enrich.go
+++ b/internal/libgen/enrich.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 // enrichTimeout is the hard wall-clock budget for a whole Enrich call: both the
@@ -21,6 +23,16 @@ const enrichTimeout = 6 * time.Second
 // enrichMaxBody bounds how many bytes of any enrichment response are read before
 // decoding, guarding against an unexpectedly large or hostile body.
 const enrichMaxBody = 1 << 20 // 1 MiB
+
+// openLibraryEnrichRPS and openLibraryEnrichAnonRPS are the OpenLibrary enrichment
+// request rates: identified (a contact email is configured) versus anonymous,
+// honoring https://openlibrary.org/developers/api. openLibraryEnrichBurst lets the
+// two-hop ISBN → work lookup proceed without an inter-hop stall.
+const (
+	openLibraryEnrichRPS     = 3
+	openLibraryEnrichAnonRPS = 1
+	openLibraryEnrichBurst   = 3
+)
 
 // crossrefBase and openLibraryBase are the enrichment API roots. They are package
 // variables (not constants) so tests can point them at local httptest servers.
@@ -115,13 +127,14 @@ func (c *Client) Enrich(ctx context.Context, doi, isbn string) *Enrichment {
 	return &Enrichment{Crossref: cr, OpenLibrary: ol}
 }
 
-// enrichGet issues a GET to an enrichment API after waiting on the separate
-// enrichment rate limiter, setting the polite-pool User-Agent (the package
-// userAgent plus a mailto when a contact email is configured). It returns the
-// response on a 200 and nil otherwise (including any transport or limiter error),
-// so callers degrade silently. The caller owns closing the returned body.
-func (c *Client) enrichGet(ctx context.Context, rawURL string) *http.Response {
-	if err := c.enrichLimiter.Wait(ctx); err != nil {
+// enrichGet issues a GET to an enrichment API after waiting on the supplied rate
+// limiter, setting the polite-pool User-Agent (the package userAgent plus a mailto
+// when a contact email is configured). Crossref and OpenLibrary pass different
+// limiters so each API is paced to its own etiquette. It returns the response on a
+// 200 and nil otherwise (including any transport or limiter error), so callers
+// degrade silently. The caller owns closing the returned body.
+func (c *Client) enrichGet(ctx context.Context, rawURL string, limiter *rate.Limiter) *http.Response {
+	if err := limiter.Wait(ctx); err != nil {
 		return nil
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
@@ -150,7 +163,7 @@ func (c *Client) fetchCrossref(ctx context.Context, doi string) *CrossrefWork {
 	// Preserve the DOI's slashes: escapeDOIPath escapes each path segment but
 	// keeps "/" literal, since Crossref routes on the raw DOI path (a %2F-encoded
 	// slash can miss the record). Same reason the download DOI sources use it.
-	resp := c.enrichGet(ctx, c.crossrefURL()+"/works/"+escapeDOIPath(doi))
+	resp := c.enrichGet(ctx, c.crossrefURL()+"/works/"+escapeDOIPath(doi), c.enrichLimiter)
 	if resp == nil {
 		return nil
 	}
@@ -244,7 +257,7 @@ func (c *Client) fetchOpenLibrary(ctx context.Context, isbn string) *OLBook {
 // fetchOLISBN requests hop 1, the OpenLibrary ISBN record, returning nil on any
 // failure (non-200, transport error, or unparseable body).
 func (c *Client) fetchOLISBN(ctx context.Context, isbn string) *olISBNRecord {
-	resp := c.enrichGet(ctx, c.openLibraryURL()+"/isbn/"+url.PathEscape(isbn)+".json")
+	resp := c.enrichGet(ctx, c.openLibraryURL()+"/isbn/"+url.PathEscape(isbn)+".json", c.olLimiter)
 	if resp == nil {
 		return nil
 	}
@@ -268,7 +281,7 @@ type olWorkRecord struct {
 // Subjects and Description from it. It is silent on any failure — the ISBN
 // record's cover/link already gathered on hop 1 still stand.
 func (c *Client) fetchOLWork(ctx context.Context, workKey string, book *OLBook) {
-	resp := c.enrichGet(ctx, c.openLibraryURL()+workKey+".json")
+	resp := c.enrichGet(ctx, c.openLibraryURL()+workKey+".json", c.olLimiter)
 	if resp == nil {
 		return
 	}

--- a/internal/libgen/enrich_test.go
+++ b/internal/libgen/enrich_test.go
@@ -8,7 +8,29 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/jmrplens/libgen-mcp/internal/config"
 )
+
+// TestNew_OpenLibraryEnrichLimiter verifies the enrichment OpenLibrary limiter is
+// paced by the presence of a contact email: identified deployments get the 3 rps
+// allowance, anonymous ones drop to 1 rps, honoring OpenLibrary's etiquette.
+func TestNew_OpenLibraryEnrichLimiter(t *testing.T) {
+	base := &config.Config{Timeout: time.Second, RateRPS: 1, RateBurst: 1, MaxConcurrentDownloads: 1}
+
+	withEmail := *base
+	withEmail.UnpaywallEmail = "dev@example.com"
+	if got := New(staticMirrors{}, &withEmail).olLimiter.Limit(); got != rate.Limit(openLibraryEnrichRPS) {
+		t.Errorf("identified olLimiter = %v, want %v (3 rps)", got, rate.Limit(openLibraryEnrichRPS))
+	}
+
+	anon := *base
+	if got := New(staticMirrors{}, &anon).olLimiter.Limit(); got != rate.Limit(openLibraryEnrichAnonRPS) {
+		t.Errorf("anonymous olLimiter = %v, want %v (1 rps)", got, rate.Limit(openLibraryEnrichAnonRPS))
+	}
+}
 
 // crossrefFixture is a realistic Crossref `{"message":{...}}` body carrying the
 // container title, ISSN, volume, issue, publisher, published year, reference and
@@ -205,15 +227,15 @@ func TestEnrichGet_ErrorPaths(t *testing.T) {
 
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
-	if resp := c.enrichGet(canceled, "http://example.invalid"); resp != nil {
+	if resp := c.enrichGet(canceled, "http://example.invalid", c.enrichLimiter); resp != nil {
 		_ = resp.Body.Close()
 		t.Error("enrichGet with a canceled context should return nil (limiter wait fails)")
 	}
-	if resp := c.enrichGet(context.Background(), "http://\x7f"); resp != nil {
+	if resp := c.enrichGet(context.Background(), "http://\x7f", c.enrichLimiter); resp != nil {
 		_ = resp.Body.Close()
 		t.Error("enrichGet with an unbuildable URL should return nil")
 	}
-	if resp := c.enrichGet(context.Background(), "http://127.0.0.1:0"); resp != nil {
+	if resp := c.enrichGet(context.Background(), "http://127.0.0.1:0", c.enrichLimiter); resp != nil {
 		_ = resp.Body.Close()
 		t.Error("enrichGet against an unreachable address should return nil")
 	}
@@ -232,7 +254,7 @@ func TestEnrichGet_PoliteMailtoUA(t *testing.T) {
 	c := newTestClient(staticMirrors{})
 	c.enrichEmail = "polite@example.com"
 
-	resp := c.enrichGet(context.Background(), srv.URL)
+	resp := c.enrichGet(context.Background(), srv.URL, c.enrichLimiter)
 	if resp == nil {
 		t.Fatal("enrichGet returned nil for a 200 response")
 	}

--- a/internal/libgen/source_unpaywall.go
+++ b/internal/libgen/source_unpaywall.go
@@ -35,12 +35,61 @@ type unpaywallSource struct {
 	baseURL string
 }
 
-// unpaywallResponse is the subset of the Unpaywall v2 record consulted here.
+// unpaywallResponse is the subset of the Unpaywall v2 record consulted here: the OA
+// flag, Unpaywall's own best location, and the full list of OA locations scanned
+// when the best one carries no direct PDF link.
 type unpaywallResponse struct {
-	IsOA           bool `json:"is_oa"`
-	BestOALocation *struct {
-		URLForPDF string `json:"url_for_pdf"`
-	} `json:"best_oa_location"`
+	IsOA           bool                `json:"is_oa"`
+	BestOALocation *unpaywallLocation  `json:"best_oa_location"`
+	OALocations    []unpaywallLocation `json:"oa_locations"`
+}
+
+// unpaywallLocation is the subset of one Unpaywall OA location read here: a direct
+// PDF link, a landing URL, and the host_type/version used to prefer a
+// published/publisher copy over a repository preprint.
+type unpaywallLocation struct {
+	URLForPDF string `json:"url_for_pdf"`
+	URL       string `json:"url"`
+	HostType  string `json:"host_type"`
+	Version   string `json:"version"`
+}
+
+// isPublished reports whether this location is the published/publisher copy, the
+// version preferred when several OA locations expose a PDF.
+func (loc unpaywallLocation) isPublished() bool {
+	return loc.Version == "publishedVersion" || loc.HostType == "publisher"
+}
+
+// bestPDFURL picks a directly-downloadable PDF from the record: Unpaywall's own best
+// location first, then a published/publisher OA location, then any OA location that
+// exposes a url_for_pdf. It returns "" when no location offers a PDF link.
+func (rec unpaywallResponse) bestPDFURL() string {
+	if rec.BestOALocation != nil && rec.BestOALocation.URLForPDF != "" {
+		return rec.BestOALocation.URLForPDF
+	}
+	var fallback string
+	for i := range rec.OALocations {
+		loc := rec.OALocations[i]
+		if loc.URLForPDF == "" {
+			continue
+		}
+		if loc.isPublished() {
+			return loc.URLForPDF
+		}
+		if fallback == "" {
+			fallback = loc.URLForPDF
+		}
+	}
+	return fallback
+}
+
+// landingURL is the last-resort URL when no location exposes a PDF: the best OA
+// location's landing page, which commonly redirects to the article file.
+func (rec unpaywallResponse) landingURL() string {
+	if rec.BestOALocation != nil {
+		return rec.BestOALocation.URL
+	}
+	return ""
 }
 
 // Name identifies the Unpaywall source.
@@ -107,11 +156,22 @@ func (s unpaywallSource) Resolve(ctx context.Context, it Item) (Resolved, error)
 		return Resolved{}, fmt.Errorf("unpaywall: decoding response for %q: %w", it.DOI, decErr)
 	}
 
-	if !rec.IsOA || rec.BestOALocation == nil || rec.BestOALocation.URLForPDF == "" {
+	// Two distinct diagnoses: a paywalled DOI ("not open access") is a different
+	// outcome from an OA DOI Unpaywall simply exposes no fetchable location for
+	// ("no open-access PDF"). Keeping them separate lets the chain and any log tell
+	// the two apart.
+	if !rec.IsOA {
+		return Resolved{}, fmt.Errorf("unpaywall: %q is not open access", it.DOI)
+	}
+	fileURL := rec.bestPDFURL()
+	if fileURL == "" {
+		fileURL = rec.landingURL()
+	}
+	if fileURL == "" {
 		return Resolved{}, fmt.Errorf("unpaywall: no open-access PDF for %q", it.DOI)
 	}
 	return Resolved{
-		FileURL:   rec.BestOALocation.URLForPDF,
+		FileURL:   fileURL,
 		VerifyMD5: false,
 		Ext:       "pdf",
 	}, nil

--- a/internal/libgen/source_unpaywall_test.go
+++ b/internal/libgen/source_unpaywall_test.go
@@ -69,6 +69,130 @@ func TestUnpaywallResolveNotOA(t *testing.T) {
 	}
 }
 
+// TestUnpaywall_OALocationsPreferPublished verifies that when best_oa_location
+// carries no direct PDF link, Resolve scans oa_locations and prefers a
+// published/publisher version's url_for_pdf over an earlier repository version.
+func TestUnpaywall_OALocationsPreferPublished(t *testing.T) {
+	const body = `{
+	  "is_oa": true,
+	  "best_oa_location": {"url_for_pdf": null, "url": "https://landing.example/article"},
+	  "oa_locations": [
+	    {"url_for_pdf": "https://repo.example/preprint.pdf", "url": "https://repo.example/rec", "host_type": "repository", "version": "submittedVersion"},
+	    {"url_for_pdf": "https://publisher.example/final.pdf", "url": "https://publisher.example/rec", "host_type": "publisher", "version": "publishedVersion"}
+	  ]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	s := unpaywallSource{email: "mail@jmrp.io", http: srv.Client(), baseURL: srv.URL}
+
+	res, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if res.FileURL != "https://publisher.example/final.pdf" {
+		t.Errorf("FileURL = %q, want the published/publisher PDF", res.FileURL)
+	}
+}
+
+// TestUnpaywall_OALocationsAnyPDF verifies that when no location is a
+// published/publisher version, Resolve still returns the first oa_location that
+// exposes a url_for_pdf rather than failing.
+func TestUnpaywall_OALocationsAnyPDF(t *testing.T) {
+	const body = `{
+	  "is_oa": true,
+	  "best_oa_location": {"url_for_pdf": null, "url": "https://landing.example/article"},
+	  "oa_locations": [
+	    {"url_for_pdf": null, "url": "https://repo.example/landing", "host_type": "repository", "version": "submittedVersion"},
+	    {"url_for_pdf": "https://repo.example/preprint.pdf", "url": "https://repo.example/rec", "host_type": "repository", "version": "acceptedVersion"}
+	  ]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	s := unpaywallSource{email: "mail@jmrp.io", http: srv.Client(), baseURL: srv.URL}
+
+	res, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if res.FileURL != "https://repo.example/preprint.pdf" {
+		t.Errorf("FileURL = %q, want the only PDF-bearing location", res.FileURL)
+	}
+}
+
+// TestUnpaywall_LandingURLLastResort verifies that an OA record exposing no
+// url_for_pdf anywhere falls back to best_oa_location.url (the landing page) rather
+// than failing, since that URL commonly redirects to the article file.
+func TestUnpaywall_LandingURLLastResort(t *testing.T) {
+	const body = `{
+	  "is_oa": true,
+	  "best_oa_location": {"url_for_pdf": null, "url": "https://landing.example/article"},
+	  "oa_locations": [
+	    {"url_for_pdf": null, "url": "https://landing.example/article", "host_type": "publisher", "version": "publishedVersion"}
+	  ]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	s := unpaywallSource{email: "mail@jmrp.io", http: srv.Client(), baseURL: srv.URL}
+
+	res, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if res.FileURL != "https://landing.example/article" {
+		t.Errorf("FileURL = %q, want the landing-page fallback", res.FileURL)
+	}
+}
+
+// TestUnpaywall_DistinctDiagnoses verifies the error taxonomy stays distinct: a
+// not-open-access record reports "not open access", while an OA record with no
+// downloadable location reports "no open-access PDF". The two are separate
+// diagnoses so a caller can tell a paywalled DOI from an OA one Unpaywall simply
+// cannot serve a file for.
+func TestUnpaywall_DistinctDiagnoses(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "not OA",
+			body: `{"is_oa": false, "best_oa_location": null, "oa_locations": []}`,
+			want: "not open access",
+		},
+		{
+			name: "OA but no downloadable location",
+			body: `{"is_oa": true, "best_oa_location": null, "oa_locations": []}`,
+			want: "no open-access PDF",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			t.Cleanup(srv.Close)
+			s := unpaywallSource{email: "mail@jmrp.io", http: srv.Client(), baseURL: srv.URL}
+			_, err := s.Resolve(context.Background(), Item{DOI: "10.1/x"})
+			if err == nil {
+				t.Fatalf("Resolve() error = nil, want %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Resolve() error = %q, want it to contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
 // TestUnpaywallRawSlashInPath verifies the DOI keeps its raw slash in the request
 // path (the documented /v2/<doi> shape) rather than being percent-encoded to %2F.
 func TestUnpaywallRawSlashInPath(t *testing.T) {

--- a/internal/tools/markdown.go
+++ b/internal/tools/markdown.go
@@ -139,14 +139,17 @@ func writeOpenAccess(b *strings.Builder, hits []discovery.DiscoveryResult) {
 }
 
 // openAccessLocator renders the most actionable identifier for an OA hit: its doi,
-// else an arXiv pdf_url, else an OpenLibrary isbn, each labeled so the reader knows
-// which key it is.
+// else an arXiv pdf_url, else a free-to-read archive.org url, else an OpenLibrary
+// isbn, each labeled so the reader knows which key it is. The archive.org url ranks
+// above the isbn because it is directly readable, not just a lookup key.
 func openAccessLocator(h discovery.DiscoveryResult) string {
 	switch {
 	case h.DOI != "":
 		return "doi:" + h.DOI
 	case h.PDFURL != "":
 		return "pdf_url:" + h.PDFURL
+	case h.ArchiveURL != "":
+		return "archive_url:" + h.ArchiveURL
 	case h.ISBN != "":
 		return "isbn:" + h.ISBN
 	default:

--- a/internal/tools/markdown_test.go
+++ b/internal/tools/markdown_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 // TestOpenAccessLocator covers every arm of openAccessLocator: a DOI wins first,
-// then an arXiv pdf_url, then an OpenLibrary isbn, and finally the empty default
-// when a hit carries none of them. Each present arm is labeled with its key.
+// then an arXiv pdf_url, then a free-to-read archive.org url, then an OpenLibrary
+// isbn, and finally the empty default when a hit carries none of them. Each present
+// arm is labeled with its key.
 func TestOpenAccessLocator(t *testing.T) {
 	cases := []struct {
 		name string
@@ -20,6 +21,7 @@ func TestOpenAccessLocator(t *testing.T) {
 	}{
 		{"doi wins", discovery.DiscoveryResult{DOI: "10.1/x", PDFURL: "http://p", ISBN: "978"}, "doi:10.1/x"},
 		{"pdf_url", discovery.DiscoveryResult{PDFURL: "http://p/f.pdf", ISBN: "978"}, "pdf_url:http://p/f.pdf"},
+		{"archive_url over isbn", discovery.DiscoveryResult{ArchiveURL: "https://archive.org/details/x", ISBN: "978"}, "archive_url:https://archive.org/details/x"},
 		{"isbn", discovery.DiscoveryResult{ISBN: "9780131103627"}, "isbn:9780131103627"},
 		{"none", discovery.DiscoveryResult{Title: "T"}, ""},
 	}

--- a/site/src/content/docs/es/how-search-works.mdx
+++ b/site/src/content/docs/es/how-search-works.mdx
@@ -50,7 +50,7 @@ Cada resultado se etiqueta con un **`origin`** (origen) que indica qué buscador
 - **`libgen`** y **`annas`** — el resultado lleva un md5, más el formato y el tamaño del fichero, de modo que ambos se pueden comparar. Descárgalo con el argumento `md5` de `download`.
 - **`crossref`** — el resultado lleva un DOI. Descárgalo con el argumento `doi` de `download`.
 - **`arxiv`** — el resultado lleva una `pdf_url` directa. Descarga esa URL; `download` no acepta identificadores de arXiv.
-- **`openlibrary`** — el resultado lleva un `isbn` y un título, y ningún archivo. OpenLibrary es un catálogo, no un repositorio: úsalos para lanzar una `search` mejor dirigida.
+- **`openlibrary`** — el resultado lleva un `isbn` y un título. OpenLibrary es principalmente un catálogo, no un repositorio, así que úsalos para lanzar una `search` mejor dirigida — salvo que el libro sea de lectura pública, en cuyo caso también lleva un `archive_url` que puedes leer directamente en Internet Archive.
 
 ```mermaid
 flowchart LR

--- a/site/src/content/docs/es/tools.mdx
+++ b/site/src/content/docs/es/tools.mdx
@@ -92,7 +92,7 @@ Cada resultado lleva al menos un identificador accionable, según su `origin`:
 
 - **`doi` (crossref)** — pásalo a `download` o `read` igual que un DOI de un resultado de Library Genesis.
 - **`pdf_url` (siempre en arxiv; en crossref cuando hay un enlace directo a PDF publicado)** — un PDF de acceso abierto directamente descargable; obtenlo tú mismo (no es una descarga de Library Genesis, así que `download`/`read` no lo resuelven).
-- **`isbn`/`title` (openlibrary)** — OpenLibrary es un _resolutor de consultas_ sin clave, no una fuente de descarga: nunca lleva `pdf_url` y nunca se marca `open_access: true`. Usa su `isbn` o `title` canónicos para refinar una `search` de Library Genesis posterior.
+- **`isbn`/`title` (openlibrary)** — OpenLibrary es principalmente un _resolutor de consultas_ sin clave: usa su `isbn` o `title` canónicos para refinar una `search` de Library Genesis posterior. La única excepción es un libro de lectura pública — uno que OpenLibrary indica como libremente legible por completo en Internet Archive — que además lleva un `archive_url` (una página `https://archive.org/details/<id>` que puedes leer directamente) y se marca `open_access: true`.
 
 <Aside type="caution">
 	Los resultados se dedupan entre sí (por DOI normalizado, luego por

--- a/site/src/content/docs/how-search-works.mdx
+++ b/site/src/content/docs/how-search-works.mdx
@@ -50,7 +50,7 @@ Every result is labeled with an **`origin`** that says which searcher produced i
 - **`libgen`** and **`annas`** — the result carries an md5, plus the file's format and size, so the two can be compared. Download it with `download`'s `md5` argument.
 - **`crossref`** — the result carries a DOI. Download it with `download`'s `doi` argument.
 - **`arxiv`** — the result carries a direct `pdf_url`. Fetch that URL; `download` takes no arXiv identifier.
-- **`openlibrary`** — the result carries an `isbn` and a title, and no file at all. OpenLibrary is a catalog, not a repository: use those to run a better-targeted `search`.
+- **`openlibrary`** — the result carries an `isbn` and a title. OpenLibrary is mainly a catalog, not a repository, so use those to run a better-targeted `search` — unless the book is publicly readable, in which case it also carries an `archive_url` you can read directly on the Internet Archive.
 
 ```mermaid
 flowchart LR

--- a/site/src/content/docs/tools.mdx
+++ b/site/src/content/docs/tools.mdx
@@ -92,7 +92,7 @@ Each hit carries at least one actionable identifier, depending on its `origin`:
 
 - **`doi` (crossref)** — pass it to `download` or `read` exactly like a DOI from a Library Genesis result.
 - **`pdf_url` (arxiv always; crossref when a direct PDF link is published)** — a directly-fetchable open-access PDF; fetch it yourself (it is not a Library Genesis download, so `download`/`read` do not resolve it).
-- **`isbn`/`title` (openlibrary)** — OpenLibrary is a keyless _query resolver_, not a download source: it never carries a `pdf_url` and is never marked `open_access: true`. Use its canonical `isbn` or `title` to refine a follow-up Library Genesis `search`.
+- **`isbn`/`title` (openlibrary)** — OpenLibrary is mainly a keyless _query resolver_: use its canonical `isbn` or `title` to refine a follow-up Library Genesis `search`. The one exception is a publicly readable book — one OpenLibrary reports as freely readable in full on the Internet Archive — which additionally carries an `archive_url` (a `https://archive.org/details/<id>` page you can read directly) and is marked `open_access: true`.
 
 <Aside type="caution">
 	Hits are deduped against each other (by normalized DOI, then by title+year),


### PR DESCRIPTION
## Summary

Fixes several ways libgen-mcp's discovery and download sources misused their upstream APIs. Each fix is test-driven (httptest fixtures, no live calls) and behavior claims in the docs were updated in EN + ES.

- **Crossref open-access mislabel** — `open_access` was `true` whenever the work carried *any* license, but paywalled works routinely advertise proprietary publisher licenses. It is now derived from a defensible heuristic: a Creative Commons license URL (contains `creativecommons.org`) **or** a usable free full-text link.
- **Crossref query + link quality** — the query now uses `query.bibliographic` (citation-oriented field query) instead of generic `query=`. Each link's `intended-application` is modeled and read; `text-mining`/`similarity-checking` PDF links (which 403 for anonymous users) are skipped in favor of `unspecified`/reader links. `intended-application` is deliberately **not** added to `select=` — Crossref rejects it there with HTTP 400 (verified live); selecting `link` already returns the full Resource Link objects that carry it.
- **Unpaywall too-strict success** — the response model gained `oa_locations[]`; `Resolve` now scans all locations for a `url_for_pdf` (preferring the published/publisher version) and falls back to `best_oa_location.url` as a last resort, instead of accepting only `best_oa_location.url_for_pdf`. The error taxonomy is now genuinely distinct: "not open access" vs. "no open-access PDF".
- **OpenLibrary etiquette** — when a contact email is configured it is advertised in the User-Agent and the discovery limiter stays at 2 rps; without one it drops to 1 rps. The enrichment path gives OpenLibrary its own limiter (3 rps identified, 1 rps anonymous) instead of sharing Crossref's 5 rps budget.
- **OpenLibrary availability** — the search projection now requests `ebook_access,has_fulltext,ia,cover_i`. A publicly readable book (`ebook_access: public` with an Internet Archive id) surfaces a direct `archive_url` (`https://archive.org/details/<id>`) and is marked `open_access`, rendered consistently in the Markdown locator.
- **Anna's discovery provider unbounded** — `NewAnnas` now equips the provider with a bounded `http.Client`, and `Search` applies a per-call timeout, matching the arXiv/Crossref/OpenLibrary pattern so a stalled mirror cannot hang a search.
- **arXiv journal_ref** — `journal_ref` is extracted and surfaced as the result's `venue` (a short citation string, never an abstract).

### Deviations from the brief
- `intended-application` was **not** added to Crossref's `select=`: it is a nested link subfield, not a valid top-level select value, and requesting it returns HTTP 400 (confirmed against the live API). It is read from the `link` objects `select=link` already returns.
- arXiv `journal_ref` is surfaced via a new compact `venue` field on the result struct (DiscoveryResult had no existing venue/notes field). It rides the structured JSON channel and does not add a Markdown column, keeping tool output lean.

## Type of change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [x] Docs updated if behavior changed

<sub>Gates run green: `golangci-lint fmt --diff`, `golangci-lint run`, `go vet ./...`, godoc audit (0 findings), `go test ./...`, `go test -race`, `make cover-check` (98.1%), `make check-md-tables`, `make check-llms`.</sub>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens how discovery and download sources use upstream APIs to avoid OA mislabels, skip unusable links, respect provider etiquette, and prevent stalls. Updates Crossref, Unpaywall, OpenLibrary, arXiv, and Anna’s behavior, with docs and tests refreshed.

- **Bug Fixes**
  - Crossref: use `query.bibliographic`; skip `text-mining`/`similarity-checking` PDF links; mark `open_access` only for Creative Commons licenses or a usable PDF link.
  - Unpaywall: scan all `oa_locations` for `url_for_pdf` (prefer published/publisher); fall back to `best_oa_location.url`; distinct errors for “not open access” vs “no open-access PDF”.
  - Anna’s: bounded `http.Client` and per-call timeout so a stalled mirror can’t hang searches.
  - OpenLibrary: advertise contact email in User-Agent and pace to 2 rps (1 rps anonymous); enrichment uses its own limiter (3 rps identified, 1 rps anonymous).

- **New Features**
  - OpenLibrary: surface `archive_url` for publicly readable books and mark them `open_access`.
  - arXiv: expose `journal_ref` as a compact `venue` field.

<sup>Written for commit 17f5024d638afb1d30efbc713a514b062abd7aa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

