### PR TITLE
fix(download): stop retrying a source that already said no

### DIFF
--- a/cmd/eval/testdata/latest-run.md
+++ b/cmd/eval/testdata/latest-run.md
@@ -11,41 +11,57 @@ Model: `claude-haiku-4-5-20251001`
 | S5 | local | PASS | downloaded 982888 bytes via libgen |
 | S6 | local | PASS | downloaded 6460651 bytes via scihub |
 | S6b | local | PASS | downloaded 982888 bytes via randombook |
-| S7 | local | PASS | downloaded DOI via unpaywall |
+| S7 | local | PASS | downloaded DOI via unpaywall, an open-access provider — the chain preferred a legal copy |
 | S8 | local | PASS | model asked to clarify instead of guessing (no tool call) |
 | S9 | local | PASS | start-retries exhausted; actionable error surfaced and the model did not fabricate success |
 | S10 | local | PASS | unguided search; 25 results; topics=[fiction] |
 | S11 | local | PASS | unguided search; 25 results; topics=[comics] |
 | S12 | local | PASS | downloaded 2404614 bytes via libgen |
-| S13 | local | PASS | downloaded 6460651 bytes via scihub (doi via search) |
+| S13 | local | PASS | downloaded 2173792 bytes via fatcat (doi via search) |
 | S14 | local | PASS | received 17 progress notification(s); final progress=982888 total=982888 |
-| S15 | local | PASS | ordered page of 110 with links; model surfaced links in its answer |
-| S16 | local | PASS | resolved a URL via libgen without downloading: https://libgen.vg/get.php?(query redacted) |
+| S15 | local | PASS | ordered page of 107 with links; model surfaced links in its answer |
+| S16 | local | PASS | resolved a URL via libgen without downloading: https://libgen.li/get.php?(query redacted) |
 | S17 | remote | PASS | remote: model got a link, harness fetched 982888 bytes to local disk |
-| S18 | remote | PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (HTTP 403) |
-| S19 | local | PASS | the file was not extractable (no extractable text layer (likely a scanned or image-only PDF); OCR is not supported); the model reported that plainly instead of inventing a result |
-| S20 | local | PASS | open-access discovery surfaced 17 hit(s); the model answered from the catalog without calling it open access |
+| S18 | remote | PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (Get "/article/S0092867411001279/pdf": stopped after 10 redirects) |
+| S19 | local | PASS | read pdf (4566 chars); model summarized it in 791 chars |
+| S20 | local | PASS | open-access discovery surfaced 41 hit(s); model referenced one in its answer |
 | S21 | local | PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S22 | local | PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S22 | local | PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S23 | local | PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S24 | local | PASS | model used read outline=true; 221 table-of-contents entr(ies) returned |
-| S25 | local | PASS | DOI download succeeded via scihub (255629 bytes); the host answered any email elicitation the server raised |
+| S24 | local | PASS | no embedded table of contents; the model read the document and compiled one from its text |
+| S25 | local | PASS | the server asked for a contact email it had none of, the host supplied one, and unpaywall served 255629 bytes |
 | S26 | local | PASS | save-confirmation elicitation fired 1x and the host accepted it; downloaded 4366258 bytes via libgen — confirmation did not block the flow |
 | S27 | remote | PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S28 | remote | PASS | no embedded table of contents; the model read the document and compiled one from its text |
-| S29 | remote | PASS | open-access discovery surfaced 20 hit(s); model referenced one in its answer |
-| S30 | remote | PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S28 | remote | PASS | model used read outline=true; 140 table-of-contents entr(ies) returned |
+| S29 | remote | PASS | open-access discovery surfaced 35 hit(s); model referenced one in its answer |
+| S30 | remote | PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S31 | remote | PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S32 | local | PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
-| S33 | remote | PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
+| S32 | local | PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
+| S33 | remote | PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
 | S34 | local | PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S35 | remote | PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S36 | local | PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S37 | remote | PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S38 | local | PASS | never mode honored and the model reported the miss honestly |
-| S39 | local | PASS | always mode consulted the extras alongside a 29-result catalog page (annas=4, open access=10) |
+| S39 | local | PASS | always mode consulted the extras alongside a 27-result catalog page (annas=2, open access=33) |
 | S40 | local | PASS | read opened an Anna's-only item (1536 chars extracted) |
