### PR TITLE
ci(release): make the Fly.io health step actually verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,24 @@ jobs:
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: make govulncheck
 
+  # The release workflow only invokes GoReleaser when a tag is pushed, so a
+  # malformed .goreleaser.yml used to surface at the worst possible moment —
+  # mid-release, after the tag exists. Validate the config on every PR instead.
+  goreleaser-config:
+    name: GoReleaser config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: check
+
   analyze-md:
     name: Analyze Markdown
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,6 +198,12 @@ jobs:
   fly-deploy:
     name: Fly.io Deploy
     runs-on: ubuntu-latest
+    # Records the deployment under the release environment, so Fly.io rollouts
+    # appear in the repository's deployment history and can be gated behind a
+    # protection rule without touching this file.
+    environment:
+      name: release
+      url: https://libgen-mcp.fly.dev/
     needs: [release, docker]
     if: ${{ github.repository == 'jmrplens/libgen-mcp' }}
     steps:
@@ -239,8 +245,31 @@ jobs:
             --ha=false \
             --strategy immediate
 
-      - name: Verify deployment health
+      - name: Report machine status
         if: steps.check.outputs.skip == 'false'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: fly status --config fly.toml
+
+      # `fly status` prints the machine state but exits 0 even when the app is
+      # unhealthy, so on its own it verifies nothing. Poll the deployed server's
+      # own readiness endpoint instead, and fail the release when it never
+      # answers. The app runs scale-to-zero (min_machines_running = 0), so the
+      # first request has to wake a cold machine: hence the retries rather than a
+      # single call.
+      - name: Verify the deployed server answers
+        if: steps.check.outputs.skip == 'false'
+        env:
+          HEALTH_URL: https://libgen-mcp.fly.dev/health
+        run: |
+          for attempt in $(seq 1 10); do
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 30 "$HEALTH_URL" || true)
+            if [ "$code" = "200" ]; then
+              echo "health check passed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${HEALTH_URL} returned '${code:-no response}'"
+            sleep 10
+          done
+          echo "::error::${HEALTH_URL} never returned 200 — the release is deployed but not serving."
+          exit 1

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,3 +17,6 @@ ignores:
   - "**/.astro/**"
   - docs/superpowers
   - .superpowers
+  # Gitignored scratch space. CI never checks it out, so linting it locally only
+  # reports errors that no pipeline can see — and that nobody should fix.
+  - plan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ development build running is just:
 
 - **Go 1.26+** — [Download](https://go.dev/dl/). The module is
   `github.com/jmrplens/libgen-mcp`.
-- **Static-analysis tools** — `golangci-lint` and `govulncheck`. Install both
-  with `make install-tools`.
+- **Static-analysis tools** — `golangci-lint`, `govulncheck` and `goreleaser`
+  (the last one only for `make release-check`). Install all three with
+  `make install-tools`.
 - **Node.js with Corepack** (only for the docs site) — the site under `site/`
   pins `pnpm@11.8.0` via its `packageManager` field.
 - **Network access** (only for the gated end-to-end suite and the live probe).

--- a/Makefile
+++ b/Makefile
@@ -187,10 +187,11 @@ audit-surface-quality: ## Fail if the MCP tool surface violates a quality conven
 	go run ./cmd/audit_surface_quality/
 
 # ─── Tools / Release ────────────────────────────────────────────────────────
-install-tools: ## Install golangci-lint and govulncheck
+install-tools: ## Install golangci-lint, govulncheck and goreleaser
 	@echo "Installing static analysis tools..."
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	go install golang.org/x/vuln/cmd/govulncheck@latest
+	go install github.com/goreleaser/goreleaser/v2@latest
 	@echo "All tools installed."
 
 release-check: ## Validate the GoReleaser config


### PR DESCRIPTION
## What

Two changes to the `fly-deploy` job in the release workflow.

### The health step verified nothing

It ran `fly status --config fly.toml`. That prints the machine state but **exits 0 regardless** — the app could be failing to serve and the release would still be reported green. (The sibling repo has the same shape, so this applies there too.)

It now polls the deployed server's own readiness endpoint and fails the release when it never answers:

```
for attempt in $(seq 1 10); do
  code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 30 "$HEALTH_URL" || true)
  ...
```

`fly status` is kept as a separate step, because its output is genuinely useful context in the log — it just is not a check.

**Why retries rather than one call:** `fly.toml` sets `min_machines_running = 0` with `auto_stop_machines = "stop"`, so the instance is usually cold and the first request has to wake it. Ten attempts at 10s intervals, each capped at 30s.

**Verified both directions** against the live app: passes on the first attempt against `/health`, and fails after exhausting the retries against a bad path (a single call would have been enough to pass a broken deploy).

### Deployment history

Added `environment: { name: release, url: https://libgen-mcp.fly.dev/ }`, matching the sibling repo. Rollouts now appear in the repository's deployment history, and a protection rule (e.g. required approval before deploying) can be attached later without editing this workflow. `FLY_API_TOKEN` stays a repository secret, so nothing about access changes.

## Not changed, deliberately

The deploy keeps `--ha=false --strategy immediate` rather than the sibling's `--strategy rolling`. With a single scale-to-zero machine, a rolling strategy has nothing to roll across and `--ha=false` is what stops Fly provisioning a second instance — the difference is correct for this app's topology, not drift.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the release workflow to actually verify Fly.io deployments by polling the app’s /health endpoint and failing if it never returns 200. Also validate the GoReleaser config on PRs and record rollouts under the `release` environment.

- **Bug Fixes**
  - Replace the no-op `fly status` check with a real probe to https://libgen-mcp.fly.dev/health, retrying 10 times (10s apart, 30s max per attempt) for scale-to-zero cold starts.
  - Keep `fly status` as a separate, log-only step for context.

- **New Features**
  - Validate `.goreleaser.yml` on every PR via `goreleaser/goreleaser-action` (`args: check`); add `goreleaser` to `make install-tools` and document it in CONTRIBUTING.
  - Add `environment: { name: release, url: https://libgen-mcp.fly.dev/ }` so deployments appear in history; ignore `plan/` in `.markdownlint-cli2.yaml` to avoid local-only lint noise.

<sup>Written for commit 4f4255090828841d151846cfa55544a566ae66bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

