### PR TITLE
test(e2e): make the live suite prove what it claims

### DIFF
--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -2427,6 +2427,156 @@ func TestElicitUnpaywallEmail_InvalidEmail(t *testing.T) {
 	}
 }
 
+// annasProbeInput drives the "aprobe" tool below: it carries the DownloadInput
+// fields elicitAnnasKey branches on, plus the key the server is configured with.
+type annasProbeInput struct {
+	MD5           string `json:"md5,omitempty"`
+	Source        string `json:"source,omitempty"`
+	AnnasMember   bool   `json:"annas_member,omitempty"`
+	ConfiguredKey string `json:"configured_key,omitempty"`
+}
+
+// annasProbeOutput carries the key elicitAnnasKey produced back to the test.
+type annasProbeOutput struct {
+	Key string `json:"key"`
+}
+
+// newAnnasProbeSession wires an in-memory MCP server exposing an "aprobe" tool
+// that calls elicitAnnasKey with a config/input built from the request, so tests
+// can exercise its capability-gated branches through a real round-trip. A nil
+// handler means the client advertises no elicitation capability. It mirrors
+// newUnpaywallProbeSession, the harness for the sibling credential prompt.
+func newAnnasProbeSession(t *testing.T, handler func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error)) *mcp.ClientSession {
+	t.Helper()
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	mcp.AddTool(server, &mcp.Tool{Name: "aprobe", Description: "exercises elicitAnnasKey for tests"},
+		func(ctx context.Context, req *mcp.CallToolRequest, in annasProbeInput) (*mcp.CallToolResult, annasProbeOutput, error) {
+			cfg := &config.Config{AnnasKey: in.ConfiguredKey}
+			key := elicitAnnasKey(ctx, req, cfg, DownloadInput{
+				MD5: in.MD5, Source: in.Source, AnnasMember: in.AnnasMember,
+			})
+			return nil, annasProbeOutput{Key: key}, nil
+		})
+
+	st, ct := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatal(err)
+	}
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"},
+		&mcp.ClientOptions{ElicitationHandler: handler})
+	session, err := mcpClient.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { session.Close() })
+	return session
+}
+
+// callAprobe drives the aprobe tool once and returns the key elicitAnnasKey
+// produced.
+func callAprobe(t *testing.T, session *mcp.ClientSession, in annasProbeInput) string {
+	t.Helper()
+	args, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshaling aprobe input: %v", err)
+	}
+	res, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "aprobe", Arguments: json.RawMessage(args)})
+	if err != nil {
+		t.Fatalf("CallTool(aprobe) failed: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("aprobe returned a tool error: %+v", res.Content)
+	}
+	raw, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshaling aprobe output: %v", err)
+	}
+	var out annasProbeOutput
+	if uerr := json.Unmarshal(raw, &out); uerr != nil {
+		t.Fatalf("decoding aprobe output: %v", uerr)
+	}
+	return out.Key
+}
+
+// annasMemberBook is the input shape that makes elicitAnnasKey prompt: an md5
+// book download that explicitly opted in to the member tier.
+var annasMemberBook = annasProbeInput{MD5: "0123456789abcdef0123456789abcdef", AnnasMember: true}
+
+// TestElicitAnnasKey_AcceptedKeyIsUsed covers the happy path: an opted-in book
+// download against a keyless server prompts the client, and the accepted secret
+// comes back trimmed for use on this request only.
+func TestElicitAnnasKey_AcceptedKeyIsUsed(t *testing.T) {
+	session := newAnnasProbeSession(t, acceptHandler(map[string]any{"key": "  SECRET123  "}))
+	if got := callAprobe(t, session, annasMemberBook); got != "SECRET123" {
+		t.Errorf("an accepted key should come back trimmed, got %q", got)
+	}
+}
+
+// TestElicitAnnasKey_PinnedAnnasSourceStillPrompts covers the one named source the
+// per-call key can still take effect for: pinning source="annas" replaces the
+// configured (keyless) source with one carrying the elicited key, so the prompt
+// must still fire.
+func TestElicitAnnasKey_PinnedAnnasSourceStillPrompts(t *testing.T) {
+	session := newAnnasProbeSession(t, acceptHandler(map[string]any{"key": "SECRET123"}))
+	in := annasMemberBook
+	in.Source = "ANNAS" // case-insensitive by contract
+	if got := callAprobe(t, session, in); got != "SECRET123" {
+		t.Errorf("source=annas should still prompt for a key, got %q", got)
+	}
+}
+
+// TestElicitAnnasKey_SkippedBranches covers every arm that must collapse to ""
+// WITHOUT prompting. The handler would accept a key, so a non-empty result proves
+// the prompt fired where it should not have: each of these is a dead-end question
+// the user would be asked for nothing.
+func TestElicitAnnasKey_SkippedBranches(t *testing.T) {
+	cases := []struct {
+		name string
+		in   annasProbeInput
+		why  string
+	}{
+		{"no opt-in", annasProbeInput{MD5: annasMemberBook.MD5}, "the keyless IPFS path already works, so an unrequested prompt is a nag"},
+		{"no md5", annasProbeInput{AnnasMember: true}, "the member tier is a book path; there is nothing to fetch without an md5"},
+		{"server has a key", annasProbeInput{MD5: annasMemberBook.MD5, AnnasMember: true, ConfiguredKey: "CONFIGURED"}, "the configured key already covers the request"},
+		{"other source pinned", annasProbeInput{MD5: annasMemberBook.MD5, AnnasMember: true, Source: "libgen"}, "the per-call key can never reach a non-annas source"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			session := newAnnasProbeSession(t, acceptHandler(map[string]any{"key": "SECRET123"}))
+			if got := callAprobe(t, session, tc.in); got != "" {
+				t.Errorf("%s: expected no prompt and \"\", got %q", tc.why, got)
+			}
+		})
+	}
+}
+
+// TestElicitAnnasKey_NoCapability covers the fallback path: a client that never
+// advertised elicitation is not prompted, so the annas source stays keyless and
+// resolves over IPFS exactly as it does today.
+func TestElicitAnnasKey_NoCapability(t *testing.T) {
+	session := newAnnasProbeSession(t, nil)
+	if got := callAprobe(t, session, annasMemberBook); got != "" {
+		t.Errorf("a client without the elicitation capability should yield \"\", got %q", got)
+	}
+}
+
+// TestElicitAnnasKey_DeclineAndEmpty covers the two answers that must leave the
+// download keyless: a declined prompt, and an accepted prompt with a blank key
+// (the prompt itself offers "leave empty to download over IPFS instead").
+func TestElicitAnnasKey_DeclineAndEmpty(t *testing.T) {
+	declined := func(context.Context, *mcp.ElicitRequest) (*mcp.ElicitResult, error) {
+		return &mcp.ElicitResult{Action: "decline"}, nil
+	}
+	if got := callAprobe(t, newAnnasProbeSession(t, declined), annasMemberBook); got != "" {
+		t.Errorf("a declined prompt should yield \"\", got %q", got)
+	}
+	blank := acceptHandler(map[string]any{"key": "   "})
+	if got := callAprobe(t, newAnnasProbeSession(t, blank), annasMemberBook); got != "" {
+		t.Errorf("a blank key should yield \"\", got %q", got)
+	}
+}
+
 // TestSearchNextStepsForbidsInventingResults verifies an empty search tells the
 // model not to fill the gap. The recovery advice alone leaves the door open: a
 // model that has been asked to find something and told only "try broadening" can

--- a/test/e2e/capabilities_test.go
+++ b/test/e2e/capabilities_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/jmrplens/libgen-mcp/internal/config"
+	"github.com/jmrplens/libgen-mcp/internal/discovery"
 	"github.com/jmrplens/libgen-mcp/internal/libgen"
 	"github.com/jmrplens/libgen-mcp/internal/prompts"
 	"github.com/jmrplens/libgen-mcp/internal/tools"
@@ -392,22 +393,13 @@ func newReadSession(t *testing.T, ctx context.Context) (*libgen.Client, *mcp.Cli
 	return client, newToolSession(t, ctx, client, cfg, nil)
 }
 
