### PR TITLE
perf(download): remember an unavailable source instead of paying for it every call

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,6 +180,8 @@ Two rules bound the behavior:
 - A cooldown only deprioritizes. When **every** source able to serve an item is in cooldown,
   the chain tries them all anyway — better to try than nothing — and says so in the log. An
   explicit `source:` argument therefore always reaches the source it names.
+- A success lifts it. A source that just served a file is not unavailable, so serving one
+  clears its cooldown.
 - Nothing is persisted. The state lives on the client for the life of the process, so a
   restart starts clean.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,6 +161,32 @@ offered article sources first, then book sources. `LIBGEN_MCP_SOURCES` removes s
 this chain without reordering it. `Download` tries each supporting source in turn and returns
 the first success; if all fail, it returns the joined per-source errors.
 
+### Per-source cooldown
+
+A source that fails because it is **unavailable** — a transport error, a timeout, a 5xx or a
+429 — is set aside for 5 minutes, so the next download does not spend its resolve budget on a
+provider that just proved unreachable. This is the source-level counterpart of the per-mirror
+cooldown in the HTTP client, and it matters most for a service that is down for hours at a
+time: without it, every article download pays the full per-source budget for that provider
+again and again.
+
+A source that answers correctly that it does **not hold the item** — not indexed, not open
+access, no preserved copy — is never set aside: that is a normal, correct answer about one
+item and says nothing about the provider's health. The two cases are told apart by the error
+taxonomy each source tags its failures with (`ErrSourceUnavailable` vs `ErrNotIndexed`).
+
+Two rules bound the behavior:
+
+- A cooldown only deprioritizes. When **every** source able to serve an item is in cooldown,
+  the chain tries them all anyway — better to try than nothing — and says so in the log. An
+  explicit `source:` argument therefore always reaches the source it names.
+- Nothing is persisted. The state lives on the client for the life of the process, so a
+  restart starts clean.
+
+Both decisions are visible in the log alongside the existing per-source attempt lines: a
+skipped source is reported at `INFO` with the instant its cooldown expires, and an
+all-cooled-down bypass at `WARN`.
+
 ## Search path
 
 The download chain above is one of two federations in the server. The other is the search

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -88,6 +88,29 @@ open-access providers first, then the shadow-library fallbacks:
 - Note that DOI downloads are **not** MD5-verified (`verified` is `false`) — there is no
   LibGen digest for them.
 
+## A source is missing from the errors of a repeated download
+
+**Symptom.** A `download` fails, and a second attempt reports fewer sources than the first —
+one that failed a moment ago is not mentioned at all.
+
+**Meaning.** That source is in **cooldown**. When a source fails because it is unavailable (a
+transport error, a timeout, a 5xx or a 429) it is set aside for 5 minutes, so the next
+download does not spend its resolve budget on a provider that just proved unreachable. It is
+skipped, not removed: the cooldown expires on its own, nothing is written to disk (a restart
+clears it), and when every source able to serve the item is in cooldown they are all tried
+anyway. A source that merely reported it does not hold the item is never set aside.
+
+The server log says which sources were skipped and why — `source in cooldown, skipping` with
+the instant it becomes eligible again, or `every capable source is in cooldown, trying them
+anyway`. Run with `LIBGEN_MCP_LOG_LEVEL=info` (the default) to see them.
+
+**Fixes.**
+
+- Nothing is needed: retry later, or immediately with `source: "<name>"` to address that
+  provider directly — an explicit source is always tried, cooldown or not.
+- If a source is repeatedly cooled down, it is genuinely unreachable from this host. Check it
+  by hand before suspecting the server.
+
 ## Truncated search results
 
 **Symptom.** A search response has `truncated: true` and a `hint`, and paging past a certain

--- a/internal/libgen/client.go
+++ b/internal/libgen/client.go
@@ -143,6 +143,21 @@ type Client struct {
 
 	mu       sync.Mutex           // protects cooldown
 	cooldown map[string]time.Time // mirror base → instant at which the cooldown expires
+
+	// sourceMu guards sourceCooldown. It is deliberately separate from mu: that one
+	// guards the per-mirror cooldown, whose keys are mirror base URLs, and conflating
+	// the two key spaces would let a failing mirror influence which download sources
+	// the chain is willing to try.
+	sourceMu sync.Mutex
+	// sourceCooldown records download sources set aside after proving unavailable:
+	// source name → instant at which the cooldown expires. It lives on the Client
+	// (which outlives every individual download) and is never persisted, so a fresh
+	// process always starts by trying every source.
+	sourceCooldown map[string]time.Time
+	// sourceCooldownWindow overrides sourceCooldownDuration. A non-positive value
+	// selects the constant; it is injectable so tests can observe an expiry without
+	// waiting minutes for one.
+	sourceCooldownWindow time.Duration
 }
 
 // refLock is a per-key serialization lock with a reference count. refs tracks how
@@ -253,6 +268,7 @@ func New(m MirrorLister, cfg *config.Config, opts ...Option) *Client {
 		stallTimeout:     cfg.DownloadStallTimeout,
 		dlSem:            make(chan struct{}, maxConcurrent),
 		cooldown:         make(map[string]time.Time),
+		sourceCooldown:   make(map[string]time.Time),
 		tempCache:        newTempCache(cfg.ReadCacheBytes, cfg.ReadCacheTTL),
 	}
 	c.retryEverySource = cfg.RetryEverySource

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -438,6 +438,7 @@ func (c *Client) ResolveLink(ctx context.Context, item Item) (ResolvedDownload, 
 			}
 			continue
 		}