-| S41 | local | PASS | member download reported the account allowance (47 of 50 left) |
+| S41 | local | PASS | member download reported the account allowance (48 of 50 left) |
 | S42 | local | PASS | nothing exists by that name and the model said so, inventing no metadata |
 | S43 | local | PASS | restriction held; the model routed through the permitted source instead of the refused one |
 | S44 | local | PASS | model set page=2 and received page 2 with 25 results |
+| S45 | local | PASS | downloaded 91408 bytes via europepmc |
+| S46 | local | PASS | downloaded 2114465 bytes via biorxiv |
+| S47 | local | PASS | downloaded 374166 bytes via fatcat |
+| S48 | local | PASS | core is absent from the download source enum on a deployment with no CORE key, and the model asked for it nowhere; enum = unpaywall, europepmc, biorxiv, fatcat, oapen, archive, scihub, scidb, libgen, randombook, annas |
+| S49 | local | PASS | downloaded DOI via europepmc, an open-access provider — the chain preferred a legal copy |
+| S50 | local | PASS | model discovered the isbn key unaided; downloaded 15684454 bytes via archive |
+| S51 | local | PASS | downloaded 1850890 bytes via oapen |
+| S52 | local | PASS | downloaded 1850890 bytes via oapen |
+| S53 | local | PASS | oapen refused an identifier OAPEN does not hold cleanly, and the model reported the miss instead of presenting a file |
+| S54 | local | PASS | downloaded 15684454 bytes via archive |
+| S55 | local | PASS | archive refused a lending-restricted book cleanly, and the model reported the miss instead of presenting a file |
+| S56 | local | PASS | gutenberg surfaced 4 hit(s) with a fetchable file URL, and the model handed the link over |
+| S57 | local | PASS | eric surfaced 7 hit(s) with a fetchable file URL, and the model handed the link over |
+| S58 | local | PASS | dblp contributed 5 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S59 | local | PASS | pubmed contributed 7 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S60 | local | PASS | the chain recorded the dead source as unavailable and acted on it on the next pass ("source in cooldown, skipping") |

