### PR TITLE
ci(release): fail the Fly.io deploy instead of skipping it silently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,31 +209,32 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check FLY_API_TOKEN
-        id: check
+      # This job already restricts itself to the canonical repository, so a missing
+      # token is not a fork politely declining to deploy — it is a release that
+      # cannot deploy, and it has to be loud. The previous version warned and set
+      # skip=true, which made every later step no-op and the job report success:
+      # v1.2.0 and v1.3.0 both "deployed" green while Fly.io went on serving an
+      # older build that had been pushed by hand.
+      - name: Require FLY_API_TOKEN
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
           if [ -z "${FLY_API_TOKEN}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::FLY_API_TOKEN not set — skipping Fly.io deployment."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "::error::FLY_API_TOKEN is unset or empty. The secret may exist with an empty value — re-set it with a real Fly.io deploy token (fly tokens create deploy)."
+            exit 1
           fi
+          echo "FLY_API_TOKEN is present."
 
       - name: Extract version
-        if: steps.check.outputs.skip == 'false'
         id: version
         run: echo "version=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_OUTPUT"
 
       - name: Install flyctl
-        if: steps.check.outputs.skip == 'false'
         run: |
           curl -L https://fly.io/install.sh | sh
           echo "$HOME/.fly/bin" >> "$GITHUB_PATH"
 
       - name: Deploy to Fly.io
-        if: steps.check.outputs.skip == 'false'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
@@ -246,7 +247,6 @@ jobs:
             --strategy immediate
 
       - name: Report machine status
-        if: steps.check.outputs.skip == 'false'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: fly status --config fly.toml
@@ -257,19 +257,45 @@ jobs:
       # answers. The app runs scale-to-zero (min_machines_running = 0), so the
       # first request has to wake a cold machine: hence the retries rather than a
       # single call.
-      - name: Verify the deployed server answers
-        if: steps.check.outputs.skip == 'false'
+      #
+      # A 200 from /health is necessary but not sufficient: it only proves that
+      # SOME machine is up. A deploy that silently did not take effect leaves the
+      # previous build answering "ok" exactly like a good one — which is how
+      # Fly.io kept serving 1.2.0 through two green releases. So the version the
+      # server reports over MCP is asserted against the tag being released.
+      - name: Verify the deployed server answers with this version
         env:
-          HEALTH_URL: https://libgen-mcp.fly.dev/health
+          BASE_URL: https://libgen-mcp.fly.dev
+          EXPECTED: ${{ steps.version.outputs.version }}
         run: |
+          code=""
           for attempt in $(seq 1 10); do
-            code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 30 "$HEALTH_URL" || true)
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 30 "${BASE_URL}/health" || true)
             if [ "$code" = "200" ]; then
               echo "health check passed on attempt ${attempt}"
-              exit 0
+              break
             fi
-            echo "attempt ${attempt}: ${HEALTH_URL} returned '${code:-no response}'"
+            echo "attempt ${attempt}: ${BASE_URL}/health returned '${code:-no response}'"
             sleep 10
           done
-          echo "::error::${HEALTH_URL} never returned 200 — the release is deployed but not serving."
-          exit 1
+          if [ "$code" != "200" ]; then
+            echo "::error::${BASE_URL}/health never returned 200 — the release is deployed but not serving."
+            exit 1
+          fi
+
+          raw=$(curl -fsS --max-time 30 -X POST "${BASE_URL}/" \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json, text/event-stream' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"release-verify","version":"1"}}}')
+          # The streamable-HTTP transport answers as SSE ("data: {...}"); fall back
+          # to the raw body in case it ever replies with plain JSON instead.
+          payload=$(printf '%s\n' "$raw" | sed -n 's/^data: //p' | head -n1)
+          [ -n "$payload" ] || payload="$raw"
+          served=$(printf '%s' "$payload" | jq -r '.result.serverInfo.version // empty')
+
+          echo "serving='${served:-unknown}' expected='${EXPECTED}'"
+          if [ "$served" != "$EXPECTED" ]; then
+            echo "::error::Fly.io is serving '${served:-unknown}' but this release is '${EXPECTED}' — the deploy did not take effect."
+            exit 1
+          fi
+          echo "Fly.io is serving ${served}."


### PR DESCRIPTION
## The bug

**Fly.io is serving 1.2.0.** Both `v1.2.0` and `v1.3.0` reported a green **Fly.io Deploy** job, and neither one deployed.

```
FLY_API_TOKEN:
##[warning]FLY_API_TOKEN not set — skipping Fly.io deployment.
```

`FLY_API_TOKEN` resolves to empty, the check set `skip=true`, and every following step was gated on `skip == 'false'` — so they all no-opped and the job went green having done nothing. Including the health check I added in #62, which never ran.

The timeline confirms the job has **never** completed a deploy:

| Event | Time |
| ----------------------- | ------------------------------- |
| `v1.2.0` published | `2026-07-21T06:21:54Z` |
| `FLY_API_TOKEN` created | `2026-07-21T06:56:42Z` (35 min later) |

The 1.2.0 currently running was pushed by hand.

### Why the secret is empty

It is a genuine Actions repo secret (not Dependabot/Codespaces scoped), so its stored **value** is empty — GitHub accepts an empty secret, and a real one would appear masked as `***` in the log. I confirmed with a throwaway probe workflow that it reads empty **both with and without** the `environment: release` block added in #62, so that addition is not the cause.

> **Action required, outside this PR:** re-set the secret with a real token (`fly tokens create deploy`). This PR only guarantees the failure is impossible to miss next time.

## The fix

**1. A missing token now fails the job.** The job is already restricted to the canonical repo, so the skip branch was never sparing a fork — it only hid a broken release.

**2. The health check now asserts the version.** A 200 from `/health` only proves *some* machine is up; a deploy that silently no-ops leaves the previous build answering exactly like a good one. It now asks the deployed server over MCP which build it is and compares against the tag.

## Verification

Ran the extraction against the live endpoint:

```
extracted served='1.2.0'
expected=1.3.0 -> FAIL (correct)
expected=1.2.0 -> pass
{"protocolVersion": "2024-11-05", "serverVersion": "1.2.0"}
```

It reads `serverInfo.version`, not `protocolVersion`, and fails for an expected `1.3.0` — precisely the case that shipped green twice. `actionlint` (which shellchecks the `run` blocks) is clean on both workflows.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] `actionlint` clean
- [ ] Tests added or updated — n/a, release-time workflow; the version assertion was exercised by hand against the live endpoint
- [ ] Docs updated if behavior changed — n/a

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the Fly.io release job when `FLY_API_TOKEN` is missing and verify that the deployed server version matches the tag, preventing “green” releases that don’t actually deploy.

- **Bug Fixes**
  - Require `FLY_API_TOKEN`; exit with an error if the secret is unset or empty (no more silent skips).
  - Remove the `skip` gating so deploy steps run only when the token is present.
  - After `/health` returns 200, call MCP `initialize` and assert `serverInfo.version` equals the tag; fail if it doesn’t.

- **Migration**
  - Set the `FLY_API_TOKEN` repo secret to a valid deploy token: `fly tokens create deploy`.

<sup>Written for commit 42fc4c819a1a9ed755851cfc55997bf7eba54108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

