### PR TITLE
ci(release): let a failed release re-run recover on its own

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,3 +105,13 @@ release:
   draft: false
   prerelease: auto
   name_template: "v{{.Version}}"
+  # Make a re-run recover on its own. GoReleaser publishes into a draft and
+  # un-drafts it once every asset is up, so a failed upload leaves a draft
+  # holding a partial set — which is exactly what v1.3.0 hit when
+  # uploads.github.com answered one asset with an HTTP/2 REFUSED_STREAM that Go
+  # could not retry (the request body was already written). Without these two,
+  # re-running the job cannot fix itself: the leftover draft stays and the
+  # already-uploaded assets collide on re-upload, so the tag needs a hand-deleted
+  # release before it can be released again.
+  replace_existing_draft: true
+  replace_existing_artifacts: true


### PR DESCRIPTION
## Summary

`v1.3.0` failed with **8 of 9 assets uploaded** — `uploads.github.com` answered `libgen-mcp-linux-arm64` with an HTTP/2 `REFUSED_STREAM`, which Go could not retry because the request body had already been written. The release itself was fine; it was one flaky upload.

Recovering still took manual work, and that is what this fixes. GoReleaser publishes into a draft and un-drafts it only once every asset is up, so the failure left **a draft holding a partial set**. Re-running the job could not resolve that on its own:

- the stale draft stayed, and
- the eight already-uploaded assets collided with the re-upload.

The release only moved after the draft was deleted by hand.

| Option | What it fixes |
| ------------------------------ | ------------------------------------------------------ |
| `replace_existing_draft` | Drops the leftover partial draft instead of adding to it |
| `replace_existing_artifacts` | Overwrites a same-named asset instead of failing on it |

Together they make `gh run rerun --failed` the entire recovery procedure. Worth having because this failure class is transient and gives no warning.

> Both are needed. `replace_existing_artifacts` alone only resolves the asset collisions and leaves the stale draft in place, which is the half of the failure that actually blocked the re-run.

## Verification

`goreleaser check` passes — but that alone would also pass if the keys were silently ignored, so I confirmed they are really recognized: GoReleaser rejects an unknown field on `config.Release` (`field totally_bogus_key_xyz not found in type config.Release`) and accepts both of these. The `goreleaser-config` CI job added in #62 validates this config on every PR, so this change is gated by it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] `make release-check` passes
- [ ] Tests added or updated for the change — n/a, release-time config validated by the `goreleaser-config` job
- [ ] Docs updated if behavior changed — n/a, no user-facing behavior change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make release re-runs recover automatically by replacing stale drafts and colliding assets in GoReleaser. Transient upload failures no longer need manual cleanup.

- **Bug Fixes**
  - Set `replace_existing_draft: true` to discard partial drafts on rerun.
  - Set `replace_existing_artifacts: true` to overwrite same-named assets on upload.

<sup>Written for commit 0418a129fbea9725a45a7982cb70cebd25cb8cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