--- a/internal/libgen/download.go
+++ b/internal/libgen/download.go
@@ -647,6 +647,14 @@ func (c *Client) downloadFrom(ctx context.Context, src DownloadSource, req downl
 func (c *Client) startAttempt(ctx context.Context, src DownloadSource, req downloadReq) (*DownloadResult, error) {
 	resolved, err := c.resolveWithin(ctx, src, req.item)
 	if err != nil {
+		// A source that answered "I do not hold this item" has settled the question:
+		// asking again cannot change the answer. Returning it unwrapped keeps it out
+		// of the start-retry schedule, which would otherwise spend its whole budget
+		// re-asking and then relabel the miss as a connection failure. Measured in a
+		// live evaluator run: 87.7s to report a DOI a pinned source does not hold.
+		if errors.Is(err, ErrNotIndexed) {
+			return nil, err
+		}
 		return nil, startErr(err)
 	}
 	// A stable partial path lets an interrupted download resume: if bytes are

--- a/internal/libgen/download_test.go
+++ b/internal/libgen/download_test.go
@@ -2212,3 +2212,75 @@ func TestRetryEverySourceRestoresTheOldBehavior(t *testing.T) {
 		t.Errorf("dead source attempts = %d, want 4 (one per wait plus the first)", got)
 	}
 }
+
+// retryProbeSchedule is a two-wait start-retry schedule short enough for a unit
+// test. newTestClient configures no waits at all, so a test about retrying has to
+// supply its own or it silently measures nothing.
+var retryProbeSchedule = []time.Duration{time.Millisecond, time.Millisecond}
+
+// TestCleanMissIsNotRetried verifies a source that correctly answers "I do not
+// hold this item" is asked exactly once. The start-retry schedule exists to
+// outlast a transport blip; a clean miss is a settled answer, so re-asking only
+// burns the schedule. Measured in a live evaluator run: a pinned source that did
+// not hold the requested DOI spent 87.7s before reporting the miss.
+func TestCleanMissIsNotRetried(t *testing.T) {
+	var attempts atomic.Int32
+	c := cooldownChainClient(countingSource{
+		name:     "only",
+		err:      notIndexed(errors.New(`"10.1/nope" is not held by this source`)),
+		attempts: &attempts,
+	})
+	c.startRetryWaits = retryProbeSchedule
+
+	if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/nope"}, t.TempDir(), ""); err == nil {
+		t.Fatal("a source that holds nothing must fail the download")
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("Resolve called %d time(s), want 1: a settled miss must not be retried", got)
+	}
+}
+
+// TestCleanMissKeepsItsOwnDiagnosis verifies the error surfaced for a clean miss
+// still says the source does not hold the item, rather than being relabeled as a
+// connection failure. The retry wrapper's message blames "resolve/connect/
+// first-byte", which is actively misleading when nothing failed to connect.
+func TestCleanMissKeepsItsOwnDiagnosis(t *testing.T) {
+	var attempts atomic.Int32
+	c := cooldownChainClient(countingSource{
+		name:     "only",
+		err:      notIndexed(errors.New(`"10.1/nope" is not held by this source`)),
+		attempts: &attempts,
+	})
+	c.startRetryWaits = retryProbeSchedule
+
+	_, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/nope"}, t.TempDir(), "")
+	if err == nil {
+		t.Fatal("a source that holds nothing must fail the download")
+	}
+	if !errors.Is(err, ErrNotIndexed) {
+		t.Errorf("error lost its ErrNotIndexed tag: %v", err)
+	}
+	if strings.Contains(err.Error(), "could not be started after the retry schedule") {
+		t.Errorf("a clean miss was reported as a start failure: %v", err)
+	}
+}
+
+// TestUnavailableSourceStillGetsTheRetrySchedule guards the other side of the
+// split: a genuine transport failure is exactly what the schedule is for, so
+// narrowing the retry must not disable it.
+func TestUnavailableSourceStillGetsTheRetrySchedule(t *testing.T) {
+	var attempts atomic.Int32
+	c := cooldownChainClient(countingSource{
+		name:     "only",
+		err:      unavailable(errors.New("dial tcp: connection refused")),
+		attempts: &attempts,
+	})
+	c.startRetryWaits = retryProbeSchedule
+
+	if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), ""); err == nil {
+		t.Fatal("an unreachable source must fail the download")
+	}
+	if got, want := int(attempts.Load()), len(retryProbeSchedule)+1; got != want {
+		t.Errorf("Resolve called %d time(s), want %d: the schedule must still apply", got, want)
+	}
+}

--- a/internal/libgen/sourcecooldown.go
+++ b/internal/libgen/sourcecooldown.go
@@ -105,6 +105,13 @@ func (c *Client) eligibleSources(supporting []DownloadSource) []DownloadSource {
 	}
 	c.sourceMu.Unlock()
 