-// smallestTargetIn searches one topic ordered by ascending size and returns the
-// smallest downloadable result (canonical md5, parseable non-zero size within the
-// polite cap). It SKIPS the calling test when no such target is available.
-func smallestTargetIn(t *testing.T, ctx context.Context, client *libgen.Client, topic, query string) libgen.Result {
+// readableTargetIn returns the smallest live target in the suite's size band whose
+// extension the read tool can actually extract (PDF or EPUB). The read cases need
+// that guarantee: left to the catalog's size ordering they were handed archives
+// and stub text files, and the assertions they could make on those were vacuous.
+func readableTargetIn(t *testing.T, ctx context.Context, client *libgen.Client, topic, query string) libgen.Result {
 	t.Helper()
-	page, _, err := client.Search(ctx, libgen.SearchParams{
-		Query: query, Topics: []string{topic}, Order: "size", OrderMode: "asc",
-	})
-	if err != nil {
-		t.Fatalf("Search error: %v", err)
-	}
-	target := smallestDownloadable(page.Results)
-	if target.MD5 == "" {
-		t.Skipf("no small downloadable %s target for %q; skipping to stay polite", topic, query)
-	}
-	return target
+	return findLiveTarget(t, ctx, client, liveTarget{topic: topic, query: query, exts: readableExts})
 }
 
 // callRead invokes the read tool and decodes its structured ReadOutput. It SKIPS
@@ -450,7 +442,7 @@ func TestE2EReadRefusesToInviteInvention(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 	defer cancel()
 	client, session := newReadSession(t, ctx)
-	target := smallestTargetIn(t, ctx, client, "nonfiction", "python")
+	target := readableTargetIn(t, ctx, client, "nonfiction", "python")
 	pace()
 
 	// A term almost certainly absent, so the empty-result branch is the live one.
@@ -477,18 +469,19 @@ func assertForbidsInvention(t *testing.T, steps []string, branch string) {
 	}
 }
 
-// TestE2EReadModes drives the read tool's three modes against a real small file
-// from the LIVE site: sequential text (with a cursor when more remains), find (a
-// plausible common word), and outline (entries or a clean no-outline result). Each
-// mode must lead with the UNTRUSTED warning. It gates on requireLive; find and
-// outline are best-effort (zero matches / no TOC are valid, not failures), and the
-// whole test SKIPS if the target is not extractable.
+// TestE2EReadModes drives the read tool's three modes against a real document from
+// the LIVE site — a PDF or EPUB above the suite's size floor, so each mode has
+// something to work on. It asserts sequential text (with a cursor when more
+// remains), find (which must locate a word this common), and outline (whose two
+// branches are BOTH asserted, never merely logged). Each mode must lead with the
+// UNTRUSTED warning. It gates on requireLive and SKIPS if the target turns out not
+// to be extractable.
 func TestE2EReadModes(t *testing.T) {
 	requireLive(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 	client, session := newReadSession(t, ctx)
-	target := smallestTargetIn(t, ctx, client, "nonfiction", "python")
+	target := readableTargetIn(t, ctx, client, "nonfiction", "python")
 	t.Logf("read target md5=%s size=%q ext=%q title=%q", target.MD5, target.Size, target.Extension, target.Title)
 	pace()
 
@@ -507,17 +500,154 @@ func TestE2EReadModes(t *testing.T) {
 
 	find := callRead(t, ctx, session, map[string]any{"md5": target.MD5, "find": "the", "max_matches": 5})
 	assertUntrustedFirst(t, find)
+	assertFindShape(t, find, target)
+	pace()
+
+	outline := callRead(t, ctx, session, map[string]any{"md5": target.MD5, "outline": true})
+	assertUntrustedFirst(t, outline)
+	assertOutlineShape(t, outline)
+}
+
+// assertFindShape asserts a find over a real document behaved: every returned
+// match carries a snippet, and the match count and the returned matches agree. A
+// document of this size that contains no occurrence of "the" at all is possible
+// (a non-English text), so a zero-match result is graded as the no-match branch
+// rather than passed over.
+func assertFindShape(t *testing.T, find tools.ReadOutput, target libgen.Result) {
+	t.Helper()
 	for i := range find.Matches {
 		if strings.TrimSpace(find.Matches[i].Snippet) == "" {
 			t.Errorf("find match %d carried an empty snippet", i)
 		}
 	}
-	t.Logf("find matches=%d total=%d", len(find.Matches), find.MatchCount)
+	switch {
+	case find.MatchCount > 0 && len(find.Matches) == 0:
+		t.Errorf("find reported %d matches but returned none", find.MatchCount)
+	case find.MatchCount == 0 && len(find.Matches) > 0:
+		t.Errorf("find returned %d matches but a total of 0", len(find.Matches))
+	case find.MatchCount == 0:
+		// The no-match branch must say so rather than leave the model free to
+		// quote passages it never received.
+		assertForbidsInvention(t, find.NextSteps, "no matches")
+		t.Logf("no occurrence of %q in %q (%s); graded the no-match branch", "the", target.Title, target.Extension)
+	default:
+		t.Logf("find matches=%d total=%d", len(find.Matches), find.MatchCount)
+	}
+}
+
+// assertOutlineShape asserts the read tool's outline mode, whichever branch a real
+// document lands in. The suite used to only log the entry count, so the feature had
+// no live protection at all: an outline that silently stopped being parsed, or one
+// whose entries lost their titles or pages, would have gone unnoticed.
+//
+// With entries: every entry needs a title, a non-negative level, a page inside the
+// document when it states one, and the guidance must tell the model how to jump
+// there. Without entries: the no-TOC branch must be reported explicitly and must
+// forbid inventing chapter titles — a valid document with no embedded table of
+// contents is a normal outcome, but it has to be a stated one.
+func assertOutlineShape(t *testing.T, outline tools.ReadOutput) {
+	t.Helper()
+	if !outline.Extractable {
+		t.Fatalf("outline on an extractable document reported extractable=false: %s", outline.Reason)
+	}
+	joined := strings.Join(outline.NextSteps, "\n")
+	if len(outline.Outline) == 0 {
+		if !strings.Contains(joined, "no embedded table of contents") {
+			t.Errorf("the no-TOC branch must say the document has none; got %q", joined)
+		}
+		assertForbidsInvention(t, outline.NextSteps, "empty outline")
+		t.Logf("outline: document has no embedded table of contents (branch asserted)")
+		return
+	}
+	if !strings.Contains(joined, "start_page") {
+		t.Errorf("an outline with entries must tell the model how to jump to one; got %q", joined)
+	}
+	for i, e := range outline.Outline {
+		if strings.TrimSpace(e.Title) == "" {
+			t.Errorf("outline entry %d has no title: %+v", i, e)
+		}
+		if e.Level < 0 {
+			t.Errorf("outline entry %d has a negative level: %+v", i, e)
+		}
+		if outline.TotalPages > 0 && (e.Page < 0 || e.Page > outline.TotalPages) {
+			t.Errorf("outline entry %d points to page %d, outside a %d-page document", i, e.Page, outline.TotalPages)
+		}
+	}
+	t.Logf("outline: %d entries, first %q (level %d, page %d)",
+		len(outline.Outline), outline.Outline[0].Title, outline.Outline[0].Level, outline.Outline[0].Page)
+}
+
+// TestE2EReadPaginationRoundTrip proves the read tool's pagination actually works
+// end to end: it reads a first chunk, feeds the RETURNED cursor back into a second
+// call, and asserts the second chunk is different content that starts where the
+// first left off. No test ever fed a cursor back before, so cursor, start_page,
+// max_pages, offset and max_chars — five input fields — had no live coverage
+// between them.
+//
+// It asks for a deliberately small chunk so has_more is set even on a modest
+// document. It gates on requireLive and SKIPS when the target is not extractable
+// or is short enough to fit in one chunk.
+func TestE2EReadPaginationRoundTrip(t *testing.T) {
+	requireLive(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+	client, session := newReadSession(t, ctx)
+	target := readableTargetIn(t, ctx, client, "nonfiction", "python")
+	t.Logf("pagination target md5=%s size=%q ext=%q", target.MD5, target.Size, target.Extension)
 	pace()
 
-	outline := callRead(t, ctx, session, map[string]any{"md5": target.MD5, "outline": true})
-	assertUntrustedFirst(t, outline)
-	t.Logf("outline entries=%d extractable=%v", len(outline.Outline), outline.Extractable)
+	// A small max_chars plus a single page makes has_more reachable for any real
+	// document, and exercises max_pages/max_chars alongside the cursor.
+	first := callRead(t, ctx, session, map[string]any{
+		"md5": target.MD5, "max_chars": 2000, "max_pages": 1, "start_page": 1,
+	})
+	assertUntrustedFirst(t, first)
+	if !first.Extractable {
+		t.Skipf("target %s is not extractable (%s); pagination needs extractable text", target.MD5, first.Reason)
+	}
+	if !first.HasMore {
+		t.Skipf("target %s fits in one chunk (%d chars, %d pages); nothing to page through",
+			target.MD5, len(first.Text), first.TotalPages)
+	}
+	if first.Cursor == "" {
+		t.Fatal("read reported has_more but returned no cursor to continue with")
+	}
+	if !strings.Contains(strings.Join(first.NextSteps, "\n"), first.Cursor) {
+		t.Error("the follow-up guidance should hand the model the cursor it must pass back")
+	}
+	pace()
+
+	second := callRead(t, ctx, session, map[string]any{"md5": target.MD5, "cursor": first.Cursor, "max_chars": 2000})
+	assertUntrustedFirst(t, second)
+	assertAdvanced(t, first, second)
+}
+
+// assertAdvanced asserts a cursor-resumed read really moved forward: it returned
+// text, that text differs from the first chunk, and its start position (page for a
+// PDF, character offset for an EPUB/TXT) is past where the first chunk began.
+// Identical text with an advanced offset would mean the cursor was accepted and
+// ignored, which is the failure worth catching.
+func assertAdvanced(t *testing.T, first, second tools.ReadOutput) {
+	t.Helper()
+	if strings.TrimSpace(second.Text) == "" {
+		t.Fatal("the cursor-resumed read returned no text")
+	}
+	if second.Text == first.Text {
+		t.Error("the cursor-resumed read returned the same text; the cursor was accepted but ignored")
+	}
+	switch {
+	case first.PageStart > 0 || second.PageStart > 0:
+		if second.PageStart <= first.PageStart {
+			t.Errorf("page_start did not advance: %d then %d", first.PageStart, second.PageStart)
+		}
+	default:
+		if second.CharStart <= first.CharStart {
+			t.Errorf("char_start did not advance: %d then %d", first.CharStart, second.CharStart)
+		}
+	}
+	t.Logf("paged on: chunk 1 pages %d-%d chars %d-%d, chunk 2 pages %d-%d chars %d-%d",
+		first.PageStart, first.PageEnd, first.CharStart, first.CharEnd,
+		second.PageStart, second.PageEnd, second.CharStart, second.CharEnd)
 }
 
 // TestE2EReadNotExtractable exercises the not-extractable path via an unsupported
@@ -530,7 +660,12 @@ func TestE2EReadNotExtractable(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 	client, session := newReadSession(t, ctx)
-	target := smallestTargetIn(t, ctx, client, "comics", "batman")
+	// Comics carry no floor of their own worth speaking of: the collection jumps
+	// from stub rows straight to hundreds of megabytes, so this case asks only for
+	// something big enough to be a real archive rather than a placeholder.
+	target := findLiveTarget(t, ctx, client, liveTarget{
+		topic: "comics", query: "batman", minBytes: minComicBytes,
+	})
 	t.Logf("not-extractable target md5=%s size=%q ext=%q", target.MD5, target.Size, target.Extension)
 	pace()
 
@@ -613,6 +748,14 @@ func TestE2EReadEPUB(t *testing.T) {
 		}
 	}
 	t.Logf("epub find matches=%d total=%d", len(find.Matches), find.MatchCount)
+	pace()
+
+	// A full-length novel is the likeliest target in the suite to carry a real
+	// navigation document, so the outline's with-entries branch gets its best shot
+	// here; the file is already cached server-side, so the extra call is cheap.
+	outline := callRead(t, ctx, session, map[string]any{"md5": target.MD5, "outline": true})
+	assertUntrustedFirst(t, outline)
+	assertOutlineShape(t, outline)
 }
 
 // validOrigin reports whether an open-access hit's origin label is one of the
@@ -629,8 +772,9 @@ func validOrigin(origin string) bool {
 // TestE2ESearchOpenAccessIncluded drives the search tool with
 // extra_sources=always for a research-y query against the LIVE site (which
 // also hits arXiv/Crossref/OpenLibrary). It asserts the OpenAccess list is
-// populated, each hit is labeled by a known origin, and no DOI is duplicated. It
-// gates on requireLive and SKIPS when the open-access providers return nothing.
+// populated, each hit is labeled by a known origin, no DOI is duplicated, and the
+// per-provider discovery fields hold up against real data. It gates on requireLive
+// and SKIPS when the open-access providers return nothing.
 func TestE2ESearchOpenAccessIncluded(t *testing.T) {
 	env := requireLive(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -652,13 +796,32 @@ func TestE2ESearchOpenAccessIncluded(t *testing.T) {
 	if len(out.OpenAccess) == 0 {
 		t.Skip("no open-access hits (providers unreachable or no matches); skipping")
 	}
+	assertOriginsAndDedup(t, out.OpenAccess)
+	assertArchiveLinksAreOpen(t, out.OpenAccess)
+	assertOpenAccessDiscriminates(t, out.OpenAccess)
+	assertArxivVenue(t, out.OpenAccess)
+	pace()
+
+	// A second, book-shaped query so OpenLibrary actually contributes: a papers
+	// query reaches it, but public-domain classics are where it publishes the
+	// free-to-read archive links this invariant is about.
+	books := callSearch(t, ctx, env, map[string]any{
+		"query": "Alice's Adventures in Wonderland", "extra_sources": "always",
+	})
+	assertOriginsAndDedup(t, books.OpenAccess)
+	assertArchiveLinksAreOpen(t, books.OpenAccess)
+}
+
+// assertOriginsAndDedup asserts every hit is labeled by a known discovery provider
+// and that no DOI appears twice across the merged list.
+func assertOriginsAndDedup(t *testing.T, hits []discovery.DiscoveryResult) {
+	t.Helper()
 	seenDOI := map[string]bool{}
-	for i := range out.OpenAccess {
-		h := out.OpenAccess[i]
-		if !validOrigin(h.Origin) {
-			t.Errorf("open-access hit %d has an unexpected origin %q", i, h.Origin)
+	for i := range hits {
+		if !validOrigin(hits[i].Origin) {
+			t.Errorf("open-access hit %d has an unexpected origin %q", i, hits[i].Origin)
 		}
-		doi := strings.ToLower(strings.TrimSpace(h.DOI))
+		doi := strings.ToLower(strings.TrimSpace(hits[i].DOI))
 		if doi == "" {
 			continue
 		}
@@ -667,7 +830,105 @@ func TestE2ESearchOpenAccessIncluded(t *testing.T) {
 		}
 		seenDOI[doi] = true
 	}
-	t.Logf("open_access hits=%d unique_dois=%d", len(out.OpenAccess), len(seenDOI))
+	t.Logf("open_access hits=%d unique_dois=%d", len(hits), len(seenDOI))
+}
+
+// assertArchiveLinksAreOpen asserts the OpenLibrary archive link keeps its promise:
+// it is only ever set for a publicly readable book, so a hit carrying one must be
+// labeled open access, and the link must be an archive.org details page — the only
+// shape the renderer and the model are told to expect. When no hit carries one it
+// says so explicitly, naming how many OpenLibrary hits there were, rather than
+// passing as though the invariant had been checked.
+func assertArchiveLinksAreOpen(t *testing.T, hits []discovery.DiscoveryResult) {
+	t.Helper()
+	var fromOpenLibrary, withArchive int
+	for i := range hits {
+		h := hits[i]
+		if h.Origin == "openlibrary" {
+			fromOpenLibrary++
+		}
+		if h.ArchiveURL == "" {
+			continue
+		}
+		withArchive++
+		if h.Origin != "openlibrary" {
+			t.Errorf("hit %d carries an archive_url but came from %q, not openlibrary", i, h.Origin)
+		}
+		if !h.OpenAccess {
+			t.Errorf("hit %d carries archive_url %q but open_access is false; the link means freely readable", i, h.ArchiveURL)
+		}
+		if !strings.Contains(h.ArchiveURL, "archive.org/details/") {
+			t.Errorf("hit %d archive_url %q is not an archive.org details page", i, h.ArchiveURL)
+		}
+	}
+	if withArchive == 0 {
+		t.Logf("no archive_url across %d hits (%d from openlibrary); the free-to-read link invariant could not be graded this run",
+			len(hits), fromOpenLibrary)
+		return
+	}
+	t.Logf("archive_url present on %d of %d hits (%d from openlibrary)", withArchive, len(hits), fromOpenLibrary)
+}
+
+// assertOpenAccessDiscriminates asserts open_access is a judgement and not a
+// rubber stamp. Crossref decides it with a license heuristic; if that heuristic
+// ever regresses to always-true the flag stops carrying information, and every
+// paywalled record starts claiming to be free. A page of Crossref hits where none
+// is open access is plausible; one where ALL of them are is the shape worth
+// flagging.
+func assertOpenAccessDiscriminates(t *testing.T, hits []discovery.DiscoveryResult) {
+	t.Helper()
+	var crossref, crossrefOA int
+	for i := range hits {
+		if hits[i].Origin != "crossref" {
+			continue
+		}
+		crossref++
+		if hits[i].OpenAccess {
+			crossrefOA++
+		}
+	}
+	if crossref < 3 {
+		t.Logf("only %d crossref hits this run; too few to grade the open-access heuristic", crossref)
+		return
+	}
+	if crossrefOA == crossref {
+		t.Errorf("all %d crossref hits claim open_access; the license heuristic looks like it regressed to always-true", crossref)
+	}
+	t.Logf("open_access true on %d of %d crossref hits", crossrefOA, crossref)
+}
+
+// assertArxivVenue asserts the arXiv venue field survives the round trip: a
+// journal_ref is a short citation string, never an abstract, so any venue that
+// comes back must be short and must not be prose. arXiv only states one for the
+// preprints that later appeared in a journal, so a run where none does is a
+// legitimate data condition — it is reported explicitly rather than passing
+// silently as though the field had been checked.
+func assertArxivVenue(t *testing.T, hits []discovery.DiscoveryResult) {
+	t.Helper()
+	var arxiv, withVenue int
+	for i := range hits {
+		if hits[i].Origin != "arxiv" {
+			continue
+		}
+		arxiv++
+		venue := strings.TrimSpace(hits[i].Venue)
+		if venue == "" {
+			continue
+		}
+		withVenue++
+		if len(venue) > 300 {
+			t.Errorf("arxiv hit %d has a %d-character venue; journal_ref is a citation, not an abstract: %q",
+				i, len(venue), venue)
+		}
+	}
+	switch {
+	case arxiv == 0:
+		t.Logf("no arXiv hits this run; the venue field could not be graded")
+	case withVenue == 0:
+		t.Logf("none of the %d arXiv hits state a journal_ref this run; venue could not be graded (arXiv states one only for published preprints)", arxiv)
+	default:
+		t.Logf("venue present on %d of %d arXiv hits", withVenue, arxiv)
+	}
 }
 
 // TestE2ESearchOpenAccessOmittedDefault proves that with extra_sources=never

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -40,6 +41,30 @@ const (
 	// maxE2EDownloadBytes caps live downloads so a size-parsing mistake can never
 	// pull a large file. It keeps the suite a polite citizen of the public mirrors.
 	maxE2EDownloadBytes = 25 << 20 // 25 MiB
+	// minE2EDownloadBytes is the size FLOOR every live download and read target
+	// must clear. A size-ascending catalog search leads with degenerate rows — the
+	// first nonfiction "python" hit is an 87-byte .txt — and without a floor every
+	// test that "downloaded" or "read" a file moved those 87 bytes: no pagination,
+	// no in-document matches, no table of contents, no PDF path. 100 KiB clears the
+	// stub rows (the catalog's real books start around it) while staying small
+	// enough to be polite.
+	minE2EDownloadBytes = 100 << 10 // 100 KiB
+	// targetSearchPages bounds how many size-ascending pages are walked when
+	// hunting for a target above the floor. Page one sits entirely below it, so at
+	// least two are normally needed.
+	targetSearchPages = 4
+	// targetPageSize is the results-per-page used while hunting for a target, so
+	// the floor is usually reached within two pages.
+	targetPageSize = 100
+	// minComicBytes is the floor for the not-extractable read case. The comics
+	// collection has almost nothing between its stub rows and its multi-hundred-
+	// megabyte scans, so it needs a lower bar than the rest of the suite: enough to
+	// be a genuine archive with no text layer, which is all that case has to prove.
+	minComicBytes = 32 << 10 // 32 KiB
+	// upstreamProbeTimeout bounds a source's reachability precondition. It is
+	// deliberately short: a host that blackholes connections must cost seconds, not
+	// the test's whole timeout budget.
+	upstreamProbeTimeout = 3 * time.Second
 )
 
 // md5Re matches a canonical lowercase LibGen md5 digest.
@@ -131,23 +156,52 @@ func preferredMirror(t *testing.T, mgr *mirrors.Manager) string {
 // within probeTimeout. Redirects are not followed, so a 3xx is observed directly.
 func reachable(t *testing.T, base string) bool {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/index.php", http.NoBody)
+	status, err := probeStatus(base+"/index.php", probeTimeout)
 	if err != nil {
 		return false
 	}
+	return status >= 200 && status < 400
+}
+
+// probeStatus GETs url with a short budget and returns the status code it
+// answered with. Redirects are not followed, so a 3xx is observed directly. It is
+// the shared primitive behind both the mirror gate and the per-source upstream
+// preconditions.
+func probeStatus(url string, timeout time.Duration) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return 0, err
+	}
 	req.Header.Set("User-Agent", "libgen-mcp-e2e-probe")
 	client := &http.Client{
-		Timeout:       probeTimeout,
+		Timeout:       timeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return false
+		return 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode >= 200 && resp.StatusCode < 400
+	return resp.StatusCode, nil
+}
+
+// requireUpstream SKIPS the calling test when a source's own upstream does not
+// answer probeURL within upstreamProbeTimeout. ANY status counts as reachable —
+// the question is whether the host answers at all, which a 404 settles as well as
+// a 200.
+//
+// It exists because a blackholed upstream otherwise burns the test's entire
+// timeout budget proving nothing: api.fatcat.wiki does not answer from every
+// network, and the fatcat case spent 90 s — 27% of a 335 s suite — reaching that
+// conclusion. Reachability is a PRECONDITION only: once the host answers, the
+// test's failure classification stays strict.
+func requireUpstream(t *testing.T, name, probeURL string) {
+	t.Helper()
+	if _, err := probeStatus(probeURL, upstreamProbeTimeout); err != nil {
+		t.Skipf("upstream unreachable: %s did not answer %s within %s (%v)", name, probeURL, upstreamProbeTimeout, err)
+	}
 }
 
 // pace inserts the courtesy pause between successive live requests.
@@ -208,20 +262,90 @@ func firstMD5(t *testing.T, ctx context.Context, c *libgen.Client, query string)
 	return ""
 }
 
-// smallestDownloadable returns the first result (from a size-ascending search)
-// that has a canonical md5 and a parseable, non-zero size within the polite cap.
-// It returns a zero Result when none qualifies.
-func smallestDownloadable(results []libgen.Result) libgen.Result {
+// liveTarget describes the live catalog target a download or read test needs.
+type liveTarget struct {
+	// topic is the collection to search.
+	topic string
+	// query is the search query.
+	query string
+	// exts, when non-empty, restricts the target to these lowercase extensions —
+	// used by the read cases, which need a format the extractors actually support.
+	exts []string
+	// minBytes overrides minE2EDownloadBytes for a collection whose real files sit
+	// below it (comics jump straight from stub rows to hundreds of megabytes, and
+	// nothing in between). Zero means the default floor.
+	minBytes int64
+}
+
+// floor returns the size floor this target requires.
+func (spec liveTarget) floor() int64 {
+	if spec.minBytes > 0 {
+		return spec.minBytes
+	}
+	return minE2EDownloadBytes
+}
+
+// readableExts are the extensions the read tool can extract text from, so a read
+// case asks for one of these rather than gambling on whatever the catalog's size
+// ordering happens to put first.
+var readableExts = []string{"pdf", "epub"}
+
+// findLiveTarget walks a size-ascending live search for the SMALLEST result that
+// clears minE2EDownloadBytes, stays within maxE2EDownloadBytes, carries a
+// canonical md5 and (when spec.exts is set) has one of the wanted extensions.
+//
+// It pages because page one of a size-ascending search sits entirely below the
+// floor: the floor is what makes the download and read cases real, so reaching it
+// is worth the extra request. It SKIPS the calling test when no page yields a
+// qualifying target, which is a live-data condition rather than a code fault.
+func findLiveTarget(t *testing.T, ctx context.Context, c *libgen.Client, spec liveTarget) libgen.Result {
+	t.Helper()
+	for p := 1; p <= targetSearchPages; p++ {
+		page, _, err := c.Search(ctx, libgen.SearchParams{
+			Query: spec.query, Topics: []string{spec.topic},
+			Order: "size", OrderMode: "asc",
+			ResultsPerPage: targetPageSize, Page: p,
+		})
+		if err != nil {
+			t.Fatalf("Search(%q, page %d) error: %v", spec.query, p, err)
+		}
+		if target := qualifyingTarget(page.Results, spec); target.MD5 != "" {
+			return target
+		}
+		if len(page.Results) < targetPageSize {
+			break
+		}
+	}
+	t.Skipf("no %s target for %q between %d and %d bytes (exts %v) across %d pages; skipping to stay polite",
+		spec.topic, spec.query, spec.floor(), maxE2EDownloadBytes, spec.exts, targetSearchPages)
+	return libgen.Result{}
+}
+
+// qualifyingTarget returns the first result on a size-ascending page that carries
+// a canonical md5, has one of the wanted extensions (any, when exts is empty) and
+// a parseable size inside [spec.floor(), maxE2EDownloadBytes]. It returns a zero
+// Result when the page holds none.
+func qualifyingTarget(results []libgen.Result, spec liveTarget) libgen.Result {
 	for i := range results {
 		r := results[i]
-		if !md5Re.MatchString(r.MD5) {
+		if !md5Re.MatchString(r.MD5) || !hasExtension(r, spec.exts) {
 			continue
 		}
-		if n, ok := parseSize(r.Size); ok && n > 0 && n <= maxE2EDownloadBytes {
+		if n, ok := parseSize(r.Size); ok && n >= spec.floor() && n <= maxE2EDownloadBytes {
 			return r
 		}
 	}
 	return libgen.Result{}
+}
+
+// hasExtension reports whether r's extension is one of want (case-insensitive).
+// An empty want accepts any extension.
+func hasExtension(r libgen.Result, want []string) bool {
+	if len(want) == 0 {
+		return true
+	}
+	got := strings.ToLower(strings.TrimSpace(r.Extension))
+	return slices.Contains(want, got)
 }
 
 // parseSize converts a human-readable size such as "1.2 MB" or "820 KB" into a
@@ -242,6 +366,76 @@ func parseSize(s string) (int64, bool) {
 		return 0, false
 	}
 	return int64(num * m), true
+}
+
+// sourceFailure is one KNOWN, diagnosed way a download source can fail against
+// its live upstream.
+//
+// The pattern must pin BOTH the source that failed and the specific diagnosis.
+// The bare substrings this suite used to match on — "requesting", "returned HTTP",
+// "context deadline" — appear in almost every failure a download can produce,
+// including a code regression that points a source at the wrong host: matching on
+// them classified "we are calling it wrong" as "the upstream is down today", which
+// is precisely the confusion the classified-outcome discipline exists to prevent.
+type sourceFailure struct {
+	// re matches the error text, anchored on the source's own message prefix.
+	re *regexp.Regexp
+	// why names the class in the SKIP message.
+	why string
+}
+
+// diagnosed builds a failure class whose pattern requires the source's own error
+// prefix ("<source>: ") immediately followed by diag, a regular-expression
+// fragment naming the specific diagnosis. Every source in internal/libgen prefixes
+// its errors this way, so the pair identifies the failure unambiguously.
+func diagnosed(source, diag, why string) sourceFailure {
+	return sourceFailure{re: regexp.MustCompile(regexp.QuoteMeta(source+": ") + diag), why: why}
+}
+
+// transportTo builds the transport-failure class for a source: the error must come
+// from the source's own request wrapper AND name the host the source is supposed
+// to be calling (Go's *url.Error carries the full URL). Pinning the host is what
+// separates "the upstream is down today" from "we are calling the wrong upstream" —
+// a source repointed at a bad host fails with identical wrapper text, and must
+// FAIL here rather than skip.
+func transportTo(source, wrapper, host string) sourceFailure {
+	return sourceFailure{
+		re: regexp.MustCompile(
+			regexp.QuoteMeta(source+": "+wrapper) + `.*` + regexp.QuoteMeta(`"https://`+host+`/`)),
+		why: "transport failure reaching " + host,
+	}
+}
+
+// classifyOrFail requires a live source failure to match one of the KNOWN,
+// diagnosed classes and SKIPs with that class's reason. An error outside the set
+// FAILS: a new, unrecognized failure mode must surface here rather than be
+// tolerated as flakiness and discovered by chance later.
+func classifyOrFail(t *testing.T, source string, err error, classes []sourceFailure) {
+	t.Helper()
+	msg := err.Error()
+	for _, c := range classes {
+		if c.re.MatchString(msg) {
+			t.Skipf("%s unavailable in a known way (%s): %v", source, c.why, err)
+		}
+	}
+	t.Fatalf("%s failed in an undiagnosed way — update this test's classification only if this is a legitimate new outcome, not if we are calling the upstream wrong: %v", source, err)
+}
+
+// assertSourcePDF asserts the best case of a source-restricted article download:
+// the named source served the file, it is non-empty, and the bytes really are a
+// PDF. The source check matters because a chain bug could have another provider
+// answer, and the PDF check because several sources omit the mimetype, so a
+// non-PDF asset would still arrive under a .pdf name.
+func assertSourcePDF(t *testing.T, source string, res *libgen.DownloadResult) {
+	t.Helper()
+	if res.SizeBytes <= 0 {
+		t.Fatalf("%s reported a download of %d bytes", source, res.SizeBytes)
+	}
+	if res.Source != source {
+		t.Errorf("Source = %q, want %q — another source answered a restricted download", res.Source, source)
+	}
+	assertPDF(t, res.Path)
+	t.Logf("%s served a real PDF: bytes=%d", source, res.SizeBytes)
 }
 
 // assertFileMD5 asserts that the file at path exists, is non-empty, and hashes to

--- a/test/e2e/live_test.go
+++ b/test/e2e/live_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -93,9 +95,11 @@ func TestE2EGetDetails(t *testing.T) {
 // hashes to the requested md5.
 //
 // Small-target choice: rather than hardcode an md5 that may vanish, the test
-// searches with order=size, order_mode=asc and picks the first result whose
-// parsed size is non-zero and within maxE2EDownloadBytes. A per-client download
-// cap enforces the same ceiling defensively. If the download cannot complete
+// searches with order=size, order_mode=asc and picks the first result whose parsed
+// size sits inside [minE2EDownloadBytes, maxE2EDownloadBytes]. The FLOOR matters as
+// much as the ceiling: without it the ordering hands every run the catalog's
+// smallest row — an 87-byte stub — and the download proves nothing. A per-client
+// download cap enforces the ceiling defensively. If the download cannot complete
 // (expired key, blocked CDN), it falls back to proving the
 // ads.php -> get.php -> CDN chain resolves and that the first bytes are a valid,
 // non-HTML file, without pulling the whole payload.
@@ -105,19 +109,10 @@ func TestE2EDownloadSmall(t *testing.T) {
 	cfg.MaxDownloadBytes = maxE2EDownloadBytes
 	client := buildClient(t, cfg)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	page, _, err := client.Search(ctx, libgen.SearchParams{
-		Query: "python", Topics: []string{"nonfiction"}, Order: "size", OrderMode: "asc",
-	})
-	if err != nil {
-		t.Fatalf("Search error: %v", err)
-	}
-	target := smallestDownloadable(page.Results)
-	if target.MD5 == "" {
-		t.Skip("no small downloadable target found; skipping to stay polite")
-	}
+	target := smallBookTarget(t, ctx, client, "python")
 	t.Logf("download target md5=%s size=%q title=%q", target.MD5, target.Size, target.Title)
 	pace()
 
@@ -128,6 +123,10 @@ func TestE2EDownloadSmall(t *testing.T) {
 	}
 	if !res.Verified {
 		t.Errorf("download not integrity-verified: %+v", res)
+	}
+	if res.SizeBytes < minE2EDownloadBytes {
+		t.Errorf("downloaded %d bytes for a target the catalog sized at %q; the size floor did not hold",
+			res.SizeBytes, target.Size)
 	}
 	assertFileMD5(t, res.Path, target.MD5)
 	t.Logf("downloaded md5=%s bytes=%d source=%s path=%s", target.MD5, res.SizeBytes, res.Source, res.Path)
@@ -449,42 +448,59 @@ const biorxivLiveDOI = "10.1101/2020.12.30.424878"
 // expected to have preserved; older OA works are the case fatcat is strongest for.
 const fatcatLiveDOI = "10.1371/journal.pbio.1002533"
 
+// downloadFromSource runs a source-restricted live download of doi and returns the
+// outcome, so every classified-outcome case shares one harness: a size-capped
+// client, a fresh temp dir, and no other source able to mask the one under test.
+func downloadFromSource(t *testing.T, ctx context.Context, doi, source string) (*libgen.DownloadResult, error) {
+	t.Helper()
+	cfg := loadLiveConfig(t)
+	cfg.MaxDownloadBytes = maxE2EDownloadBytes
+	client := buildClient(t, cfg)
+	return client.DownloadItem(ctx, libgen.Item{DOI: doi, Source: source}, t.TempDir(), "")
+}
+
+// europePMCFailures are the KNOWN, diagnosed ways the europepmc source can fail
+// live. Each pattern pins the source's own error prefix plus a specific diagnosis,
+// and the transport class additionally pins the EBI host, so a source repointed at
+// the wrong upstream fails the test instead of skipping it.
+var europePMCFailures = []sourceFailure{
+	diagnosed("europepmc", `"[^"]*" is not indexed`, "DOI absent from Europe PMC"),
+	diagnosed("europepmc", `"[^"]*" is indexed but has no open-access full text`, "indexed but not open access"),
+	diagnosed("europepmc", `no reachable PDF endpoint for `, "both render endpoints unreachable"),
+	diagnosed("europepmc", `"[^"]*" returned HTTP \d+`, "search API answered an unexpected status"),
+	transportTo("europepmc", "requesting ", "www.ebi.ac.uk"),
+}
+
 // TestE2EEuropePMCClassifiedOutcome exercises the europepmc source end to end
 // against the live Europe PMC APIs, restricted to source=europepmc so no other
 // source can mask its behavior. On error the failure must be one of the known,
 // diagnosed classes; anything else fails the test.
 func TestE2EEuropePMCClassifiedOutcome(t *testing.T) {
 	requireLive(t)
-	cfg := loadLiveConfig(t)
-	cfg.MaxDownloadBytes = maxE2EDownloadBytes
-	client := buildClient(t, cfg)
-
+	requireUpstream(t, "europepmc", "https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=test&format=json")
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	res, err := client.DownloadItem(ctx, libgen.Item{DOI: europePMCLiveDOI, Source: "europepmc"}, t.TempDir(), "")
+	res, err := downloadFromSource(t, ctx, europePMCLiveDOI, "europepmc")
 	if err == nil {
-		if res.SizeBytes <= 0 {
-			t.Fatalf("europepmc reported a download of %d bytes", res.SizeBytes)
-		}
-		assertPDF(t, res.Path)
-		t.Logf("europepmc served a real PDF: bytes=%d", res.SizeBytes)
+		assertSourcePDF(t, "europepmc", res)
 		return
 	}
-	known := []string{
-		"not indexed",               // DOI absent from Europe PMC
-		"no open-access full text",  // indexed but no OA full text
-		"no reachable PDF endpoint", // both render endpoints unreachable
-		"returned HTTP",             // search API answered non-200
-		"requesting",                // transport failure reaching Europe PMC
-		"context deadline",          // a slow endpoint inside the timeout budget
-	}
-	for _, k := range known {
-		if strings.Contains(err.Error(), k) {
-			t.Skipf("europepmc unavailable in a known way: %v", err)
-		}
-	}
-	t.Fatalf("europepmc failed in an undiagnosed way: %v", err)
+	classifyOrFail(t, "europepmc", err, europePMCFailures)
+}
+
+// biorxivFailures are the KNOWN, diagnosed ways the biorxiv source can fail live.
+// The details-API classes pin api.biorxiv.org; the content-host class covers the
+// interstitial bioRxiv serves in place of the PDF, which arrives from the download
+// stream rather than the source, so it is matched on the chain's own wrapper.
+var biorxivFailures = []sourceFailure{
+	diagnosed("biorxiv", `"[^"]*" not found on bioRxiv or medRxiv`, "neither server carries the DOI"),
+	diagnosed("biorxiv", `(bio|med)rxiv returned HTTP \d+`, "details API answered an unexpected status"),
+	transportTo("biorxiv", "requesting ", "api.biorxiv.org"),
+	{
+		re:  regexp.MustCompile(`source biorxiv: .*HTML page instead of the file`),
+		why: "the content host served an interstitial, not the PDF",
+	},
 }
 
 // TestE2EBiorxivClassifiedOutcome exercises the biorxiv source end to end against
@@ -492,35 +508,33 @@ func TestE2EEuropePMCClassifiedOutcome(t *testing.T) {
 // error the failure must be one of the known, diagnosed classes.
 func TestE2EBiorxivClassifiedOutcome(t *testing.T) {
 	requireLive(t)
-	cfg := loadLiveConfig(t)
-	cfg.MaxDownloadBytes = maxE2EDownloadBytes
-	client := buildClient(t, cfg)
-
+	requireUpstream(t, "biorxiv", "https://api.biorxiv.org/details/biorxiv/"+biorxivLiveDOI)
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	res, err := client.DownloadItem(ctx, libgen.Item{DOI: biorxivLiveDOI, Source: "biorxiv"}, t.TempDir(), "")
+	res, err := downloadFromSource(t, ctx, biorxivLiveDOI, "biorxiv")
 	if err == nil {
-		if res.SizeBytes <= 0 {
-			t.Fatalf("biorxiv reported a download of %d bytes", res.SizeBytes)
-		}
-		assertPDF(t, res.Path)
-		t.Logf("biorxiv served a real PDF: bytes=%d", res.SizeBytes)
+		assertSourcePDF(t, "biorxiv", res)
 		return
 	}
-	known := []string{
-		"not found on bioRxiv or medRxiv", // neither server carries the DOI
-		"returned HTTP",                   // details API answered non-200
-		"requesting",                      // transport failure reaching bioRxiv
-		"HTML page",                       // content host served an interstitial, not the PDF
-		"context deadline",                // a slow endpoint inside the timeout budget
-	}
-	for _, k := range known {
-		if strings.Contains(err.Error(), k) {
-			t.Skipf("biorxiv unavailable in a known way: %v", err)
-		}
-	}
-	t.Fatalf("biorxiv failed in an undiagnosed way: %v", err)
+	classifyOrFail(t, "biorxiv", err, biorxivFailures)
+}
+
+// fatcatAPIProbe is the fatcat API root the source calls. The classified-outcome
+// case probes it first: it does not answer from every network, and without the
+// precondition the test spent its full 90 s timeout budget establishing that.
+const fatcatAPIProbe = "https://api.fatcat.wiki/v0/release/lookup?doi=" + fatcatLiveDOI
+
+// fatcatFailures are the KNOWN, diagnosed ways the fatcat source can fail live.
+var fatcatFailures = []sourceFailure{
+	diagnosed("fatcat", `"[^"]*" is unknown to fatcat`, "fatcat has no release for the DOI"),
+	diagnosed("fatcat", `"[^"]*" has no preserved Internet Archive file`, "release known but nothing preserved"),
+	diagnosed("fatcat", `"[^"]*" returned HTTP \d+`, "API answered an unexpected status"),
+	transportTo("fatcat", "requesting ", "api.fatcat.wiki"),
+	{
+		re:  regexp.MustCompile(`source fatcat: .*HTML page instead of the file`),
+		why: "the Internet Archive served an interstitial, not the PDF",
+	},
 }
 
 // TestE2EFatcatClassifiedOutcome exercises the fatcat source end to end against the
@@ -528,45 +542,76 @@ func TestE2EBiorxivClassifiedOutcome(t *testing.T) {
 // failure must be one of the known, diagnosed classes.
 func TestE2EFatcatClassifiedOutcome(t *testing.T) {
 	requireLive(t)
-	cfg := loadLiveConfig(t)
-	cfg.MaxDownloadBytes = maxE2EDownloadBytes
-	client := buildClient(t, cfg)
-
+	requireUpstream(t, "fatcat", fatcatAPIProbe)
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	res, err := client.DownloadItem(ctx, libgen.Item{DOI: fatcatLiveDOI, Source: "fatcat"}, t.TempDir(), "")
+	res, err := downloadFromSource(t, ctx, fatcatLiveDOI, "fatcat")
 	if err == nil {
-		if res.SizeBytes <= 0 {
-			t.Fatalf("fatcat reported a download of %d bytes", res.SizeBytes)
-		}
-		// Assert the bytes really are a PDF, not merely non-empty: fatcat records
-		// often omit the mimetype, so a non-PDF archive asset selected by mistake
-		// would still arrive as a plausible-looking file under a .pdf name.
-		assertPDF(t, res.Path)
-		t.Logf("fatcat served a real PDF: bytes=%d", res.SizeBytes)
+		// The PDF check matters more here than elsewhere: fatcat records often omit
+		// the mimetype, so a non-PDF archive asset picked by mistake would still
+		// arrive as a plausible-looking file under a .pdf name.
+		assertSourcePDF(t, "fatcat", res)
 		return
 	}
-	known := []string{
-		"unknown to fatcat",                  // fatcat has no release for the DOI
-		"no preserved Internet Archive file", // release known but nothing preserved
-		"returned HTTP",                      // API answered an unexpected status
-		"requesting",                         // transport failure reaching fatcat/IA
-		"HTML page",                          // IA served an interstitial, not the PDF
-		"context deadline",                   // a slow endpoint inside the timeout budget
+	classifyOrFail(t, "fatcat", err, fatcatFailures)
+}
+
+// scihubLiveDOI is a long-established, heavily-cited DOI: if Sci-Hub carries
+// anything, it carries this.
+const scihubLiveDOI = "10.1016/j.cell.2011.02.013"
+
+// scihubFailures are the KNOWN, diagnosed ways the scihub source can fail live.
+// Every class requires the outer "no mirror resolved" wrapper AND a specific inner
+// diagnosis, and the transport class pins the sci-hub.<tld> host family, so a
+// source pointed at some other host fails rather than skipping. Sci-Hub is the
+// most fragile source in the chain — its mirrors rotate and block — which is
+// exactly why the failure it reports has to stay legible.
+var scihubFailures = []sourceFailure{
+	diagnosed("scihub", `no mirror resolved "[^"]*": scihub: host "[^"]*" served no PDF link`,
+		"mirrors reachable, article absent from Sci-Hub"),
+	diagnosed("scihub", `no mirror resolved "[^"]*": scihub: host "[^"]*" returned HTTP \d+`,
+		"every mirror answered an unexpected status"),
+	diagnosed("scihub", `no mirror resolved "[^"]*": scihub: requesting "sci-hub\.[a-z]+"`,
+		"every sci-hub mirror was unreachable"),
+	diagnosed("scihub", `no hosts configured for `, "no Sci-Hub hosts configured"),
+}
+
+// TestE2ESciHubClassifiedOutcome exercises the scihub source end to end against the
+// live Sci-Hub mirrors, restricted to source=scihub so no other source can mask its
+// behavior. It was the only one of the ten known sources with no source-restricted
+// live test, and the most fragile: its mirror list rotates, so a silent move from
+// "the mirrors are blocking us today" to "we are asking them the wrong way" had
+// nothing watching for it. On error the failure must be one of the known, diagnosed
+// classes; anything else fails the test.
+func TestE2ESciHubClassifiedOutcome(t *testing.T) {
+	requireLive(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	res, err := downloadFromSource(t, ctx, scihubLiveDOI, "scihub")
+	if err == nil {
+		assertSourcePDF(t, "scihub", res)
+		return
 	}
-	for _, k := range known {
-		if strings.Contains(err.Error(), k) {
-			t.Skipf("fatcat unavailable in a known way: %v", err)
-		}
-	}
-	t.Fatalf("fatcat failed in an undiagnosed way: %v", err)
+	classifyOrFail(t, "scihub", err, scihubFailures)
 }
 
 // coreLiveDOI is an open-access DOI whose CORE record served a live PDF on
 // 2026-07-24; CORE's download URLs go stale often, so the test tolerates a
 // diagnosed "no live file today" outcome rather than pinning on permanence.
 const coreLiveDOI = "10.1186/s12864-016-3299-5"
+
+// coreFailures are the KNOWN, diagnosed ways the core source can fail live. The
+// transport class pins api.core.ac.uk so a repointed source cannot pass as an
+// upstream outage.
+var coreFailures = []sourceFailure{
+	diagnosed("core", `"[^"]*" has no downloadable open-access full text`, "CORE has no live file for this DOI today"),
+	diagnosed("core", `"[^"]*" is not in CORE`, "CORE does not hold the DOI"),
+	diagnosed("core", `API key rejected \(HTTP \d+\)`, "the API key is invalid or expired"),
+	diagnosed("core", `"[^"]*" returned HTTP \d+`, "the API answered an unexpected status"),
+	transportTo("core", "requesting ", "api.core.ac.uk"),
+}
 
 // TestE2ECoreClassifiedOutcome exercises the opt-in core source end to end against
 // the live CORE API, restricted to source=core. It is skipped unless
@@ -578,35 +623,16 @@ func TestE2ECoreClassifiedOutcome(t *testing.T) {
 	if strings.TrimSpace(os.Getenv("LIBGEN_MCP_CORE_KEY")) == "" {
 		t.Skip("LIBGEN_MCP_CORE_KEY not set; the core source is opt-in and out of the chain")
 	}
-	cfg := loadLiveConfig(t)
-	cfg.MaxDownloadBytes = maxE2EDownloadBytes
-	client := buildClient(t, cfg)
-
+	requireUpstream(t, "core", "https://api.core.ac.uk/v3/")
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	res, err := client.DownloadItem(ctx, libgen.Item{DOI: coreLiveDOI, Source: "core"}, t.TempDir(), "")
+	res, err := downloadFromSource(t, ctx, coreLiveDOI, "core")
 	if err == nil {
-		if res.SizeBytes <= 0 {
-			t.Fatalf("core reported a download of %d bytes", res.SizeBytes)
-		}
-		assertPDF(t, res.Path)
-		t.Logf("core served a real PDF: bytes=%d", res.SizeBytes)
+		assertSourcePDF(t, "core", res)
 		return
 	}
-	known := []string{
-		"no downloadable open-access full text", // CORE has no live file for this DOI today
-		"is not in CORE",                        // CORE does not hold the DOI
-		"API key rejected",                      // key invalid or expired
-		"requesting",                            // transport failure reaching CORE
-		"context deadline",                      // a slow endpoint inside the timeout budget
-	}
-	for _, k := range known {
-		if strings.Contains(err.Error(), k) {
-			t.Skipf("core unavailable in a known way: %v", err)
-		}
-	}
-	t.Fatalf("core failed in an undiagnosed way: %v", err)
+	classifyOrFail(t, "core", err, coreFailures)
 }
 
 // scidbLiveDOI is a long-established, heavily-mirrored DOI verified served by
@@ -665,6 +691,132 @@ func TestE2EAnnasClassifiedOutcome(t *testing.T) {
 	}
 	skipIfAnnasUnavailable(t, err)
 	t.Fatalf("annas failed in an undiagnosed way: %v", err)
+}
+
+// TestE2EDownloadToolHonorsSourceArgument proves the `source` argument works where
+// a real client actually sets it: as a tool argument over MCP. Every other
+// source-restricted case in this suite builds a libgen.Item{Source: …} directly,
+// which bypasses validateDownloadInput and the dynamically-built enum entirely —
+// so the argument a model would pass had no live coverage at all. It resolves the
+// pinned Anna's-only md5 with source="annas" and asserts the resolved link really
+// came from that source.
+func TestE2EDownloadToolHonorsSourceArgument(t *testing.T) {
+	env := requireLive(t)
+	item := loadEscalationItem(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "libgen-mcp-e2e", Version: "test"}, nil)
+	tools.Register(server, env.client, env.cfg)
+	session := connectInMemory(t, ctx, server, nil)
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "download",
+		Arguments: map[string]any{"md5": item.MD5, "source": "annas", "resolve_only": true},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(download source=annas) transport error: %v", err)
+	}
+	if res.IsError {
+		// A live Anna's outage is tolerated; a rejected argument is not, so the
+		// error text has to name a known unavailability rather than a bad input.
+		skipIfAnnasUnavailable(t, errors.New(textOf(res)))
+		t.Fatalf("download with source=annas failed in an undiagnosed way: %v", res.Content)
+	}
+	var out tools.DownloadOutput
+	decodeStructured(t, res, &out)
+	if out.Resolved == nil {
+		t.Fatalf("resolve_only with source=annas returned no link: %+v", out)
+	}
+	if out.Resolved.Source != "annas" {
+		t.Errorf("resolved.source = %q, want annas — the source argument did not pin the chain", out.Resolved.Source)
+	}
+	t.Logf("tool-layer source argument honored: resolved via %s", out.Resolved.Source)
+}
+
+// TestE2EDownloadToolAdvertisesEveryEnabledSource proves the download tool's
+// `source` enum, as served over ListTools, names every source the deployment has
+// enabled. The enum is the model's ONLY discovery path to a source — a provider
+// missing from it is a provider no client will ever ask for by name — and it was
+// covered by unit tests alone, never over a real tools/list round-trip.
+func TestE2EDownloadToolAdvertisesEveryEnabledSource(t *testing.T) {
+	env := requireLive(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "libgen-mcp-e2e", Version: "test"}, nil)
+	tools.Register(server, env.client, env.cfg)
+	session := connectInMemory(t, ctx, server, nil)
+
+	list, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools error: %v", err)
+	}
+	enum := downloadSourceEnum(t, list)
+	for _, want := range expectedSourceEnum(env.cfg) {
+		if !slices.Contains(enum, want) {
+			t.Errorf("download source enum omits %q; a model has no way to ask for it. got %v", want, enum)
+		}
+	}
+	t.Logf("download source enum advertises %v", enum)
+}
+
+// listedSchema is the slice of an advertised input schema this suite inspects: the
+// `source` property's enum. A tools/list result carries the schema as decoded JSON,
+// so it is re-marshaled through this shape rather than reaching into the server's
+// own schema type.
+type listedSchema struct {
+	Properties struct {
+		Source struct {
+			Enum []string `json:"enum"`
+		} `json:"source"`
+	} `json:"properties"`
+}
+
+// downloadSourceEnum extracts the download tool's `source` enum from a tools/list
+// result. It FAILS when the tool, the property, or the enum is missing: each is a
+// discoverability guarantee, not an optional extra.
+func downloadSourceEnum(t *testing.T, list *mcp.ListToolsResult) []string {
+	t.Helper()
+	for _, tool := range list.Tools {
+		if tool.Name != "download" {
+			continue
+		}
+		raw, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshaling the download tool's input schema: %v", err)
+		}
+		var schema listedSchema
+		if uerr := json.Unmarshal(raw, &schema); uerr != nil {
+			t.Fatalf("decoding the download tool's input schema: %v", uerr)
+		}
+		if len(schema.Properties.Source.Enum) == 0 {
+			t.Fatalf("the download tool advertises no source enum; every enabled source is undiscoverable. schema: %s", raw)
+		}
+		return schema.Properties.Source.Enum
+	}
+	t.Fatal("tools/list did not advertise a download tool")
+	return nil
+}
+
+// expectedSourceEnum lists the sources this deployment must advertise: every
+// KnownSource the configuration enables, minus the two that are credential-gated
+// and legitimately absent when their credential is not set.
+func expectedSourceEnum(cfg *config.Config) []string {
+	want := make([]string, 0, len(config.KnownSources))
+	for _, name := range config.KnownSources {
+		if len(cfg.Sources) > 0 && !slices.Contains(cfg.Sources, name) {
+			continue
+		}
+		if name == "unpaywall" && strings.TrimSpace(cfg.UnpaywallEmail) == "" {
+			continue
+		}
+		if name == "core" && strings.TrimSpace(cfg.CoreKey) == "" {
+			continue
+		}
+		want = append(want, name)
+	}
+	return want
 }
 
 // escalationItem is the pinned catalog-miss / Anna's-hit fixture.

--- a/test/e2e/remote_http_test.go
+++ b/test/e2e/remote_http_test.go
@@ -148,7 +148,7 @@ func TestE2EHTTPRemoteReadByMD5(t *testing.T) {
 	defer cancel()
 
 	client, _, session := newRemoteHTTPSession(t, ctx, mcp.ClientOptions{})
-	target := smallestTargetIn(t, ctx, client, "nonfiction", "python")
+	target := readableTargetIn(t, ctx, client, "nonfiction", "python")
 	t.Logf("http remote read target md5=%s size=%q ext=%q", target.MD5, target.Size, target.Extension)
 	pace()
 

--- a/test/e2e/remote_test.go
+++ b/test/e2e/remote_test.go
@@ -60,22 +60,12 @@ func newMCPDownloadEnv(t *testing.T, ctx context.Context, remote bool) *mcpDownl
 }
 
 // smallBookTarget searches nonfiction ordered by ascending size and returns the
-// smallest downloadable result (canonical md5, parseable non-zero size within the
-// polite cap). It skips the calling test when no such target is available, to stay
-// a polite citizen of the public mirrors.
+// smallest downloadable result inside the suite's size band — above
+// minE2EDownloadBytes so the download is a real one, below maxE2EDownloadBytes so
+// it stays polite. It skips the calling test when no such target is available.
 func smallBookTarget(t *testing.T, ctx context.Context, client *libgen.Client, query string) libgen.Result {
 	t.Helper()
-	page, _, err := client.Search(ctx, libgen.SearchParams{
-		Query: query, Topics: []string{"nonfiction"}, Order: "size", OrderMode: "asc",
-	})
-	if err != nil {
-		t.Fatalf("Search error: %v", err)
-	}
-	target := smallestDownloadable(page.Results)
-	if target.MD5 == "" {
-		t.Skip("no small downloadable target found; skipping to stay polite")
-	}
-	return target
+	return findLiveTarget(t, ctx, client, liveTarget{topic: "nonfiction", query: query})
 }
 
 // callDownload invokes the `download` tool and decodes its structured output. It
@@ -200,8 +190,9 @@ func TestE2EMCPDownloadLocalToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("saved file missing on disk: %v", err)
 	}
-	if info.Size() == 0 {
-		t.Fatalf("saved file is empty: %s", out.Path)
+	if info.Size() < minE2EDownloadBytes {
+		t.Errorf("saved %d bytes for a target the catalog sized at %q; the size floor did not hold (%s)",
+			info.Size(), target.Size, out.Path)
 	}
 	t.Logf("saved md5=%s bytes=%d source=%s path=%s markdown=%d bytes",
 		target.MD5, out.SizeBytes, out.Source, out.Path, len(textOf(res)))


### PR DESCRIPTION
## Summary

The live end-to-end suite was green but several of its cases were not proving anything.

**Every download and read case ran on an 87-byte file.** `smallestDownloadable` took the first result of a size-ascending search with no lower bound, so it always returned the collection's smallest stub row. `find` matched nothing, `outline` had nothing to list, pagination never triggered, and six tests moved 87 bytes between them. Targets now come from `findLiveTarget`, which walks the size-ascending pages for the smallest result inside `[100 KiB, 25 MiB]` and can require a format the extractors support, so the read cases get a real PDF or EPUB. Comics keep a lower floor — that collection has nothing between its stub rows and its multi-hundred-megabyte scans.

**`outline` was called and only logged.** Both branches are asserted now: with entries, each must carry a title, a non-negative level and a page inside the document, and the guidance must tell the model how to jump there; with none, the no-TOC branch must say so and forbid inventing chapter titles. An outline call was added to the EPUB case too, which is the suite's likeliest target to carry a real navigation document (it finds 53 entries).

**The classified-outcome tests could not tell an outage from a bug.** They matched on `requesting`, `returned HTTP` and `context deadline` — substrings present in almost every failure a download can produce, including a source pointed at the wrong host. Each class now pins the source's own error prefix plus a specific diagnosis, and the transport classes pin the host the source is meant to be calling, so a repointed source fails instead of skipping. Applied to europepmc, biorxiv, fatcat and core.

**fatcat burned 90 s of a 335 s suite** establishing that `api.fatcat.wiki` does not answer from this network. A reachability precondition settles it in three.

New coverage, all of it previously absent:

- a read pagination round-trip that feeds a returned `cursor` back and asserts the second chunk differs and its start position advanced — covering `cursor`, `start_page`, `max_pages`, `offset` and `max_chars`;
- the `download` tool's `source` argument driven over MCP, so `validateDownloadInput` and the dynamic enum are actually exercised (every other source test constructed a `libgen.Item` directly);
- the `download` tool's `source` enum asserted over a real `tools/list` — the model's only discovery path to a source;
- a source-restricted **scihub** case, the last of the ten `KnownSources` without one and the most fragile;
- the `archive_url` / `open_access` / `venue` discovery fields, including a check that Crossref's open-access heuristic has not regressed to always-true;
- a deterministic harness for `elicitAnnasKey` (httptest + scripted elicitation, no network), which had **no test of any kind** — every skip arm, the decline, the blank answer and the accepted key.

## Live results

| | before | after |
| --- | --- | --- |
| PASS | 56 | 60 |
| SKIP | 1 | 1 (fatcat, upstream unreachable) |
| FAIL | 0 | 0 |
| runtime | 335 s | 269 s |

Download targets went from 87 B to 102,773 B; the read cases now work on a 100 kB EPUB and a 2 MB novel.

## Type of change

- [x] Refactor / maintenance

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [ ] Docs updated if behavior changed — no behavior change, tests only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the live e2e suite actually test real downloads and reads by selecting targets in [100 KiB, 25 MiB], asserting outline/find behavior, and classifying source failures precisely with reachability guards. Adds coverage for read pagination, MCP `download` source argument and enum, `scihub`, discovery fields, and a deterministic `elicitAnnasKey` harness; the suite runs faster and more reliably.

- **New Features**
  - Added read pagination round-trip that feeds back the returned cursor and checks content/position advance.
  - Exercised MCP `download` `source` argument over `mcp` and verified the dynamic enum via `tools/list`.
  - Added source-restricted `scihub` live case.
  - Validated discovery fields: `archive_url`, `open_access` (discriminates on Crossref), and `venue` (arXiv).
  - Introduced a deterministic test harness for `elicitAnnasKey` (accept, decline, blank, capability-less).

- **Bug Fixes**
  - Replaced smallest-file picker with `findLiveTarget` to enforce a [100 KiB, 25 MiB] floor/ceiling and pick extractable formats (`pdf`/`epub`) for reads; comics use a lower floor.
  - Asserted `read` modes fully: find snippets/counts, outline entries (titles/levels/pages) or explicit no-TOC with “don’t invent” guidance; added EPUB outline.
  - Tightened classified outcomes: match on source-prefixed diagnostics and pin expected hosts; added fast upstream reachability preconditions (e.g., `fatcat`).
  - Ensured saved downloads clear the size floor; overall runtime dropped from 335 s to 269 s.

<sup>Written for commit db70445ab7774b7a4214d9742a76a21e6c6b2abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

