### PR TITLE
fix(prompts): stop telling the model get_details rejects a DOI

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -617,9 +617,9 @@ download it. Provide exactly one of `doi` or `citation`.
 | `doi`      | one of   | DOI of the paper to fetch directly (mutually exclusive with `citation`).       |
 | `citation` | one of   | Free-text citation or reference to search for (mutually exclusive with `doi`). |
 
-With `doi`, the prompt hands back a direct `download {"doi": ...}` plan — it explicitly
-notes that `get_details` does **not** accept a bare DOI as input, so the model doesn't
-misroute there. With `citation`, it searches articles for a match, retrying once among
+With `doi`, the prompt hands back a direct `download {"doi": ...}` plan, and points at
+`get_details` with the same DOI for the record and its BibTeX or RIS citation — the one
+thing `download` cannot produce. With `citation`, it searches articles for a match, retrying once among
 books (some papers are cataloged that way) when nothing turns up, and lists the
 candidates to download by DOI.
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -448,7 +448,7 @@ func doiText(doi string) string {
 	b.WriteString("\"}` to fetch the article — add `\"resolve_only\": true` if this server runs remotely and cannot write to your disk.\n\n")
 	b.WriteString("2. For the record rather than the file — publisher, year, journal and a ready-made BibTeX or RIS citation — call `get_details` with `{\"doi\": \"")
 	b.WriteString(doi)
-	b.WriteString("\"}`. It is the only route that produces a citation; `download` returns the file alone.\n\n")
+	b.WriteString("\"}`. It is the only route that produces a citation; `download` retrieves the article itself — as a saved file, or as a link when this server runs remotely — and nothing more.\n\n")
 	b.WriteString(untrustedCaveat)
 	return b.String()
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -428,9 +428,15 @@ func handleGetPaper(ctx context.Context, client *libgen.Client, req *mcp.GetProm
 	return handleGetPaperCitation(ctx, client, citation)
 }
 
-// doiText builds the DOI-path instruction message: call download directly
-// with the DOI, with an explicit note that get_details does not accept a
-// bare DOI (so the model doesn't misroute there).
+// doiText builds the DOI-path instruction message: call download directly with the
+// DOI, and name get_details as the way to the record itself.
+//
+// It used to end on a note that get_details does NOT accept a bare DOI. That was
+// false — the tool has a doi argument and a detailsByDOI path behind it, and a
+// bare DOI returns the edition record and a ready-made BibTeX citation. The note
+// steered a model away from the one route that produces a citation, which download
+// cannot do, so it cost the caller a capability to prevent a misroute that was
+// never possible.
 func doiText(doi string) string {
 	var b strings.Builder
 	b.WriteString("Fetching paper by DOI **")
@@ -440,7 +446,9 @@ func doiText(doi string) string {
 	b.WriteString("1. Call the `download` tool with `{\"doi\": \"")
 	b.WriteString(doi)
 	b.WriteString("\"}` to fetch the article — add `\"resolve_only\": true` if this server runs remotely and cannot write to your disk.\n\n")
-	b.WriteString("Note: the `get_details` tool does NOT accept a bare DOI as input; use `download` directly with the DOI as shown above.\n\n")
+	b.WriteString("2. For the record rather than the file — publisher, year, journal and a ready-made BibTeX or RIS citation — call `get_details` with `{\"doi\": \"")
+	b.WriteString(doi)
+	b.WriteString("\"}`. It is the only route that produces a citation; `download` returns the file alone.\n\n")
 	b.WriteString(untrustedCaveat)
 	return b.String()
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -403,7 +403,19 @@ func TestGetPaper_DOINoSearch(t *testing.T) {
 		t.Errorf("missing DOI in message:\n%s", txt)
 	}
 	if !strings.Contains(txt, "get_details") {
-		t.Errorf("missing get_details caveat:\n%s", txt)
+		t.Errorf("missing the get_details route:\n%s", txt)
+	}
+	// The prompt used to end on "get_details does NOT accept a bare DOI", which was
+	// false — the tool has a doi argument and a detailsByDOI path behind it — and it
+	// steered a model away from the only route that produces a citation. Pinned so
+	// the claim cannot come back.
+	for _, denial := range []string{"does NOT accept", "does not accept", "bare DOI as input"} {
+		if strings.Contains(txt, denial) {
+			t.Errorf("the prompt tells the model get_details rejects a DOI, which it does not:\n%s", txt)
+		}
+	}
+	if !strings.Contains(txt, "citation") {
+		t.Errorf("the DOI path should name the citation get_details can produce:\n%s", txt)
 	}
 }
 

--- a/site/src/content/docs/es/tools.mdx
+++ b/site/src/content/docs/es/tools.mdx
@@ -527,7 +527,7 @@ Resuelve un artículo concreto por DOI o por una cita en texto libre, y obtén i
 | `doi`      | uno de    | DOI del artículo a obtener directamente (mutuamente excluyente con `citation`). |
 | `citation` | uno de    | Cita o referencia en texto libre a buscar (mutuamente excluyente con `doi`).    |
 
-Con `doi`, el prompt devuelve un plan directo `download {"doi": ...}` — indica explícitamente que `get_details` **no** acepta un DOI a secas como entrada, para que el modelo no se equivoque de ruta. Con `citation`, busca en artículos una coincidencia, reintentando una vez entre los libros (algunos artículos están catalogados así) cuando no aparece nada, y enumera los candidatos a descargar por DOI.
+Con `doi`, el prompt devuelve un plan directo `download {"doi": ...}` y remite a `get_details` con ese mismo DOI para obtener el registro y su cita en BibTeX o RIS — lo único que `download` no puede producir. Con `citation`, busca en artículos una coincidencia, reintentando una vez entre los libros (algunos artículos están catalogados así) cuando no aparece nada, y enumera los candidatos a descargar por DOI.
 
 ### download_troubleshoot
 

--- a/site/src/content/docs/tools.mdx
+++ b/site/src/content/docs/tools.mdx
@@ -520,7 +520,7 @@ Resolve a specific paper by DOI or by a free-text citation and get instructions 
 | `doi`      | one of   | DOI of the paper to fetch directly (mutually exclusive with `citation`).       |
 | `citation` | one of   | Free-text citation or reference to search for (mutually exclusive with `doi`). |
 
-With `doi`, the prompt hands back a direct `download {"doi": ...}` plan — it explicitly notes that `get_details` does **not** accept a bare DOI as input, so the model doesn't misroute there. With `citation`, it searches articles for a match, retrying once among books (some papers are cataloged that way) when nothing turns up, and lists the candidates to download by DOI.
+With `doi`, the prompt hands back a direct `download {"doi": ...}` plan, and points at `get_details` with the same DOI for the record and its BibTeX or RIS citation — the one thing `download` cannot produce. With `citation`, it searches articles for a match, retrying once among books (some papers are cataloged that way) when nothing turns up, and lists the candidates to download by DOI.
 
 ### download_troubleshoot
 


### PR DESCRIPTION
## Summary

The `get_paper` prompt ended its DOI path on this line:

> Note: the `get_details` tool does NOT accept a bare DOI as input; use `download` directly with the DOI as shown above.

**It is false.** `DetailsInput` carries a `doi` argument, `detailsHandler` has a `case in.DOI != ""` branch behind it, and a live call with nothing but a DOI comes back with the edition record and a ready-made BibTeX citation:

```
get_details {"doi": "10.1371/journal.pone.0000308"}
→ {"citations": {"bibtex": "@article{...}"}, "edition": {...}, "next_steps": [...]}
```

The note existed to prevent a misroute that was never possible, and it cost something real. `get_details` is the **only** route that produces a citation — `download` returns the file and nothing else — so the prompt whose whole job is fetching a paper was steering callers away from the capability they are most likely to want next. The DOI path now names that route as step 2 instead of denying it.

A test pins the denial out: any of "does NOT accept", "does not accept" or "bare DOI as input" reappearing in that message fails.

The three documentation copies that faithfully described the note — `docs/tools.md` and the English and Spanish tools pages — are corrected with it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [ ] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [x] Docs updated if behavior changed

## Note on timing

This was found during the #84 review and set aside as a product decision — which side of the contradiction should give — rather than resolved before v1.4.0 was tagged. That was the wrong call: the API was right and the prompt was simply wrong about it, so there was nothing to decide. It ships in the next release.

## Summary by Sourcery

Correct the DOI-based get_paper prompt flow to direct models to use get_details for metadata and citations instead of incorrectly warning that it rejects bare DOIs.

Bug Fixes:
- Fix misleading get_paper DOI instructions that claimed get_details does not accept a bare DOI and omitted its citation-producing role.

Enhancements:
- Clarify DOI-path prompt text to describe download for files and get_details for bibliographic records and citations, emphasizing their complementary capabilities.

Documentation:
- Update English and Spanish tools documentation, plus tools.md, to reflect that get_details accepts a DOI and is the route for BibTeX/RIS citations when resolving by DOI.

Tests:
- Extend get_paper DOI-path tests to assert presence of the get_details route and citation mention, and to guard against reintroducing the incorrect claim that get_details rejects bare DOIs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `get_paper` DOI path. The prompt now says to use `download` for the file or a link (when remote), then `get_details` for metadata and BibTeX/RIS.

- **Bug Fixes**
  - Updated DOI instructions to include `get_details {"doi": ...}` and clarify `download` may return a link when remote; mention `resolve_only`.
  - Added a test to block the false claim that `get_details` rejects a DOI and to assert the citation route is present.
  - Synced `docs/tools.md` and site docs (`/tools.mdx`, `/es/tools.mdx`) with the corrected flow and `download` behavior.

<sup>Written for commit 6b096ef2f4f34919552016059c2c26b3f65aa74d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated DOI guidance for `get_paper` to provide a direct download plan.
  * Added instructions to use `get_details` with the same DOI to retrieve metadata and BibTeX/RIS citations.
  * Clarified that downloads provide the file, while citation details come from `get_details`.
  * Updated English and Spanish documentation.

* **Bug Fixes**
  * Corrected prompt guidance that incorrectly described DOI handling limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->