+	// No capable source at all is not a cooldown: there is nothing set aside and
+	// nothing to bypass. Warning about one here would send a reader debugging a
+	// restricted deployment chasing a state that does not exist; the caller's
+	// "no download source supports ..." error already says the true reason.
+	if len(supporting) == 0 {
+		return supporting
+	}
 	if len(avail) == 0 {
 		logging.SourceCooldownBypassed(cooledNames(cooled))
 		return supporting

--- a/internal/libgen/sourcecooldown_test.go
+++ b/internal/libgen/sourcecooldown_test.go
@@ -233,3 +233,20 @@ func TestSourceCooldownIsRaceFree(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestNoCapableSourceDoesNotClaimACooldown verifies the "every capable source is
+// in cooldown" warning is reserved for an actual cooldown. When nothing supports
+// the item at all — a DOI on a deployment restricted to book sources — the list is
+// empty, and warning about a cooldown sends a reader chasing a state that does not
+// exist. Observed 5 times in a single live evaluator scenario.
+func TestNoCapableSourceDoesNotClaimACooldown(t *testing.T) {
+	buf := captureLog(t)
+	c := cooldownChainClient(stubSource{name: "books-only", supports: false})
+
+	if _, err := c.DownloadItem(context.Background(), Item{DOI: "10.1/x"}, t.TempDir(), ""); err == nil {
+		t.Fatal("no source supports the item, so the download must fail")
+	}
+	if strings.Contains(buf.String(), "every capable source is in cooldown") {
+		t.Errorf("warned about a cooldown with no capable source at all:\n%s", buf.String())
+	}
+}

--- a/site/src/content/docs/es/eval-results.mdx
+++ b/site/src/content/docs/es/eval-results.mdx
@@ -178,44 +178,60 @@ aguanta.
 | S5 | local | ✅ PASS | downloaded 982888 bytes via libgen |
 | S6 | local | ✅ PASS | downloaded 6460651 bytes via scihub |
 | S6b | local | ✅ PASS | downloaded 982888 bytes via randombook |
-| S7 | local | ✅ PASS | downloaded DOI via unpaywall |
+| S7 | local | ✅ PASS | downloaded DOI via unpaywall, an open-access provider — the chain preferred a legal copy |
 | S8 | local | ✅ PASS | model asked to clarify instead of guessing (no tool call) |
 | S9 | local | ✅ PASS | start-retries exhausted; actionable error surfaced and the model did not fabricate success |
 | S10 | local | ✅ PASS | unguided search; 25 results; topics=[fiction] |
 | S11 | local | ✅ PASS | unguided search; 25 results; topics=[comics] |
 | S12 | local | ✅ PASS | downloaded 2404614 bytes via libgen |
-| S13 | local | ✅ PASS | downloaded 6460651 bytes via scihub (doi via search) |
+| S13 | local | ✅ PASS | downloaded 2173792 bytes via fatcat (doi via search) |
 | S14 | local | ✅ PASS | received 17 progress notification(s); final progress=982888 total=982888 |
-| S15 | local | ✅ PASS | ordered page of 110 with links; model surfaced links in its answer |
-| S16 | local | ✅ PASS | resolved a URL via libgen without downloading: https://libgen.vg/get.php?(query redacted) |
+| S15 | local | ✅ PASS | ordered page of 107 with links; model surfaced links in its answer |
+| S16 | local | ✅ PASS | resolved a URL via libgen without downloading: https://libgen.li/get.php?(query redacted) |
 | S17 | remote | ✅ PASS | remote: model got a link, harness fetched 982888 bytes to local disk |
-| S18 | remote | ✅ PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (HTTP 403) |
-| S19 | local | ✅ PASS | the file was not extractable (no extractable text layer (likely a scanned or image-only PDF); OCR is not supported); the model reported that plainly instead of inventing a result |
-| S20 | local | ✅ PASS | open-access discovery surfaced 17 hit(s); the model answered from the catalog without calling it open access |
+| S18 | remote | ✅ PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (Get "/article/S0092867411001279/pdf": stopped after 10 redirects) |
+| S19 | local | ✅ PASS | read pdf (4566 chars); model summarized it in 791 chars |
+| S20 | local | ✅ PASS | open-access discovery surfaced 41 hit(s); model referenced one in its answer |
 | S21 | local | ✅ PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S22 | local | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S22 | local | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S23 | local | ✅ PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S24 | local | ✅ PASS | model used read outline=true; 221 table-of-contents entr(ies) returned |
-| S25 | local | ✅ PASS | DOI download succeeded via scihub (255629 bytes); the host answered any email elicitation the server raised |
+| S24 | local | ✅ PASS | no embedded table of contents; the model read the document and compiled one from its text |
+| S25 | local | ✅ PASS | the server asked for a contact email it had none of, the host supplied one, and unpaywall served 255629 bytes |
 | S26 | local | ✅ PASS | save-confirmation elicitation fired 1x and the host accepted it; downloaded 4366258 bytes via libgen — confirmation did not block the flow |
 | S27 | remote | ✅ PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S28 | remote | ✅ PASS | no embedded table of contents; the model read the document and compiled one from its text |
-| S29 | remote | ✅ PASS | open-access discovery surfaced 20 hit(s); model referenced one in its answer |
-| S30 | remote | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S28 | remote | ✅ PASS | model used read outline=true; 140 table-of-contents entr(ies) returned |
+| S29 | remote | ✅ PASS | open-access discovery surfaced 35 hit(s); model referenced one in its answer |
+| S30 | remote | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S31 | remote | ✅ PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S32 | local | ✅ PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
-| S33 | remote | ✅ PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
+| S32 | local | ✅ PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
+| S33 | remote | ✅ PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
 | S34 | local | ✅ PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S35 | remote | ✅ PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S36 | local | ✅ PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S37 | remote | ✅ PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S38 | local | ✅ PASS | never mode honored and the model reported the miss honestly |
-| S39 | local | ✅ PASS | always mode consulted the extras alongside a 29-result catalog page (annas=4, open access=10) |
+| S39 | local | ✅ PASS | always mode consulted the extras alongside a 27-result catalog page (annas=2, open access=33) |
 | S40 | local | ✅ PASS | read opened an Anna's-only item (1536 chars extracted) |
-| S41 | local | ✅ PASS | member download reported the account allowance (47 of 50 left) |
+| S41 | local | ✅ PASS | member download reported the account allowance (48 of 50 left) |
 | S42 | local | ✅ PASS | nothing exists by that name and the model said so, inventing no metadata |
 | S43 | local | ✅ PASS | restriction held; the model routed through the permitted source instead of the refused one |
 | S44 | local | ✅ PASS | model set page=2 and received page 2 with 25 results |
+| S45 | local | ✅ PASS | downloaded 91408 bytes via europepmc |
+| S46 | local | ✅ PASS | downloaded 2114465 bytes via biorxiv |
+| S47 | local | ✅ PASS | downloaded 374166 bytes via fatcat |
+| S48 | local | ✅ PASS | core is absent from the download source enum on a deployment with no CORE key, and the model asked for it nowhere; enum = unpaywall, europepmc, biorxiv, fatcat, oapen, archive, scihub, scidb, libgen, randombook, annas |
+| S49 | local | ✅ PASS | downloaded DOI via europepmc, an open-access provider — the chain preferred a legal copy |
+| S50 | local | ✅ PASS | model discovered the isbn key unaided; downloaded 15684454 bytes via archive |
+| S51 | local | ✅ PASS | downloaded 1850890 bytes via oapen |
+| S52 | local | ✅ PASS | downloaded 1850890 bytes via oapen |
+| S53 | local | ✅ PASS | oapen refused an identifier OAPEN does not hold cleanly, and the model reported the miss instead of presenting a file |
+| S54 | local | ✅ PASS | downloaded 15684454 bytes via archive |
+| S55 | local | ✅ PASS | archive refused a lending-restricted book cleanly, and the model reported the miss instead of presenting a file |
+| S56 | local | ✅ PASS | gutenberg surfaced 4 hit(s) with a fetchable file URL, and the model handed the link over |
+| S57 | local | ✅ PASS | eric surfaced 7 hit(s) with a fetchable file URL, and the model handed the link over |
+| S58 | local | ✅ PASS | dblp contributed 5 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S59 | local | ✅ PASS | pubmed contributed 7 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S60 | local | ✅ PASS | the chain recorded the dead source as unavailable and acted on it on the next pass ("source in cooldown, skipping") |
 
 {/* end generated */}
 

--- a/site/src/content/docs/eval-results.mdx
+++ b/site/src/content/docs/eval-results.mdx
@@ -167,44 +167,60 @@ restricts the deployment to the catalog to prove the restriction holds.
 | S5 | local | ✅ PASS | downloaded 982888 bytes via libgen |
 | S6 | local | ✅ PASS | downloaded 6460651 bytes via scihub |
 | S6b | local | ✅ PASS | downloaded 982888 bytes via randombook |
-| S7 | local | ✅ PASS | downloaded DOI via unpaywall |
+| S7 | local | ✅ PASS | downloaded DOI via unpaywall, an open-access provider — the chain preferred a legal copy |
 | S8 | local | ✅ PASS | model asked to clarify instead of guessing (no tool call) |
 | S9 | local | ✅ PASS | start-retries exhausted; actionable error surfaced and the model did not fabricate success |
 | S10 | local | ✅ PASS | unguided search; 25 results; topics=[fiction] |
 | S11 | local | ✅ PASS | unguided search; 25 results; topics=[comics] |
 | S12 | local | ✅ PASS | downloaded 2404614 bytes via libgen |
-| S13 | local | ✅ PASS | downloaded 6460651 bytes via scihub (doi via search) |
+| S13 | local | ✅ PASS | downloaded 2173792 bytes via fatcat (doi via search) |
 | S14 | local | ✅ PASS | received 17 progress notification(s); final progress=982888 total=982888 |
-| S15 | local | ✅ PASS | ordered page of 110 with links; model surfaced links in its answer |
-| S16 | local | ✅ PASS | resolved a URL via libgen without downloading: https://libgen.vg/get.php?(query redacted) |
+| S15 | local | ✅ PASS | ordered page of 107 with links; model surfaced links in its answer |
+| S16 | local | ✅ PASS | resolved a URL via libgen without downloading: https://libgen.li/get.php?(query redacted) |
 | S17 | remote | ✅ PASS | remote: model got a link, harness fetched 982888 bytes to local disk |
-| S18 | remote | ✅ PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (HTTP 403) |
-| S19 | local | ✅ PASS | the file was not extractable (no extractable text layer (likely a scanned or image-only PDF); OCR is not supported); the model reported that plainly instead of inventing a result |
-| S20 | local | ✅ PASS | open-access discovery surfaced 17 hit(s); the model answered from the catalog without calling it open access |
+| S18 | remote | ✅ PASS | remote: model got a link and the server returned it; the harness's own fetch was refused upstream (Get "/article/S0092867411001279/pdf": stopped after 10 redirects) |
+| S19 | local | ✅ PASS | read pdf (4566 chars); model summarized it in 791 chars |
+| S20 | local | ✅ PASS | open-access discovery surfaced 41 hit(s); model referenced one in its answer |
 | S21 | local | ✅ PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S22 | local | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S22 | local | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S23 | local | ✅ PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S24 | local | ✅ PASS | model used read outline=true; 221 table-of-contents entr(ies) returned |
-| S25 | local | ✅ PASS | DOI download succeeded via scihub (255629 bytes); the host answered any email elicitation the server raised |
+| S24 | local | ✅ PASS | no embedded table of contents; the model read the document and compiled one from its text |
+| S25 | local | ✅ PASS | the server asked for a contact email it had none of, the host supplied one, and unpaywall served 255629 bytes |
 | S26 | local | ✅ PASS | save-confirmation elicitation fired 1x and the host accepted it; downloaded 4366258 bytes via libgen — confirmation did not block the flow |
 | S27 | remote | ✅ PASS | model used read find="pointer"; 503 match(es); model surfaced a passage |
-| S28 | remote | ✅ PASS | no embedded table of contents; the model read the document and compiled one from its text |
-| S29 | remote | ✅ PASS | open-access discovery surfaced 20 hit(s); model referenced one in its answer |
-| S30 | remote | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56388; model answered the ask |
+| S28 | remote | ✅ PASS | model used read outline=true; 140 table-of-contents entr(ies) returned |
+| S29 | remote | ✅ PASS | open-access discovery surfaced 35 hit(s); model referenced one in its answer |
+| S30 | remote | ✅ PASS | model set enrich=true; Crossref journal="Cell" citations=56401; model answered the ask |
 | S31 | remote | ✅ PASS | model searched, called get_details, and surfaced the returned BibTeX citation |
-| S32 | local | ✅ PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
-| S33 | remote | ✅ PASS | escalation surfaced 10 Anna's-origin result(s); model did not report not-found |
+| S32 | local | ✅ PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
+| S33 | remote | ✅ PASS | escalation surfaced 7 Anna's-origin result(s); model did not report not-found |
 | S34 | local | ✅ PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S35 | remote | ✅ PASS | model searched, found an Anna's-origin item, and downloaded it (md5=00dd2b0b58e81e3c6e7cb9e7b72dee23) |
 | S36 | local | ✅ PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S37 | remote | ✅ PASS | get_details fell back to Anna's for the escalated md5 (collection=zlib) |
 | S38 | local | ✅ PASS | never mode honored and the model reported the miss honestly |
-| S39 | local | ✅ PASS | always mode consulted the extras alongside a 29-result catalog page (annas=4, open access=10) |
+| S39 | local | ✅ PASS | always mode consulted the extras alongside a 27-result catalog page (annas=2, open access=33) |
 | S40 | local | ✅ PASS | read opened an Anna's-only item (1536 chars extracted) |
-| S41 | local | ✅ PASS | member download reported the account allowance (47 of 50 left) |
+| S41 | local | ✅ PASS | member download reported the account allowance (48 of 50 left) |
 | S42 | local | ✅ PASS | nothing exists by that name and the model said so, inventing no metadata |
 | S43 | local | ✅ PASS | restriction held; the model routed through the permitted source instead of the refused one |
 | S44 | local | ✅ PASS | model set page=2 and received page 2 with 25 results |
+| S45 | local | ✅ PASS | downloaded 91408 bytes via europepmc |
+| S46 | local | ✅ PASS | downloaded 2114465 bytes via biorxiv |
+| S47 | local | ✅ PASS | downloaded 374166 bytes via fatcat |
+| S48 | local | ✅ PASS | core is absent from the download source enum on a deployment with no CORE key, and the model asked for it nowhere; enum = unpaywall, europepmc, biorxiv, fatcat, oapen, archive, scihub, scidb, libgen, randombook, annas |
+| S49 | local | ✅ PASS | downloaded DOI via europepmc, an open-access provider — the chain preferred a legal copy |
+| S50 | local | ✅ PASS | model discovered the isbn key unaided; downloaded 15684454 bytes via archive |
+| S51 | local | ✅ PASS | downloaded 1850890 bytes via oapen |
+| S52 | local | ✅ PASS | downloaded 1850890 bytes via oapen |
+| S53 | local | ✅ PASS | oapen refused an identifier OAPEN does not hold cleanly, and the model reported the miss instead of presenting a file |
+| S54 | local | ✅ PASS | downloaded 15684454 bytes via archive |
+| S55 | local | ✅ PASS | archive refused a lending-restricted book cleanly, and the model reported the miss instead of presenting a file |
+| S56 | local | ✅ PASS | gutenberg surfaced 4 hit(s) with a fetchable file URL, and the model handed the link over |
+| S57 | local | ✅ PASS | eric surfaced 7 hit(s) with a fetchable file URL, and the model handed the link over |
+| S58 | local | ✅ PASS | dblp contributed 5 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S59 | local | ✅ PASS | pubmed contributed 7 record(s), each labeled a citation rather than free full text, and the model answered from the merged results |
+| S60 | local | ✅ PASS | the chain recorded the dead source as unavailable and acted on it on the next pass ("source in cooldown, skipping") |
 
 {/* end generated */}
 

--- a/test/e2e/live_test.go
+++ b/test/e2e/live_test.go
@@ -1413,6 +1413,42 @@ func TestE2EOapenRejectsUnheldIdentifier(t *testing.T) {
 	t.Logf("oapen correctly refused an unheld DOI: %v", err)
 }
 
+// cleanRefusalBudget bounds how long a source may take to report that it does not
+// hold an item. A settled "no" costs one resolve; it must not be put through the
+// start-retry schedule, whose waits are measured in tens of seconds. The budget is
+// deliberately far above a healthy resolve so a slow network cannot make this
+// flaky, yet far below the schedule it guards against.
+const cleanRefusalBudget = 30 * time.Second
+
+// TestE2ECleanRefusalIsPrompt pins the cost of a correct "I do not hold this".
+// A live evaluator run spent 87.7s on exactly this case: the miss was wrapped as a
+// start failure, so the retry schedule re-asked a question whose answer could not
+// change, and then reported it as a connection problem. Asserting the refusal is
+// both correct AND prompt is what distinguishes the fixed behavior from the bug —
+// TestE2EOapenRejectsUnheldIdentifier alone passed throughout.
+func TestE2ECleanRefusalIsPrompt(t *testing.T) {
+	requireLive(t)
+	requireUpstream(t, "oapen", "https://library.oapen.org/rest/search?query="+oapenLiveISBN)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	started := time.Now()
+	res, err := downloadFromSource(t, ctx, "10.9999/not-a-real-doi-zzz", "oapen")
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatalf("oapen served %q for a DOI it does not hold", res.Path)
+	}
+	if !errors.Is(err, libgen.ErrNotIndexed) {
+		classifyOrFail(t, "oapen", err, oapenFailures)
+		return
+	}
+	if elapsed > cleanRefusalBudget {
+		t.Fatalf("a settled miss took %s (budget %s): the retry schedule is being spent on an answer that cannot change",
+			elapsed.Round(time.Millisecond), cleanRefusalBudget)
+	}
+	t.Logf("oapen refused an unheld DOI in %s", elapsed.Round(time.Millisecond))
+}
+
 // archiveFailures are the KNOWN, diagnosed ways the archive source can fail live.
 // The lending classes are the interesting ones: they are how the source reports that
 // it found the book and deliberately declined to download a controlled-lending copy.


### PR DESCRIPTION
## What

Two defects surfaced by analysing the server logs of a full 61-scenario evaluator run. Both scenarios **passed** — the bugs were only visible in the logs behind the green result.

### 1. A settled miss was put through the start-retry schedule

`startAttempt` wrapped every resolve error as `errStartFailed`, so a source answering `ErrNotIndexed` ("I do not hold this item") was re-asked on the full schedule. Re-asking cannot change that answer, and the surfaced error then blamed transport:

> download could not be started after the retry schedule (resolve/connect/first-byte kept failing)

Measured in the run: **S53 spent 87.7s** refusing a DOI OAPEN does not hold, **S55 63.0s** refusing a lending-restricted book — 150s of the run's 159s of wasted source time.

A clean miss now returns immediately with the source's own diagnosis. Live: the same refusal takes **5.08s** and reads `oapen: no catalog entry states "10.9999/…"`. A genuine transport failure still gets the whole schedule.

### 2. "Every capable source is in cooldown" was logged when there were none

`eligibleSources` reached the bypass branch whenever `avail` was empty — including when *nothing supported the item at all*, e.g. a DOI on a deployment restricted to book sources. It logged a WARN naming an empty source list (5 times in S43), pointing a reader at a cooldown that does not exist. The real reason was already correct in the returned error.

## Tests

- `TestCleanMissIsNotRetried` — one Resolve call despite a configured schedule.
- `TestCleanMissKeepsItsOwnDiagnosis` — keeps `ErrNotIndexed`, drops the start-failure wording.
- `TestUnavailableSourceStillGetsTheRetrySchedule` — guards the other side: transport failures still retry.
- `TestNoCapableSourceDoesNotClaimACooldown` — no bypass warning without a cooldown.
- `TestE2ECleanRefusalIsPrompt` — live, asserts the refusal is both correct **and** prompt. The pre-existing `TestE2EOapenRejectsUnheldIdentifier` passed throughout the bug, because it never checked the cost.

Tests were placed in the files matching the code under test (`download_test.go`, `sourcecooldown_test.go`) per the repo's `xx.go` ↔ `xx_test.go` convention.

Also refreshes `cmd/eval/testdata/latest-run.md` and the generated site pages with the full run (61/61).

## Verification

`golangci-lint fmt --diff` · `golangci-lint run` · `go vet ./...` · `go vet -tags e2e ./test/e2e/` · godoc audit · `go test ./...` · `make cover-check` (97.9%) · `check-md-tables` · `check-llms` · `check-eval-pages` · `check-doc-links` · `audit-surface-quality` · prettier — all clean. New e2e run live against OAPEN.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop retrying a source after it clearly says it doesn’t hold the item, and fix a misleading cooldown log when no source supports the request. This removes wasted retry time and makes logs accurate.

- **Bug Fixes**
  - Return `ErrNotIndexed` directly in `startAttempt` so clean misses skip the start-retry schedule; transport errors still use the schedule.
  - In `eligibleSources`, don’t log “every capable source is in cooldown” when the `supporting` list is empty.
  - Added unit and e2e tests to lock in both behaviors (including a 30s budget for clean refusals), and refreshed evaluator run artifacts and site pages.

<sup>Written for commit 63843dc12aafb4a136883ce473c028aaa6590a14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

