### PR TITLE
test(tools): guard that download still asks for the email it lacks

### DIFF
--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -3114,3 +3114,65 @@ func TestSearchTool_RejectsAnUnknownExtraSourcesMode(t *testing.T) {
 		t.Fatalf("an unknown extra_sources mode must be rejected, got res=%+v err=%v", res, err)
 	}
 }
+
+// TestDownloadToolAsksForTheEmailItLacks is the guard for the failure that made
+// the SDK upgrade dangerous. Every helper here collapses "could not ask" into
+// its fall-back answer, so a server that has lost the ability to ask the user
+// anything still builds, still passes its tests, and still downloads — it just
+// silently stops asking, and nobody finds out until a user notices a prompt that
+// never appears. This drives the REAL download tool and asserts the question
+// reaches the client: a DOI download against a server with no contact email
+// configured must come back asking for one.
+func TestDownloadToolAsksForTheEmailItLacks(t *testing.T) {
+	cfg := &config.Config{
+		DownloadDir: t.TempDir(), Timeout: 5 * time.Second,
+		RateRPS: 1000, RateBurst: 100, RetryAttempts: 1,
+		// No contact email, and no save confirmation: the email is then the only
+		// question this call has to ask, and nothing touches the network before it.
+		UnpaywallEmail: "", ConfirmDownloads: false,
+		// unpaywall is the only enabled source, and without a contact email it is
+		// not in the chain at all — so a server that has stopped asking fails here
+		// offline and fast, instead of quietly downloading the article from
+		// somewhere else and leaving the lost prompt invisible.
+		Sources: []string{"unpaywall"},
+	}
+	client := libgen.New(staticMirrors{"http://127.0.0.1:0"}, cfg)
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0.0.1"}, nil)
+	Register(server, client, cfg)
+
+	st, ct := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	if _, err := server.Connect(ctx, st, nil); err != nil {
+		t.Fatal(err)
+	}
+	// The client advertises elicitation (so the server may ask) but answers no
+	// round trip automatically, so the question itself is observable.
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "0.0.1"}, &mcp.ClientOptions{
+		ElicitationHandler: acceptHandler(map[string]any{"email": "reader@example.com"}),
+		MultiRoundTrip:     &mcp.MultiRoundTripOptions{Disabled: true},
+	})
+	session, err := mcpClient.Connect(ctx, ct, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "download",
+		Arguments: map[string]any{"doi": "10.1371/journal.pmed.0020124"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !res.NeedsInput() {
+		t.Fatalf("download must ask for the contact email it has none of; got %+v", res)
+	}
+	if _, ok := res.InputRequests["unpaywall_email"]; !ok {
+		t.Errorf("the question is not the contact email: %+v", res.InputRequests)
+	}
+
+	// The answered call is deliberately not driven here: fulfilling it would run
+	// a real DOI download, and this suite stays offline. That the answer reaches
+	// the handler is covered by TestInputRound_AsksThroughTheResult, and end to
+	// end by the gated e2e and eval suites.
+}


### PR DESCRIPTION
## Summary

Adds the regression guard for the failure mode that made the SDK upgrade dangerous.

Every prompt helper collapses "could not ask" into its fall-back answer. That is deliberate — elicitation is advisory — but it is also what makes losing the ability to ask so quiet: the server builds, its tests pass, and downloads keep working; the prompt just never appears again. Taking go-sdk v1.7.0 without the SEP-2322 migration would have landed exactly like that, and nothing in the suite would have objected.

The test drives the **real** `download` tool with a client that advertises elicitation and answers no round trip automatically, then asserts the question comes back: a DOI download against a server with no contact email configured must ask for one.

It stays offline in both outcomes — `unpaywall` is the only enabled source, and without a contact email it is not in the chain at all, so a server that has stopped asking fails here fast instead of quietly fetching the article from another source and leaving the lost prompt invisible. (That is what happened when I simulated the regression before pinning the source: the download completed via `europepmc` and only the prompt was missing.)

Verified by simulating the regression: the assertion fires, in 0.01s, with no network.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [ ] Docs updated if behavior changed — no behavior change

## Summary by Sourcery

Tests:
- Add an offline integration-style test that drives the real download tool and asserts it requests a contact email when required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test that ensures the `download` tool prompts for a contact email when none is configured, preventing silent loss of elicitation. It runs the real tool with elicitation enabled, asserts an `unpaywall_email` request, and stays offline by enabling only `unpaywall`.

<sup>Written for commit d0f832b9762bf3662dd4d6981c1f2ec70dc6c6a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming the download feature requests an Unpaywall contact email when it is not configured.
  * Verified that the download request pauses for the required `unpaywall_email` input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->