### PR TITLE
geo: carry the Search Console and Bing Webmaster verification tags

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -336,6 +336,26 @@ export default defineConfig({
 					tag: "meta",
 					attrs: { name: "author", content: "José Manuel Requena Plens" },
 				},
+				// Search Console and Bing Webmaster ownership. Verifying the host
+				// root at jmrplens.github.io covers this sub-path, but a sub-path
+				// registered as a property in its own right — which is what lets you
+				// see this project's queries and sitemap status separately — has to
+				// carry the tag itself. Same tokens as the hub and the sibling docs
+				// sites, so all three verify against one account.
+				{
+					tag: "meta",
+					attrs: {
+						name: "google-site-verification",
+						content: "4Hx_PJ1seU_BgKfWpo_FA7_Hkh7GeYVNrvnvzqCjF0Q",
+					},
+				},
+				{
+					tag: "meta",
+					attrs: {
+						name: "msvalidate.01",
+						content: "7574EB3B44624C239F14920DBC34EE25",
+					},
+				},
 				// GitHub Pages cannot set response headers, so the policies that do
 				// have a <meta> equivalent are declared here. X-Frame-Options,
 				// X-Content-Type-Options and Permissions-Policy are header-only and


### PR DESCRIPTION
## Summary

Adds the two webmaster ownership tags to the docs site:

```html
<meta name="google-site-verification" content="4Hx_PJ1seU_BgKfWpo_FA7_Hkh7GeYVNrvnvzqCjF0Q" />
<meta name="msvalidate.01" content="7574EB3B44624C239F14920DBC34EE25" />
```

Verifying the host root at `jmrplens.github.io` already covers this sub-path, so
this is not about being crawled. It is about being able to register
`https://jmrplens.github.io/libgen-mcp/` as a **property in its own right** —
which is what shows this project's queries, impressions and sitemap status
separately instead of pooled with every other project on the host.

Checked before writing: the hub root and the `gitlab-mcp-server` docs both
already emit both tags. This was the only one of the three that emitted neither.
Same tokens, so all three verify against one account.

Verified in the build: both tags are emitted on the English and Spanish
homepages.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [ ] Tests added or updated for the change
- [x] Docs updated if behavior changed

No tests: this adds two static `<meta>` tags to the Astro head config and touches
no Go code. Site lint is green (astro check, i18n parity, privacy sync, eslint,
prettier, html-validate, htmlhint — 22 files, 0 errors).

https://claude.ai/code/session_014qZgHy1GjFPHhuYMcSfQ1h


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Google Search Console (`google-site-verification`) and Bing Webmaster (`msvalidate.01`) meta tags to the docs site so the sub-path `https://jmrplens.github.io/libgen-mcp/` can be verified and tracked as its own property. Implemented in `site/astro.config.mjs` using the same tokens as the hub and sibling docs.

<sup>Written for commit a3720e75729a8665fa4f27f90167f12176c4b5df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added site ownership verification metadata for Google Search Console and Bing Webmaster Tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->