+		c.clearSourceCooldown(src.Name())
 		return ResolvedDownload{
 			URL:       resolved.FileURL,
 			Header:    resolved.Header,
@@ -544,6 +545,7 @@ func (c *Client) DownloadItem(ctx context.Context, item Item, dir, filename stri
 		res, err := c.downloadFrom(ctx, src, req, lastResort)
 		logging.SourceAttempt(src.Name(), started, err)
 		if err == nil {
+			c.clearSourceCooldown(src.Name())
 			return res, nil
 		}
 		c.noteSourceFailure(ctx, src.Name(), err)

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -428,12 +428,10 @@ func (c *Client) ResolveLink(ctx context.Context, item Item) (ResolvedDownload, 
 	sources = c.withPerCallUnpaywall(item, sources)
 	sources = c.withPerCallAnnas(item, sources)
 	var errs []error
-	for _, src := range sources {
-		if !src.Supports(item) {
-			continue
-		}
+	for _, src := range c.eligibleSources(supportingSources(sources, item)) {
 		resolved, rerr := c.resolveWithin(ctx, src, item)
 		if rerr != nil {
+			c.noteSourceFailure(ctx, src.Name(), rerr)
 			errs = append(errs, fmt.Errorf("source %s: %w", src.Name(), rerr))
 			if ctx.Err() != nil {
 				break
@@ -535,13 +533,9 @@ func (c *Client) DownloadItem(ctx context.Context, item Item, dir, filename stri
 	// stream is rejected (HTML page / integrity mismatch / short read) advances to
 	// the next. The first success returns; if all fail, the joined errors surface.
 	// Only the sources that can serve this item matter, and the last of them is the
-	// one worth waiting on: see downloadFrom.
-	supporting := make([]DownloadSource, 0, len(sources))
-	for _, src := range sources {
-		if src.Supports(item) {
-			supporting = append(supporting, src)
-		}
-	}
+	// one worth waiting on: see downloadFrom. Sources a recent failure proved
+	// unavailable are passed over unless they are all that is left (eligibleSources).
+	supporting := c.eligibleSources(supportingSources(sources, item))
 
 	var errs []error
 	for i, src := range supporting {
@@ -552,6 +546,7 @@ func (c *Client) DownloadItem(ctx context.Context, item Item, dir, filename stri
 		if err == nil {
 			return res, nil
 		}
+		c.noteSourceFailure(ctx, src.Name(), err)
 		errs = append(errs, fmt.Errorf("source %s: %w", src.Name(), err))
 		// A canceled/expired context will not recover on the next source, so stop.
 		if ctx.Err() != nil {

--- a/internal/libgen/source.go
+++ b/internal/libgen/source.go
@@ -156,6 +156,14 @@ type DownloadSource interface {
 	Supports(it Item) bool
 	// Resolve turns the Item into a Resolved (URL + streaming directives), or
 	// returns an error so the caller can try the next source.
+	//
+	// That error should be classified with the taxonomy in sourceerr.go: wrap a
+	// failure that shows the source itself to be unreachable (transport error,
+	// timeout, 5xx/429) with unavailable, and a correct "I do not hold this item"
+	// with notIndexed. The chain sets an unavailable source aside for a while
+	// (see eligibleSources) and never penalizes a clean miss, so an untagged
+	// failure only costs the chain that optimization — it is never wrong, just
+	// less informed.
 	Resolve(ctx context.Context, it Item) (Resolved, error)
 }
 

--- a/internal/libgen/source_annas.go
+++ b/internal/libgen/source_annas.go
@@ -164,7 +164,7 @@ func (s annasSource) resolveViaMemberAPI(ctx context.Context, httpClient *http.C
 
 	resp, err := s.get(ctx, httpClient, endpoint, nil)
 	if err != nil {
-		return "", nil, fmt.Errorf("annas: member request to %q: %w", base, err)
+		return "", nil, unavailable(fmt.Errorf("annas: member request to %q: %w", base, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -225,16 +225,16 @@ func (s annasSource) resolveViaIPFS(ctx context.Context, httpClient *http.Client
 func (s annasSource) fetchCID(ctx context.Context, httpClient *http.Client, base, md5 string) (cid, ext string, err error) {
 	resp, err := s.get(ctx, httpClient, base+"/md5/"+url.PathEscape(md5), nil)
 	if err != nil {
-		return "", "", fmt.Errorf("annas: requesting %q: %w", base, err)
+		return "", "", unavailable(fmt.Errorf("annas: requesting %q: %w", base, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("annas: mirror %q returned HTTP %d", base, resp.StatusCode)
+		return "", "", unavailableStatus(resp.StatusCode, fmt.Errorf("annas: mirror %q returned HTTP %d", base, resp.StatusCode))
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, annasMaxBody))
 	if err != nil {
-		return "", "", fmt.Errorf("annas: reading %q: %w", base, err)
+		return "", "", unavailable(fmt.Errorf("annas: reading %q: %w", base, err))
 	}
 	cid, ok := extractIPFSCID(body)
 	if !ok {

--- a/internal/libgen/source_biorxiv.go
+++ b/internal/libgen/source_biorxiv.go
@@ -107,7 +107,7 @@ func (s biorxivSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 		}
 	}
 	if misses == len(biorxivServers) {
-		return Resolved{}, fmt.Errorf("biorxiv: %q not found on bioRxiv or medRxiv", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("biorxiv: %q not found on bioRxiv or medRxiv", it.DOI))
 	}
 	return Resolved{}, fmt.Errorf("biorxiv: could not confirm %q: %w", it.DOI, failure)
 }
@@ -133,11 +133,11 @@ func (s biorxivSource) lookupVersion(ctx context.Context, server, doi string) (s
 	httpClient := httpClientOr(s.http)
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("biorxiv: requesting %s for %q: %w", server, doi, err)
+		return "", unavailable(fmt.Errorf("biorxiv: requesting %s for %q: %w", server, doi, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("biorxiv: %s returned HTTP %d for %q", server, resp.StatusCode, doi)
+		return "", unavailableStatus(resp.StatusCode, fmt.Errorf("biorxiv: %s returned HTTP %d for %q", server, resp.StatusCode, doi))
 	}
 
 	var rec biorxivResponse

--- a/internal/libgen/source_core.go
+++ b/internal/libgen/source_core.go
@@ -85,7 +85,7 @@ func (s coreSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 	// falls through here rather than costing a wasted download attempt. The probe
 	// carries no Authorization, so the key stays on the API host, not the file URL.
 	if !probePDF(ctx, s.client(), downloadURL) {
-		return Resolved{}, fmt.Errorf("core: %q has no downloadable open-access full text", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("core: %q has no downloadable open-access full text", it.DOI))
 	}
 	return Resolved{FileURL: downloadURL, VerifyMD5: false, Ext: "pdf"}, nil
 }
@@ -114,15 +114,17 @@ func (s coreSource) lookupDownloadURL(ctx context.Context, doi string) (string, 
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return "", fmt.Errorf("core: requesting %q: %w", doi, err)
+		return "", unavailable(fmt.Errorf("core: requesting %q: %w", doi, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return "", fmt.Errorf("core: API key rejected (HTTP %d)", resp.StatusCode)
+		// A rejected key is item-independent: every later item would be rejected the
+		// same way, so the source is unusable rather than this DOI missing.
+		return "", unavailable(fmt.Errorf("core: API key rejected (HTTP %d)", resp.StatusCode))
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("core: %q returned HTTP %d", doi, resp.StatusCode)
+		return "", unavailableStatus(resp.StatusCode, fmt.Errorf("core: %q returned HTTP %d", doi, resp.StatusCode))
 	}
 
 	var rec coreResponse
@@ -130,10 +132,10 @@ func (s coreSource) lookupDownloadURL(ctx context.Context, doi string) (string, 
 		return "", fmt.Errorf("core: decoding response for %q: %w", doi, decErr)
 	}
 	if len(rec.Results) == 0 {
-		return "", fmt.Errorf("core: %q is not in CORE", doi)
+		return "", notIndexed(fmt.Errorf("core: %q is not in CORE", doi))
 	}
 	if rec.Results[0].DownloadURL == "" {
-		return "", fmt.Errorf("core: %q has no downloadable open-access full text", doi)
+		return "", notIndexed(fmt.Errorf("core: %q has no downloadable open-access full text", doi))
 	}
 	return rec.Results[0].DownloadURL, nil
 }

--- a/internal/libgen/source_europepmc.go
+++ b/internal/libgen/source_europepmc.go
@@ -89,7 +89,7 @@ func (s europePMCSource) Resolve(ctx context.Context, it Item) (Resolved, error)
 		return Resolved{}, err
 	}
 	if rec.PMCID == "" || !strings.EqualFold(rec.InEPMC, "Y") || !strings.EqualFold(rec.IsOpenAccess, "Y") {
-		return Resolved{}, fmt.Errorf("europepmc: %q is indexed but has no open-access full text", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("europepmc: %q is indexed but has no open-access full text", it.DOI))
 	}
 	fileURL, err := s.pdfURL(ctx, rec.PMCID)
 	if err != nil {
@@ -125,11 +125,11 @@ func (s europePMCSource) lookup(ctx context.Context, doi string) (europePMCResul
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return europePMCResult{}, fmt.Errorf("europepmc: requesting %q: %w", doi, err)
+		return europePMCResult{}, unavailable(fmt.Errorf("europepmc: requesting %q: %w", doi, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return europePMCResult{}, fmt.Errorf("europepmc: %q returned HTTP %d", doi, resp.StatusCode)
+		return europePMCResult{}, unavailableStatus(resp.StatusCode, fmt.Errorf("europepmc: %q returned HTTP %d", doi, resp.StatusCode))
 	}
 
 	var rec europePMCResponse
@@ -137,7 +137,7 @@ func (s europePMCSource) lookup(ctx context.Context, doi string) (europePMCResul
 		return europePMCResult{}, fmt.Errorf("europepmc: decoding response for %q: %w", doi, decErr)
 	}
 	if rec.HitCount == 0 || len(rec.ResultList.Result) == 0 {
-		return europePMCResult{}, fmt.Errorf("europepmc: %q is not indexed", doi)
+		return europePMCResult{}, notIndexed(fmt.Errorf("europepmc: %q is not indexed", doi))
 	}
 	return rec.ResultList.Result[0], nil
 }
@@ -161,7 +161,9 @@ func (s europePMCSource) pdfURL(ctx context.Context, pmcid string) (string, erro
 			return c, nil
 		}
 	}
-	return "", fmt.Errorf("europepmc: no reachable PDF endpoint for %s", pmcid)
+	// Both candidates are official Europe PMC hosts, so neither answering is the
+	// service being unreachable rather than a statement about this article.
+	return "", unavailable(fmt.Errorf("europepmc: no reachable PDF endpoint for %s", pmcid))
 }
 
 // client returns the configured HTTP client, or the shared default when none was

--- a/internal/libgen/source_fatcat.go
+++ b/internal/libgen/source_fatcat.go
@@ -88,15 +88,15 @@ func (s fatcatSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 	httpClient := httpClientOr(s.http)
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return Resolved{}, fmt.Errorf("fatcat: requesting %q: %w", it.DOI, err)
+		return Resolved{}, unavailable(fmt.Errorf("fatcat: requesting %q: %w", it.DOI, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return Resolved{}, fmt.Errorf("fatcat: %q is unknown to fatcat", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("fatcat: %q is unknown to fatcat", it.DOI))
 	}
 	if resp.StatusCode != http.StatusOK {
-		return Resolved{}, fmt.Errorf("fatcat: %q returned HTTP %d", it.DOI, resp.StatusCode)
+		return Resolved{}, unavailableStatus(resp.StatusCode, fmt.Errorf("fatcat: %q returned HTTP %d", it.DOI, resp.StatusCode))
 	}
 
 	var rec fatcatResponse
@@ -105,7 +105,7 @@ func (s fatcatSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 	}
 	fileURL, ok := pickArchivedPDF(rec.Files)
 	if !ok {
-		return Resolved{}, fmt.Errorf("fatcat: %q has no preserved Internet Archive file", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("fatcat: %q has no preserved Internet Archive file", it.DOI))
 	}
 	return Resolved{FileURL: fileURL, VerifyMD5: false, Ext: "pdf"}, nil
 }

--- a/internal/libgen/source_randombook.go
+++ b/internal/libgen/source_randombook.go
@@ -163,7 +163,7 @@ func (s randombookSource) lookupID(ctx context.Context, md5 string) (string, err
 		return "", fmt.Errorf("randombook: by-id API reported an error for md5 %q", md5)
 	}
 	if rec.Result == nil {
-		return "", fmt.Errorf("randombook: md5 %q not indexed", md5)
+		return "", notIndexed(fmt.Errorf("randombook: md5 %q not indexed", md5))
 	}
 	if rec.Result.ID == "" {
 		return "", fmt.Errorf("%w: randombook by-id result carries no id", ErrLayoutChanged)
@@ -243,7 +243,7 @@ func (s randombookSource) resolveViaDownloadAPI(ctx context.Context, mirror, id 
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return "", fmt.Errorf("randombook: probing %q: %w", base, err)
+		return "", unavailable(fmt.Errorf("randombook: probing %q: %w", base, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -277,12 +277,12 @@ func (s randombookSource) resolveViaMirror(ctx context.Context, mirror, md5 stri
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return "", fmt.Errorf("randombook: requesting %q: %w", base, err)
+		return "", unavailable(fmt.Errorf("randombook: requesting %q: %w", base, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("randombook: mirror %q returned HTTP %d", base, resp.StatusCode)
+		return "", unavailableStatus(resp.StatusCode, fmt.Errorf("randombook: mirror %q returned HTTP %d", base, resp.StatusCode))
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodySize))
 	if err != nil {
@@ -309,12 +309,12 @@ func (s randombookSource) getJSON(ctx context.Context, endpoint string, out any)
 
 	resp, err := s.client().Do(req)
 	if err != nil {
-		return fmt.Errorf("randombook: requesting %q: %w", endpoint, err)
+		return unavailable(fmt.Errorf("randombook: requesting %q: %w", endpoint, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("randombook: %q returned HTTP %d", endpoint, resp.StatusCode)
+		return unavailableStatus(resp.StatusCode, fmt.Errorf("randombook: %q returned HTTP %d", endpoint, resp.StatusCode))
 	}
 	if decErr := json.NewDecoder(io.LimitReader(resp.Body, randombookMaxBody)).Decode(out); decErr != nil {
 		return fmt.Errorf("%w: randombook: decoding %q: %w", ErrLayoutChanged, endpoint, decErr)

--- a/internal/libgen/source_scidb.go
+++ b/internal/libgen/source_scidb.go
@@ -70,7 +70,7 @@ func (s scidbSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 			continue
 		}
 		if pdfURL == "" {
-			lastErr = fmt.Errorf("scidb: mirror %q embedded no PDF for %q", base, it.DOI)
+			lastErr = notIndexed(fmt.Errorf("scidb: mirror %q embedded no PDF for %q", base, it.DOI))
 			continue
 		}
 		return Resolved{
@@ -102,19 +102,19 @@ func (s scidbSource) tryMirror(ctx context.Context, httpClient *http.Client, bas
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("scidb: requesting %q: %w", base, err)
+		return "", unavailable(fmt.Errorf("scidb: requesting %q: %w", base, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	// Gate extraction on a 200: an error or challenge page can still carry a stale
 	// marker, so scraping it would hand back a dead URL. Skip the mirror instead.
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("scidb: mirror %q returned HTTP %d", base, resp.StatusCode)
+		return "", unavailableStatus(resp.StatusCode, fmt.Errorf("scidb: mirror %q returned HTTP %d", base, resp.StatusCode))
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, scidbMaxBody))
 	if err != nil {
-		return "", fmt.Errorf("scidb: reading %q: %w", base, err)
+		return "", unavailable(fmt.Errorf("scidb: reading %q: %w", base, err))
 	}
 	pdfURL, _ := extractSciDBPDF(body)
 	return pdfURL, nil

--- a/internal/libgen/source_scihub.go
+++ b/internal/libgen/source_scihub.go
@@ -75,7 +75,7 @@ func (s scihubSource) Resolve(ctx context.Context, it Item) (Resolved, error) {
 			continue
 		}
 		if pdfURL == "" {
-			lastErr = fmt.Errorf("scihub: host %q served no PDF link for %q", host, it.DOI)
+			lastErr = notIndexed(fmt.Errorf("scihub: host %q served no PDF link for %q", host, it.DOI))
 			continue
 		}
 		return Resolved{
@@ -108,7 +108,7 @@ func (s scihubSource) tryHost(ctx context.Context, httpClient *http.Client, sche
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("scihub: requesting %q: %w", host, err)
+		return "", unavailable(fmt.Errorf("scihub: requesting %q: %w", host, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -116,12 +116,12 @@ func (s scihubSource) tryHost(ctx context.Context, httpClient *http.Client, sche
 	// embed a stale id="pdf" element, so scraping a PDF link from a non-OK
 	// response would hand back a dead URL. Skip the host instead.
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("scihub: host %q returned HTTP %d", host, resp.StatusCode)
+		return "", unavailableStatus(resp.StatusCode, fmt.Errorf("scihub: host %q returned HTTP %d", host, resp.StatusCode))
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, scihubMaxBody))
 	if err != nil {
-		return "", fmt.Errorf("scihub: reading %q: %w", host, err)
+		return "", unavailable(fmt.Errorf("scihub: reading %q: %w", host, err))
 	}
 	pdfURL, _ := extractScihubPDF(body)
 	return pdfURL, nil

--- a/internal/libgen/source_unpaywall.go
+++ b/internal/libgen/source_unpaywall.go
@@ -140,12 +140,12 @@ func (s unpaywallSource) Resolve(ctx context.Context, it Item) (Resolved, error)
 	httpClient := httpClientOr(s.http)
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return Resolved{}, fmt.Errorf("unpaywall: requesting %q: %w", it.DOI, err)
+		return Resolved{}, unavailable(fmt.Errorf("unpaywall: requesting %q: %w", it.DOI, err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return Resolved{}, fmt.Errorf("unpaywall: %q returned HTTP %d", it.DOI, resp.StatusCode)
+		return Resolved{}, unavailableStatus(resp.StatusCode, fmt.Errorf("unpaywall: %q returned HTTP %d", it.DOI, resp.StatusCode))
 	}
 
 	var rec unpaywallResponse
@@ -158,14 +158,14 @@ func (s unpaywallSource) Resolve(ctx context.Context, it Item) (Resolved, error)
 	// ("no open-access PDF"). Keeping them separate lets the chain and any log tell
 	// the two apart.
 	if !rec.IsOA {
-		return Resolved{}, fmt.Errorf("unpaywall: %q is not open access", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("unpaywall: %q is not open access", it.DOI))
 	}
 	fileURL := rec.bestPDFURL()
 	if fileURL == "" {
 		fileURL = rec.landingURL()
 	}
 	if fileURL == "" {
-		return Resolved{}, fmt.Errorf("unpaywall: no open-access PDF for %q", it.DOI)
+		return Resolved{}, notIndexed(fmt.Errorf("unpaywall: no open-access PDF for %q", it.DOI))
 	}
 	return Resolved{
 		FileURL:   fileURL,

--- a/internal/libgen/sourcecooldown.go
+++ b/internal/libgen/sourcecooldown.go
@@ -1,0 +1,127 @@
+package libgen
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmrplens/libgen-mcp/internal/logging"
+)
+
+// sourceCooldownDuration is how long a download source is set aside after a failure
+// that showed the SOURCE to be unavailable rather than the item to be missing. It is
+// the source-level counterpart of cooldownDuration (the per-mirror window) and is
+// deliberately much longer: a mirror is one host inside a family that rotates by the
+// second, whereas a source is a whole service, and when one is down it is typically
+// down for hours (api.fatcat.wiki has been unreachable for days at a time). The cost
+// of a stale cooldown is bounded — the source is only deprioritized, never removed —
+// while the cost of retrying too eagerly is a full resolve budget burned on every
+// download.
+//
+// Five minutes is long enough to cover a working session's worth of downloads and
+// short enough that a service coming back is picked up without restarting the
+// server. It is a constant rather than an environment variable on purpose: this is a
+// self-tuning failover detail, not a deployment decision, and every new
+// LIBGEN_MCP_* knob is one more thing to document, validate and support.
+const sourceCooldownDuration = 5 * time.Minute
+
+// cooldownWindow returns the cooldown length to apply: the injected test override
+// when one is set, else sourceCooldownDuration.
+func (c *Client) cooldownWindow() time.Duration {
+	if c.sourceCooldownWindow > 0 {
+		return c.sourceCooldownWindow
+	}
+	return sourceCooldownDuration
+}
+
+// markSourceCooldown sets a source aside for the cooldown window after a failure
+// that proved it unavailable. The map is created on demand so a Client built
+// directly (as tests do) needs no extra wiring.
+func (c *Client) markSourceCooldown(name string) {
+	c.sourceMu.Lock()
+	if c.sourceCooldown == nil {
+		c.sourceCooldown = make(map[string]time.Time)
+	}
+	c.sourceCooldown[name] = time.Now().Add(c.cooldownWindow())
+	c.sourceMu.Unlock()
+}
+
+// noteSourceFailure records what a failed source attempt taught us: an unavailable
+// source is put in cooldown so the next download does not pay for it again, while a
+// source that answered correctly that it does not hold the item is left alone.
+func (c *Client) noteSourceFailure(ctx context.Context, name string, err error) {
+	if cooldownWorthy(ctx, err) {
+		c.markSourceCooldown(name)
+	}
+}
+
+// cooledSource is one source passed over for being in cooldown, carried out of the
+// locked section so the skip can be logged without holding the mutex.
+type cooledSource struct {
+	// name is the skipped source's Name().
+	name string
+	// until is the instant its cooldown expires.
+	until time.Time
+}
+
+// eligibleSources filters a per-item source list down to those not currently in
+// cooldown, preserving chain order, and logs each source it passes over so a
+// shortened chain is never a silent one.
+//
+// When EVERY candidate is in cooldown it returns the full list instead: a cooldown
+// deprioritizes a source, it never makes a download impossible — the same "better to
+// try than nothing" rule the mirror cooldown follows in candidates. That fallback is
+// also what keeps an explicit source: request working: a single-source chain is
+// always fully cooled down, so the caller still reaches the source it named.
+//
+// Skipping was chosen over moving cooled-down sources to the end of the chain
+// because the chain grants its LAST source the full start-retry schedule
+// (downloadFrom): pushing a dead source to the tail would hand it the most patience
+// of all, which is the opposite of the intent.
+func (c *Client) eligibleSources(supporting []DownloadSource) []DownloadSource {
+	now := time.Now()
+	avail := make([]DownloadSource, 0, len(supporting))
+	var cooled []cooledSource
+
+	c.sourceMu.Lock()
+	for _, s := range supporting {
+		until, ok := c.sourceCooldown[s.Name()]
+		if !ok || now.After(until) {
+			avail = append(avail, s)
+			continue
+		}
+		cooled = append(cooled, cooledSource{name: s.Name(), until: until})
+	}
+	c.sourceMu.Unlock()
+
+	if len(avail) == 0 {
+		logging.SourceCooldownBypassed(cooledNames(cooled))
+		return supporting
+	}
+	for _, s := range cooled {
+		logging.SourceSkipped(s.name, s.until)
+	}
+	return avail
+}
+
+// cooledNames reduces the cooled-down sources to their names, for the log line that
+// reports a bypass.
+func cooledNames(cooled []cooledSource) []string {
+	names := make([]string, 0, len(cooled))
+	for _, s := range cooled {
+		names = append(names, s.name)
+	}
+	return names
+}
+
+// supportingSources returns the sources from chain that can serve item, in chain
+// order. Filtering up front is what lets the chain know which source is its last
+// resort, and which ones the cooldown may pass over.
+func supportingSources(chain []DownloadSource, item Item) []DownloadSource {
+	supporting := make([]DownloadSource, 0, len(chain))
+	for _, src := range chain {
+		if src.Supports(item) {
+			supporting = append(supporting, src)
+		}
+	}
+	return supporting
+}

--- a/internal/libgen/sourcecooldown.go
+++ b/internal/libgen/sourcecooldown.go
@@ -45,6 +45,18 @@ func (c *Client) markSourceCooldown(name string) {
 	c.sourceMu.Unlock()
 }
 
+// clearSourceCooldown lifts a source's cooldown after it served an item: whatever
+// an earlier failure suggested, a source that just answered is available.
+//
+// It matters because of the all-cooled-down bypass: that path can let a cooled-down
+// source succeed, and leaving its stale entry in place would make the next call skip
+// the one source now known to work.
+func (c *Client) clearSourceCooldown(name string) {
+	c.sourceMu.Lock()
+	delete(c.sourceCooldown, name)
+	c.sourceMu.Unlock()
+}
+
 // noteSourceFailure records what a failed source attempt taught us: an unavailable
 // source is put in cooldown so the next download does not pay for it again, while a
 // source that answered correctly that it does not hold the item is left alone.

--- a/internal/libgen/sourcecooldown_test.go
+++ b/internal/libgen/sourcecooldown_test.go
@@ -192,6 +192,26 @@ func TestPinnedSourceIgnoresItsOwnCooldown(t *testing.T) {
 	}
 }
 
+// TestSourceCooldownIsLiftedOnSuccess verifies a source that serves an item leaves
+// its cooldown behind. The all-cooled-down bypass can let a cooled source succeed,
+// and a stale entry would then make the next call skip the one source known to work.
+func TestSourceCooldownIsLiftedOnSuccess(t *testing.T) {
+	good := stubSource{name: "good", supports: true, resolved: Resolved{FileURL: "https://cdn/x.pdf", Ext: "pdf"}}
+	other := stubSource{name: "other", supports: true}
+	c := cooldownChainClient(good)
+	c.markSourceCooldown("good")
+	c.markSourceCooldown("other")
+
+	if _, err := c.ResolveLink(context.Background(), Item{DOI: "10.1/x"}); err != nil {
+		t.Fatalf("ResolveLink: %v", err)
+	}
+
+	// "other" stays in cooldown, so there is no bypass to mask the result.
+	if got := srcNames(c.eligibleSources([]DownloadSource{good, other})); len(got) != 1 || got[0] != "good" {
+		t.Errorf("eligible sources = %v, want [good]: a source that just served must not stay in cooldown", got)
+	}
+}
+
 // TestSourceCooldownIsRaceFree exercises the cooldown map from several goroutines
 // at once, so `go test -race` proves the shared state is properly guarded.
 func TestSourceCooldownIsRaceFree(t *testing.T) {

--- a/internal/libgen/sourcecooldown_test.go
+++ b/internal/libgen/sourcecooldown_test.go
@@ -1,0 +1,215 @@
+package libgen
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingSource is a DownloadSource that counts how often it was asked to resolve
+// and always fails with a fixed error, so a test can prove which sources the chain
+// actually reached across successive calls.
+type countingSource struct {
+	name     string
+	err      error
+	attempts *atomic.Int32
+}
+
+func (s countingSource) Name() string     { return s.name }
+func (countingSource) Supports(Item) bool { return true }
+func (s countingSource) Resolve(context.Context, Item) (Resolved, error) {
+	s.attempts.Add(1)
+	return Resolved{}, s.err
+}
+
+// cooldownChainClient builds a client whose article chain is the two counting
+// sources given, with the short start-retry schedule the unit tests use.
+func cooldownChainClient(sources ...DownloadSource) *Client {
+	c := newTestClient(staticMirrors{})
+	c.sources = sources
+	return c
+}
+
+// captureLog redirects slog to a buffer for the duration of the test and returns it.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	return &buf
+}
+
+// TestUnavailableSourceIsSkippedOnTheNextCall is the feature's core promise: a
+// source that proved unreachable is remembered and passed over on the next
+// download, while a source that merely answered "I do not hold this item" keeps its
+// place in the chain. Without this, a globally dead source burns its resolve budget
+// on every single call.
+func TestUnavailableSourceIsSkippedOnTheNextCall(t *testing.T) {
+	var dead, missing atomic.Int32
+	c := cooldownChainClient(
+		countingSource{name: "dead", err: unavailable(errors.New("dial tcp: no answer")), attempts: &dead},
+		countingSource{name: "missing", err: notIndexed(errors.New("not in my index")), attempts: &missing},
+	)
+
+	for range 2 {
+		if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), ""); err == nil {
+			t.Fatal("every source fails, so DownloadItem must return an error")
+		}
+	}
+
+	if got := dead.Load(); got != 1 {
+		t.Errorf("the unavailable source resolved %d times, want 1 (the second call must skip it)", got)
+	}
+	if got := missing.Load(); got != 2 {
+		t.Errorf(`the "not indexed" source resolved %d times, want 2 (a clean miss must not cost it its place)`, got)
+	}
+}
+
+// TestSourceCooldownExpires verifies the cooldown is a delay, not a removal: once
+// the window passes the source is offered to the chain again.
+func TestSourceCooldownExpires(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	c.sourceCooldownWindow = 20 * time.Millisecond
+	chain := []DownloadSource{
+		stubSource{name: "fatcat", supports: true},
+		stubSource{name: "scidb", supports: true},
+	}
+
+	c.markSourceCooldown("fatcat")
+	if got := srcNames(c.eligibleSources(chain)); len(got) != 1 || got[0] != "scidb" {
+		t.Fatalf("eligible sources = %v, want [scidb] while fatcat is in cooldown", got)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := srcNames(c.eligibleSources(chain)); len(got) != 2 {
+		t.Errorf("eligible sources = %v, want both once the cooldown expired", got)
+	}
+}
+
+// TestEverySourceCooledDownIsStillAttempted verifies a cooldown never makes a
+// download impossible: when every source able to serve the item is set aside, the
+// chain tries them all anyway — better to try than nothing.
+func TestEverySourceCooledDownIsStillAttempted(t *testing.T) {
+	var first, second atomic.Int32
+	c := cooldownChainClient(
+		countingSource{name: "first", err: unavailable(errors.New("dial tcp")), attempts: &first},
+		countingSource{name: "second", err: unavailable(errors.New("dial tcp")), attempts: &second},
+	)
+	c.markSourceCooldown("first")
+	c.markSourceCooldown("second")
+
+	if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), ""); err == nil {
+		t.Fatal("both sources fail, so DownloadItem must return an error")
+	}
+	if first.Load() != 1 || second.Load() != 1 {
+		t.Errorf("attempts = (%d, %d), want (1, 1): a cooldown must deprioritize, never disable",
+			first.Load(), second.Load())
+	}
+}
+
+// TestSourceCooldownIsVisibleInTheLog verifies a skipped source is reported rather
+// than silently absent. A source that vanishes from the chain log with no
+// explanation is the debugging dead end this feature must not create.
+func TestSourceCooldownIsVisibleInTheLog(t *testing.T) {
+	buf := captureLog(t)
+	var dead, missing atomic.Int32
+	c := cooldownChainClient(
+		countingSource{name: "dead", err: unavailable(errors.New("dial tcp")), attempts: &dead},
+		countingSource{name: "missing", err: notIndexed(errors.New("not indexed")), attempts: &missing},
+	)
+
+	for range 2 {
+		_, _ = c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), "")
+	}
+
+	log := buf.String()
+	if !strings.Contains(log, "cooldown") || !strings.Contains(log, `"source":"dead"`) {
+		t.Errorf("the log never explains that dead was skipped for being in cooldown; log=%s", log)
+	}
+}
+
+// TestEverySourceCooledDownIsLogged verifies the bypass is reported too: trying
+// sources that are all in cooldown is a deliberate decision, so the log says so.
+func TestEverySourceCooledDownIsLogged(t *testing.T) {
+	buf := captureLog(t)
+	var only atomic.Int32
+	c := cooldownChainClient(countingSource{name: "only", err: unavailable(errors.New("dial tcp")), attempts: &only})
+	c.markSourceCooldown("only")
+
+	_, _ = c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), "")
+
+	if log := buf.String(); !strings.Contains(log, "in cooldown, trying them anyway") {
+		t.Errorf("the log never explains why a cooled-down source was tried anyway; log=%s", log)
+	}
+}
+
+// TestResolveLinkHonorsTheSourceCooldown verifies the remote (resolve-only) path
+// shares the cooldown: it runs the same chain, so it must both record and respect
+// an unavailable source.
+func TestResolveLinkHonorsTheSourceCooldown(t *testing.T) {
+	var dead, missing atomic.Int32
+	c := cooldownChainClient(
+		countingSource{name: "dead", err: unavailable(errors.New("dial tcp")), attempts: &dead},
+		countingSource{name: "missing", err: notIndexed(errors.New("not indexed")), attempts: &missing},
+	)
+
+	for range 2 {
+		if _, err := c.ResolveLink(context.Background(), Item{DOI: "10.1/x"}); err == nil {
+			t.Fatal("every source fails, so ResolveLink must return an error")
+		}
+	}
+	if got := dead.Load(); got != 1 {
+		t.Errorf("the unavailable source resolved %d times through ResolveLink, want 1", got)
+	}
+	if got := missing.Load(); got != 2 {
+		t.Errorf(`the "not indexed" source resolved %d times through ResolveLink, want 2`, got)
+	}
+}
+
+// TestPinnedSourceIgnoresItsOwnCooldown verifies an explicit source: argument still
+// reaches that source. The caller asked for it by name, and the all-cooled fallback
+// is what keeps that promise.
+func TestPinnedSourceIgnoresItsOwnCooldown(t *testing.T) {
+	var pinned atomic.Int32
+	c := cooldownChainClient(
+		countingSource{name: "dead", err: unavailable(errors.New("dial tcp")), attempts: &pinned},
+		stubSource{name: "other", supports: true},
+	)
+	c.markSourceCooldown("dead")
+
+	if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/x", Source: "dead"}, t.TempDir(), ""); err == nil {
+		t.Fatal("the pinned source fails, so DownloadItem must return an error")
+	}
+	if got := pinned.Load(); got != 1 {
+		t.Errorf("the pinned source resolved %d times, want 1: a cooldown must not override an explicit request", got)
+	}
+}
+
+// TestSourceCooldownIsRaceFree exercises the cooldown map from several goroutines
+// at once, so `go test -race` proves the shared state is properly guarded.
+func TestSourceCooldownIsRaceFree(t *testing.T) {
+	c := newTestClient(staticMirrors{})
+	chain := []DownloadSource{
+		stubSource{name: "a", supports: true},
+		stubSource{name: "b", supports: true},
+	}
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for range 50 {
+				c.noteSourceFailure(context.Background(), chain[i%2].Name(), unavailable(errors.New("dial tcp")))
+				_ = c.eligibleSources(chain)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/libgen/sourceerr.go
+++ b/internal/libgen/sourceerr.go
@@ -1,0 +1,95 @@
+package libgen
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+)
+
+// ErrSourceUnavailable marks a resolve failure that says nothing about the item and
+// everything about the source: the host never answered, the request timed out, or
+// the service replied with a transient status (5xx/429). Every item offered to that
+// source next would fail the same way, so it is the signal the per-source cooldown
+// acts on.
+//
+// It is exported so callers outside the package (notably the live e2e suite) can
+// classify a chain failure with errors.Is instead of matching error text.
+var ErrSourceUnavailable = errors.New("download source unavailable")
+
+// ErrNotIndexed marks the opposite outcome: the source answered correctly and
+// simply does not hold this item — not indexed, not open access, no preserved copy.
+// That is a NORMAL, final answer about one item and says nothing about the source's
+// health, so it must never put a source in cooldown: a provider that legitimately
+// does not carry an item would otherwise be punished for being honest.
+var ErrNotIndexed = errors.New("item not held by this download source")
+
+// taggedError attaches one of the taxonomy sentinels to a source's own error
+// WITHOUT changing its message: Error returns the underlying text verbatim while
+// Unwrap exposes both the original error and the tag, so errors.Is finds either.
+// Wrapping with fmt.Errorf would instead splice the sentinel's wording into every
+// message, changing text that logs, tests and the e2e suite read.
+type taggedError struct {
+	// err is the source's own error, whose message and wrapped chain are preserved.
+	err error
+	// tag is the taxonomy sentinel this failure is being classified as.
+	tag error
+}
+
+// Error returns the underlying error's message unchanged, so tagging is invisible
+// to anything that renders the error.
+func (e taggedError) Error() string { return e.err.Error() }
+
+// Unwrap exposes both the underlying error and the taxonomy tag, which is what
+// makes errors.Is match either of them.
+func (e taggedError) Unwrap() []error { return []error{e.err, e.tag} }
+
+// unavailable tags err as evidence that the source itself could not serve any item
+// right now (transport failure, timeout, transient status), keeping its message
+// intact.
+func unavailable(err error) error { return taggedError{err: err, tag: ErrSourceUnavailable} }
+
+// notIndexed tags err as the source's correct answer that it does not hold this
+// particular item, keeping its message intact.
+func notIndexed(err error) error { return taggedError{err: err, tag: ErrNotIndexed} }
+
+// unavailableStatus tags err as unavailability when status is a transient HTTP
+// status — 5xx (the service is broken) or 429 (it is asking us to back off) — and
+// returns it untouched otherwise, since a 4xx is an answer about the request, not a
+// verdict on the service.
+func unavailableStatus(status int, err error) error {
+	if status >= http.StatusInternalServerError || status == http.StatusTooManyRequests {
+		return unavailable(err)
+	}
+	return err
+}
+
+// cooldownWorthy reports whether err is evidence that a source is unavailable, and
+// therefore worth setting aside for a while, as opposed to a correct answer about
+// one item.
+//
+// ctx is the caller's context: when it is already done, nothing was learned about
+// the source (the download was abandoned from this side), so no cooldown is
+// recorded. Otherwise a failure counts when it is tagged ErrSourceUnavailable, when
+// every libgen mirror was unreachable (ErrAllMirrorsFailed, the same diagnosis one
+// layer down), when the per-source resolve budget expired — a source that cannot
+// produce a URL inside its whole budget is exactly the case this exists for — or
+// when the error is a network timeout. Anything else, including an unclassified
+// failure, is deliberately NOT cooldown-worthy: setting a healthy source aside is
+// more expensive than retrying an unhealthy one.
+func cooldownWorthy(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	// A clean miss wins over every other signal: it is a correct answer about the
+	// item, whatever else the error chain happens to carry.
+	if errors.Is(err, ErrNotIndexed) {
+		return false
+	}
+	if errors.Is(err, ErrSourceUnavailable) || errors.Is(err, ErrAllMirrorsFailed) ||
+		errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/internal/libgen/sourceerr_test.go
+++ b/internal/libgen/sourceerr_test.go
@@ -1,0 +1,177 @@
+package libgen
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// taxonomyDOI carries the bioRxiv preprint prefix so every DOI source — including
+// the prefix-restricted biorxiv one — claims the item under test.
+const taxonomyDOI = "10.1101/2020.12.30.424878"
+
+// doiSourceFor builds the named DOI source with every upstream it talks to pointed
+// at srv, so one local server decides the whole outcome of a Resolve. It fails the
+// test for an unknown name rather than silently testing nothing.
+func doiSourceFor(t *testing.T, name string, srv *httptest.Server) DownloadSource {
+	t.Helper()
+	cl := srv.Client()
+	switch name {
+	case "unpaywall":
+		return unpaywallSource{email: "mail@jmrp.io", http: cl, baseURL: srv.URL}
+	case "europepmc":
+		return europePMCSource{http: cl, searchBase: srv.URL, renderBase: srv.URL}
+	case "biorxiv":
+		return biorxivSource{http: cl, apiBase: srv.URL, contentBase: srv.URL}
+	case "fatcat":
+		return fatcatSource{http: cl, apiBase: srv.URL}
+	case "core":
+		return coreSource{http: cl, key: "test-key", apiBase: srv.URL}
+	case "scihub":
+		return scihubSource{http: cl, hosts: []string{strings.TrimPrefix(srv.URL, "http://")}, scheme: "http"}
+	case "scidb":
+		return scidbSource{http: cl, mirrors: staticMirrors{srv.URL}}
+	default:
+		t.Fatalf("no DOI source named %q", name)
+		return nil
+	}
+}
+
+// fixedResponse serves status and body for every request, so a source's whole
+// lookup path sees one deliberate upstream answer.
+func fixedResponse(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// doiSourceNames lists every DOI source in chain order, so the taxonomy tests
+// cover the whole article chain rather than a sample of it.
+var doiSourceNames = []string{"unpaywall", "europepmc", "biorxiv", "fatcat", "core", "scihub", "scidb"}
+
+// TestUnavailableUpstreamIsDiagnosedAsSuch verifies every DOI source reports a
+// server that answers 503 as ErrSourceUnavailable: the failure says nothing about
+// the item, so the source itself is what went wrong.
+func TestUnavailableUpstreamIsDiagnosedAsSuch(t *testing.T) {
+	for _, name := range doiSourceNames {
+		t.Run(name, func(t *testing.T) {
+			srv := fixedResponse(http.StatusServiceUnavailable, "down")
+			defer srv.Close()
+
+			_, err := doiSourceFor(t, name, srv).Resolve(context.Background(), Item{DOI: taxonomyDOI})
+			if err == nil {
+				t.Fatal("Resolve should fail against a 503 upstream")
+			}
+			if !errors.Is(err, ErrSourceUnavailable) {
+				t.Errorf("error %v is not ErrSourceUnavailable; a 503 upstream must be diagnosable as unavailability", err)
+			}
+			if !cooldownWorthy(context.Background(), err) {
+				t.Errorf("error %v should be cooldown-worthy", err)
+			}
+		})
+	}
+}
+
+// TestCleanMissIsNotDiagnosedAsUnavailability verifies a source that answers
+// correctly that it does not hold the item reports ErrNotIndexed and is NOT
+// cooldown-worthy: a source must never be punished for a normal miss.
+func TestCleanMissIsNotDiagnosedAsUnavailability(t *testing.T) {
+	misses := map[string]string{
+		"unpaywall": `{"is_oa":false}`,
+		"europepmc": `{"hitCount":0,"resultList":{"result":[]}}`,
+		"biorxiv":   `{"collection":[]}`,
+		"fatcat":    "",
+		"core":      `{"results":[]}`,
+		"scihub":    "<html><body>article not found</body></html>",
+		"scidb":     "<html><body>nothing here</body></html>",
+	}
+	for _, name := range doiSourceNames {
+		t.Run(name, func(t *testing.T) {
+			status := http.StatusOK
+			if name == "fatcat" {
+				status = http.StatusNotFound // fatcat's clean miss is a 404
+			}
+			srv := fixedResponse(status, misses[name])
+			defer srv.Close()
+
+			_, err := doiSourceFor(t, name, srv).Resolve(context.Background(), Item{DOI: taxonomyDOI})
+			if err == nil {
+				t.Fatal("Resolve should fail when the source does not hold the item")
+			}
+			if !errors.Is(err, ErrNotIndexed) {
+				t.Errorf("error %v is not ErrNotIndexed; a clean miss must be diagnosable as one", err)
+			}
+			if errors.Is(err, ErrSourceUnavailable) {
+				t.Errorf("error %v is tagged unavailable; a clean miss is a correct answer, not a failure", err)
+			}
+			if cooldownWorthy(context.Background(), err) {
+				t.Errorf("a clean miss (%v) must not put the source in cooldown", err)
+			}
+		})
+	}
+}
+
+// TestTaggedErrorKeepsItsMessage verifies the taxonomy tags are invisible in the
+// rendered message: the diagnosis rides alongside the source's own wording so
+// error text (and everything that reads it) is unchanged.
+func TestTaggedErrorKeepsItsMessage(t *testing.T) {
+	inner := errors.New(`fatcat: requesting "10.1/x": dial tcp: i/o timeout`)
+	tagged := unavailable(inner)
+	if tagged.Error() != inner.Error() {
+		t.Errorf("tagged message = %q, want the original %q", tagged.Error(), inner.Error())
+	}
+	if !errors.Is(tagged, inner) {
+		t.Error("the tagged error should still unwrap to the source's own error")
+	}
+	if !errors.Is(tagged, ErrSourceUnavailable) {
+		t.Error("the tagged error should carry ErrSourceUnavailable")
+	}
+}
+
+// TestCooldownWorthy pins the classification that decides whether a failure sets a
+// source aside. It is the heart of the feature: an unreachable source must be
+// remembered, and a correct "I do not have this" must not be.
+func TestCooldownWorthy(t *testing.T) {
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	timeout := &net.DNSError{Err: "i/o timeout", IsTimeout: true}
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{name: "no failure at all", ctx: context.Background(), err: nil},
+		{name: "tagged unavailable", ctx: context.Background(), err: unavailable(errors.New("dial tcp")), want: true},
+		{name: "tagged not indexed", ctx: context.Background(), err: notIndexed(errors.New("not in index"))},
+		{name: "every mirror unreachable", ctx: context.Background(), err: fmt.Errorf("%w: x", ErrAllMirrorsFailed), want: true},
+		{name: "every mirror rejected the request", ctx: context.Background(), err: fmt.Errorf("%w: 404", ErrRequestRejected)},
+		{name: "resolve budget expired", ctx: context.Background(), err: fmt.Errorf("fatcat: %w", context.DeadlineExceeded), want: true},
+		{name: "network timeout", ctx: context.Background(), err: fmt.Errorf("scidb: %w", timeout), want: true},
+		{name: "transient status", ctx: context.Background(), err: unavailableStatus(http.StatusTooManyRequests, errors.New("rate limited")), want: true},
+		{name: "server error status", ctx: context.Background(), err: unavailableStatus(http.StatusBadGateway, errors.New("bad gateway")), want: true},
+		{name: "client error status", ctx: context.Background(), err: unavailableStatus(http.StatusNotFound, errors.New("missing"))},
+		{name: "unclassified failure", ctx: context.Background(), err: errors.New("something else")},
+		{name: "caller canceled the download", ctx: canceled, err: unavailable(errors.New("dial tcp"))},
+		{
+			name: "unavailability wrapped by the download chain",
+			ctx:  context.Background(),
+			err:  fmt.Errorf("%w: %w", errDownloadCouldNotStart, startErr(unavailable(errors.New("dial tcp")))),
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cooldownWorthy(tt.ctx, tt.err); got != tt.want {
+				t.Errorf("cooldownWorthy(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -54,6 +54,25 @@ func SourceAttempt(source string, start time.Time, err error) {
 	slog.Info("source resolved", "source", source, "duration", duration)
 }
 
+// SourceSkipped records that the chain passed over a download source because an
+// earlier failure showed it to be unavailable and its cooldown has not expired.
+//
+// It is Info, at the same level as SourceAttempt, because a source that simply
+// vanishes from the chain log is the harder debugging problem: the reader can see
+// which sources were tried but not why one they expected is missing. until is the
+// instant the source becomes eligible again.
+func SourceSkipped(source string, until time.Time) {
+	slog.Info("source in cooldown, skipping", "source", source, "cooldown_until", until)
+}
+
+// SourceCooldownBypassed records that every source able to serve the item was in
+// cooldown, so the chain tried them regardless. A cooldown only deprioritizes a
+// source, so this is the expected outcome rather than an error — but it is worth a
+// Warn, since it means every provider for this kind of item recently failed.
+func SourceCooldownBypassed(sources []string) {
+	slog.Warn("every capable source is in cooldown, trying them anyway", "sources", sources)
+}
+
 // ToolCall records the outcome of an MCP tool execution.
 //
 // It emits an Info-level log when err is nil and an Error-level log otherwise,

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -93,6 +93,54 @@ func TestToolCallSuccess(t *testing.T) {
 	}
 }
 
+// TestSourceSkipped verifies a source passed over for being in cooldown is
+// reported with its name and the instant it becomes eligible again, so a shortened
+// chain is never a silent one.
+func TestSourceSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	logging.SourceSkipped("fatcat", time.Now().Add(time.Minute))
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to unmarshal log line %q: %v", buf.String(), err)
+	}
+	if entry["level"] != "INFO" {
+		t.Errorf("expected level INFO, got %v", entry["level"])
+	}
+	if entry["source"] != "fatcat" {
+		t.Errorf("expected source %q, got %v", "fatcat", entry["source"])
+	}
+	if entry["cooldown_until"] == nil {
+		t.Error("expected the log line to report when the cooldown expires")
+	}
+}
+
+// TestSourceCooldownBypassed verifies the all-cooled-down bypass is reported at
+// Warn with the sources it tried anyway.
+func TestSourceCooldownBypassed(t *testing.T) {
+	var buf bytes.Buffer
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	logging.SourceCooldownBypassed([]string{"fatcat", "scidb"})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to unmarshal log line %q: %v", buf.String(), err)
+	}
+	if entry["level"] != "WARN" {
+		t.Errorf("expected level WARN, got %v", entry["level"])
+	}
+	if got, ok := entry["sources"].([]any); !ok || len(got) != 2 {
+		t.Errorf("expected the two bypassed sources, got %v", entry["sources"])
+	}
+}
+
 // TestSetupWritesStderr verifies SetupWritesStderr.
 func TestSetupWritesStderr(t *testing.T) {
 	prev := slog.Default()

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -103,6 +103,19 @@ Download sources implement a common interface — `Name`, `Supports(item)`, and 
 
 Because the chain is a single ordered slice filtered by `Supports`, a book item is offered `[libgen, randombook, annas]`, an article item `[unpaywall, europepmc, biorxiv, fatcat, core, scihub, scidb]`, and an item carrying both is offered article sources first, then book sources. `LIBGEN_MCP_SOURCES` removes sources from this chain without reordering it. `Download` tries each supporting source in turn and returns the first success; if all fail, it returns the joined per-source errors.
 
+### Per-source cooldown
+
+A source that fails because it is **unavailable** — a transport error, a timeout, a 5xx or a 429 — is set aside for 5 minutes, so the next download does not spend its resolve budget on a provider that just proved unreachable. This is the source-level counterpart of the per-mirror cooldown in the HTTP client, and it matters most for a service that is down for hours at a time: without it, every article download pays the full per-source budget for that provider again and again.
+
+A source that answers correctly that it does **not hold the item** — not indexed, not open access, no preserved copy — is never set aside: that is a normal, correct answer about one item and says nothing about the provider's health. The two cases are told apart by the error taxonomy each source tags its failures with (`ErrSourceUnavailable` vs `ErrNotIndexed`).
+
+Two rules bound the behavior:
+
+- A cooldown only deprioritizes. When **every** source able to serve an item is in cooldown, the chain tries them all anyway — better to try than nothing — and says so in the log. An explicit `source:` argument therefore always reaches the source it names.
+- Nothing is persisted. The state lives on the client for the life of the process, so a restart starts clean.
+
+Both decisions are visible in the log alongside the existing per-source attempt lines: a skipped source is reported at `INFO` with the instant its cooldown expires, and an all-cooled-down bypass at `WARN`.
+
 ## Search path
 
 The download chain above is one of two federations in the server. The other is the search path, which is structured differently: the download chain is ordered and stops at the first success, while the searchers run concurrently and their answers are merged.

--- a/site/src/content/docs/architecture.mdx
+++ b/site/src/content/docs/architecture.mdx
@@ -112,6 +112,7 @@ A source that answers correctly that it does **not hold the item** — not index
 Two rules bound the behavior:
 
 - A cooldown only deprioritizes. When **every** source able to serve an item is in cooldown, the chain tries them all anyway — better to try than nothing — and says so in the log. An explicit `source:` argument therefore always reaches the source it names.
+- A success lifts it. A source that just served a file is not unavailable, so serving one clears its cooldown.
 - Nothing is persisted. The state lives on the client for the life of the process, so a restart starts clean.
 
 Both decisions are visible in the log alongside the existing per-source attempt lines: a skipped source is reported at `INFO` with the instant its cooldown expires, and an all-cooled-down bypass at `WARN`.

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -112,6 +112,7 @@ Una fuente que responde correctamente que **no tiene el elemento** — no indexa
 Dos reglas acotan el comportamiento:
 
 - Un enfriamiento solo baja la prioridad, nunca deshabilita. Cuando **todas** las fuentes capaces de servir un elemento están en enfriamiento, la cadena las prueba igualmente — mejor intentarlo que nada — y lo indica en el log. Por eso un argumento `source:` explícito siempre llega a la fuente que nombra.
+- Un éxito lo levanta. Una fuente que acaba de servir un archivo no está no disponible, así que servir uno borra su enfriamiento.
 - Nada se persiste. El estado vive en el cliente durante la vida del proceso, así que un reinicio empieza limpio.
 
 Ambas decisiones son visibles en el log junto a las líneas de intento por fuente ya existentes: una fuente omitida se registra en `INFO` con el instante en que expira su enfriamiento, y el caso de todas en enfriamiento en `WARN`.

--- a/site/src/content/docs/es/architecture.mdx
+++ b/site/src/content/docs/es/architecture.mdx
@@ -103,6 +103,19 @@ Las fuentes de descarga implementan una interfaz común — `Name`, `Supports(it
 
 Como la cadena es un único slice ordenado filtrado por `Supports`, a un elemento libro se le ofrece `[libgen, randombook, annas]`, a uno artículo `[unpaywall, europepmc, biorxiv, fatcat, core, scihub, scidb]`, y a uno que lleva ambos se le ofrecen primero las fuentes de artículo, luego las de libro. `LIBGEN_MCP_SOURCES` elimina fuentes de esta cadena sin reordenarla. `Download` prueba cada fuente compatible por turno y devuelve el primer éxito; si todas fallan, devuelve los errores por fuente unidos.
 
+### Enfriamiento por fuente
+
+Una fuente que falla porque está **no disponible** — un error de transporte, un timeout, un 5xx o un 429 — se aparta durante 5 minutos, de modo que la siguiente descarga no gaste su presupuesto de resolución en un proveedor que acaba de demostrar ser inalcanzable. Es el equivalente a nivel de fuente del enfriamiento por mirror del cliente HTTP, y donde más importa es en un servicio caído durante horas: sin él, cada descarga de artículo paga otra vez el presupuesto completo de esa fuente.
+
+Una fuente que responde correctamente que **no tiene el elemento** — no indexado, sin acceso abierto, sin copia preservada — nunca se aparta: es una respuesta normal y correcta sobre un elemento y no dice nada sobre la salud del proveedor. Ambos casos se distinguen por la taxonomía de errores con la que cada fuente etiqueta sus fallos (`ErrSourceUnavailable` frente a `ErrNotIndexed`).
+
+Dos reglas acotan el comportamiento:
+
+- Un enfriamiento solo baja la prioridad, nunca deshabilita. Cuando **todas** las fuentes capaces de servir un elemento están en enfriamiento, la cadena las prueba igualmente — mejor intentarlo que nada — y lo indica en el log. Por eso un argumento `source:` explícito siempre llega a la fuente que nombra.
+- Nada se persiste. El estado vive en el cliente durante la vida del proceso, así que un reinicio empieza limpio.
+
+Ambas decisiones son visibles en el log junto a las líneas de intento por fuente ya existentes: una fuente omitida se registra en `INFO` con el instante en que expira su enfriamiento, y el caso de todas en enfriamiento en `WARN`.
+
 ## Camino de búsqueda
 
 La cadena de descarga anterior es una de las dos federaciones del servidor. La otra es el camino de búsqueda, con una estructura distinta: la cadena de descarga está ordenada y se detiene en el primer éxito, mientras que los buscadores se ejecutan en paralelo y sus respuestas se fusionan.

--- a/site/src/content/docs/es/troubleshooting.mdx
+++ b/site/src/content/docs/es/troubleshooting.mdx
@@ -101,6 +101,19 @@ Un error relacionado pero distinto, `request rejected by all mirrors`, significa
 - Fija `LIBGEN_MCP_CORE_KEY` (una clave de API gratuita de CORE) para añadir CORE a la cadena de acceso abierto.
 - Ten en cuenta que las descargas por DOI **no** se verifican por MD5 (`verified` es `false`) — no hay digest de LibGen para ellas.
 
+## Falta una fuente en los errores de una descarga repetida
+
+**Síntoma.** Una `download` falla y un segundo intento informa de menos fuentes que el primero — una que falló hace un momento no aparece en absoluto.
+
+**Significado.** Esa fuente está en **enfriamiento**. Cuando una fuente falla porque no está disponible (un error de transporte, un timeout, un 5xx o un 429) se aparta durante 5 minutos, de modo que la siguiente descarga no gaste su presupuesto de resolución en un proveedor que acaba de demostrar ser inalcanzable. Se omite, no se elimina: el enfriamiento expira por sí solo, no se escribe nada en disco (un reinicio lo borra) y cuando todas las fuentes capaces de servir el elemento están en enfriamiento se prueban todas igualmente. Una fuente que solo informó de que no tiene el elemento nunca se aparta.
+
+El log del servidor dice qué fuentes se omitieron y por qué — `source in cooldown, skipping` con el instante en que vuelve a ser elegible, o `every capable source is in cooldown, trying them anyway`. Ejecuta con `LIBGEN_MCP_LOG_LEVEL=info` (el valor por defecto) para verlas.
+
+**Soluciones.**
+
+- No hace falta nada: reintenta más tarde, o de inmediato con `source: "<nombre>"` para dirigirte a ese proveedor directamente — una fuente explícita siempre se prueba, esté en enfriamiento o no.
+- Si una fuente entra en enfriamiento repetidamente, es realmente inalcanzable desde este host. Compruébalo a mano antes de sospechar del servidor.
+
 ## Resultados de búsqueda truncados
 
 **Síntoma.** Una respuesta de búsqueda tiene `truncated: true` y un `hint`, y paginar más allá de cierto punto no devuelve nada.

--- a/site/src/content/docs/troubleshooting.mdx
+++ b/site/src/content/docs/troubleshooting.mdx
@@ -101,6 +101,19 @@ A related but distinct error, `request rejected by all mirrors`, means every mir
 - Set `LIBGEN_MCP_CORE_KEY` (a free CORE API key) to add CORE to the open-access chain.
 - Note that DOI downloads are **not** MD5-verified (`verified` is `false`) — there is no LibGen digest for them.
 
+## A source is missing from the errors of a repeated download
+
+**Symptom.** A `download` fails, and a second attempt reports fewer sources than the first — one that failed a moment ago is not mentioned at all.
+
+**Meaning.** That source is in **cooldown**. When a source fails because it is unavailable (a transport error, a timeout, a 5xx or a 429) it is set aside for 5 minutes, so the next download does not spend its resolve budget on a provider that just proved unreachable. It is skipped, not removed: the cooldown expires on its own, nothing is written to disk (a restart clears it), and when every source able to serve the item is in cooldown they are all tried anyway. A source that merely reported it does not hold the item is never set aside.
+
+The server log says which sources were skipped and why — `source in cooldown, skipping` with the instant it becomes eligible again, or `every capable source is in cooldown, trying them anyway`. Run with `LIBGEN_MCP_LOG_LEVEL=info` (the default) to see them.
+
+**Fixes.**
+
+- Nothing is needed: retry later, or immediately with `source: "<name>"` to address that provider directly — an explicit source is always tried, cooldown or not.
+- If a source is repeatedly cooled down, it is genuinely unreachable from this host. Check it by hand before suspecting the server.
+
 ## Truncated search results
 
 **Symptom.** A search response has `truncated: true` and a `hint`, and paging past a certain point returns nothing.


### PR DESCRIPTION
## Summary

A download source that cannot be reached costs the chain its whole per-source resolve budget — and costs it again on the next download, and the one after that. `api.fatcat.wiki` is unreachable right now (verified from this host and through two independent third-party proxies; the live suite's own precondition probe skips the fatcat case for the same reason) while sitting at position 4 of the 7-source article chain, so every article the first three sources cannot serve waits on a dead host from scratch, every single call.

This adds a **per-source cooldown**: a source that fails in a way that shows the *source* to be unavailable is set aside for 5 minutes and the next download skips it. A source that reports it does not hold the item keeps its place — that is a correct answer about one item and says nothing about the provider's health.

### Design decisions

**Where the state lives.** On the `Client`, in a `sourceCooldown map[string]time.Time` guarded by its own `sourceMu`. The client outlives every individual download, which is exactly the scope the problem has. The mutex is deliberately separate from the one guarding the per-mirror cooldown: those keys are mirror base URLs, and conflating the two key spaces would let a failing mirror influence which *sources* the chain will try. Nothing is persisted, so a fresh process starts by trying everything.

**What counts as cooldown-worthy.** This is the heart of the change, so it is made explicit rather than inferred from error text. Two exported, `errors.Is`-able sentinels now classify every source failure:

- `ErrSourceUnavailable` — transport error, timeout, 5xx, 429. Item-independent: the next item would fail identically.
- `ErrNotIndexed` — not indexed, not open access, no preserved copy, no PDF link. A normal, final answer about one item; never triggers a cooldown.

The tags are attached with a small `taggedError` whose `Error()` returns the underlying message **byte-identical**, so no log line, unit test or e2e classification pattern changes; only `errors.Is` gains an answer. `cooldownWorthy` additionally reads the diagnoses that already existed — `ErrAllMirrorsFailed` (the same verdict one layer down, for `libgen`), an expired per-source resolve budget (`context.DeadlineExceeded`, precisely the fatcat case), and any `net.Error` timeout — and refuses to record anything when the *caller's* context is done, since an abandoned download taught us nothing. An unclassified failure is deliberately not cooldown-worthy: setting a healthy source aside costs more than retrying an unhealthy one.

All ten sources are tagged, not just the article chain, so the taxonomy is uniform. It also gives the e2e suite `errors.Is` where it currently matches regexes.

**Skip, not deprioritise.** Cooled-down sources are skipped rather than moved to the end of the chain, because `downloadFrom` grants the chain's **last** source the full start-retry schedule: pushing a dead source to the tail would hand it the most patience of all — the opposite of the intent. Two rules keep skipping safe:

- When *every* source able to serve an item is cooled down, the whole list is used anyway ("better to try than nothing", the same fallback `candidates()` uses for mirrors). This is also what keeps an explicit `source:` argument working — a single-source chain is always fully cooled down, so the caller still reaches the source it named.
- A source that serves an item has its cooldown cleared. The bypass above can let a cooled source succeed, and a stale entry would then make the next call skip the one source known to work.

**Observability.** A skipped source is logged at `INFO` (`source in cooldown, skipping`, with the instant it becomes eligible again) next to the existing `logging.SourceAttempt` lines, and an all-cooled-down bypass at `WARN`. A source silently missing from the chain log was the debugging dead end this had to avoid.

**Configurability.** A named constant (`sourceCooldownDuration = 5 * time.Minute`), no new environment variable: this is a self-tuning failover detail rather than a deployment decision, and 5 minutes covers a working session's worth of downloads while still picking up a service that recovers, without a restart. An unexported field keeps it injectable for tests.

### Live evidence

Second article download in the same process, real chain, real network (paywalled DOI, so the chain has to walk past the open-access sources):

```text
resolve budget per source (LIBGEN_MCP_TIMEOUT) = 30s

call 1: total=42.583s  served by scihub
  unpaywall  1.859s  failed, advancing
  europepmc  0.483s  failed, advancing
  fatcat    30.002s  failed, advancing   <- the entire per-source budget
  core       9.600s  failed, advancing
  scihub     0.638s  resolved

call 2: total=5.726s   served by scihub
  fatcat            source in cooldown, skipping
  unpaywall  0.807s  failed, advancing
  europepmc  0.064s  failed, advancing
  core       4.556s  failed, advancing
  scihub     0.299s  resolved
```

Same file, same process, same chain: **42.6 s → 5.7 s (−36.9 s, −87 %)**, and the 30 s fatcat spent is gone entirely rather than reduced. The measurement harness was temporary and is not part of this diff — the live suite has no test that depends on a specific provider being down.


`LIBGEN_E2E=1 go test -tags e2e ./test/e2e/` — full suite green.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [x] Docs updated if behavior changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-source cooldown to the download chain so unreachable providers are skipped for 5 minutes, avoiding repeated 30s timeouts per call. Also introduce a clear error taxonomy to distinguish “source unavailable” from “item not held,” improving performance and logs without changing error messages.

- New Features
  - Per-source cooldown: sources tagged unavailable are skipped for 5 minutes; success clears the cooldown; state lives on the client and is not persisted.
  - Safe fallback: if every capable source is cooled down, try them all anyway; an explicit `source:` always runs.
  - Error taxonomy: sources tag failures as `ErrSourceUnavailable` (transport error, timeout, 5xx/429) or `ErrNotIndexed` (clean miss). Classifier also recognizes `context.DeadlineExceeded`, `ErrAllMirrorsFailed`, and network timeouts; unclassified errors don’t trigger cooldown.
  - Logging: `source in cooldown, skipping` (INFO with expiry) and `every capable source is in cooldown, trying them anyway` (WARN).
  - Applies to both streaming and resolve-only paths; docs and tests updated.

<sup>Written for commit 7d33108e67567f80370bdf40a4eb50ec6b95a3b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

