### PR TITLE
chore(ci): publish the Docker Hub description from the release workflow

### DIFF
--- a/.github/dockerhub-description.md
+++ b/.github/dockerhub-description.md
@@ -1,0 +1,72 @@
+# libgen-mcp
+
+**Connect your AI assistant to Library Genesis and the open-access web so it can find, cite, download and read books, papers, comics, magazines and standards — in plain language.** One static binary (or this container), four focused tools (`search`, `get_details`, `download`, `read`) plus guided prompts, working with Claude, Cursor, VS Code, and any MCP client.
+
+You talk to your AI assistant; it does the searching and fetching. No mirrors, MD5 hashes, or download URLs to track — mirrors are discovered automatically and cached, with transparent failover.
+
+> "Find me the latest edition of _Clean Code_." · "Download that paper by its DOI." · "Search comics for _Watchmen_ and grab the CBR." · "Read the first chapter and summarize it."
+
+## Run with Docker
+
+The image runs on **stdio by default** — the correct mode for MCP clients. Stdio transport, for desktop clients such as Claude Desktop, Cursor or VS Code:
+
+```json
+{
+  "mcpServers": {
+    "libgen": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "jmrplens/libgen-mcp:latest"]
+    }
+  }
+}
+```
+
+Or directly, with the options combining freely:
+
+```bash
+# Plain (stdio, zero config)
+docker run -i --rm jmrplens/libgen-mcp:latest
+
+# Enable open-access articles via Unpaywall
+docker run -i --rm -e LIBGEN_MCP_UNPAYWALL_EMAIL=you@example.com jmrplens/libgen-mcp:latest
+
+# Consult the extra searchers on every search, not only when the catalog misses
+docker run -i --rm -e LIBGEN_MCP_EXTRA_SOURCES=always jmrplens/libgen-mcp:latest
+
+# Save downloads to a host folder
+docker run -i --rm -e LIBGEN_MCP_DOWNLOAD_DIR=/downloads -v "$HOME/Downloads:/downloads" jmrplens/libgen-mcp:latest
+
+# Serve streamable HTTP instead of stdio
+docker run --rm -p 8080:8080 jmrplens/libgen-mcp:latest --http :8080
+```
+
+Images are multi-arch (`linux/amd64`, `linux/arm64`), published for every release with provenance and SBOM attestations, and signed with Cosign. The same image is also available as `ghcr.io/jmrplens/libgen-mcp`.
+
+## Why this server
+
+- 🔑 **Keyless by default.** No account, no API key, no token. Search, details and downloads all work with zero configuration; credentials are strictly opt-in and, when supplied per call, used once and never stored.
+- 🌐 **Catalog first, then the open-access web.** Queries the Library Genesis catalog, then reaches beyond it — Anna's Archive, arXiv, Crossref, OpenLibrary, Project Gutenberg, dblp, PubMed, ERIC — merged, deduped and labeled by origin.
+- 📄 **Papers that actually download.** An ordered source chain with transparent failover across Unpaywall, OpenAlex, Europe PMC, bioRxiv/medRxiv, the RFC Editor, NIST, Schloss Dagstuhl, the ACL Anthology, Zenodo, SciELO, the FAO Knowledge Repository, Internet Archive Scholar, CORE, OAPEN and the Internet Archive.
+- 📚 **Reads what it fetches.** `read` extracts and paginates a PDF/EPUB/TXT so your assistant can summarize a book or paper, search inside it, or outline it.
+- 🔖 **Citations built in.** `get_details` returns a ready-to-paste BibTeX/RIS export, with opt-in Crossref/OpenLibrary enrichment.
+- 🪶 **Light context footprint.** The four tools add ~6,700 tokens to a request, and are verified against a real LLM by an automated evaluator.
+
+## Try it without installing anything
+
+A public instance runs at **`https://mcp.jmrp.io/libgen`** — no account, no key, nothing to install. It is stateless streamable HTTP: `POST` is the transport, a `GET` answers `405` by design, and `/health` answers `ok`.
+
+## Responsible use
+
+This tool accesses third-party mirrors of Library Genesis. You are responsible for respecting the copyright and intellectual-property laws that apply where you live. Use it only for content you are legally entitled to access.
+
+## Documentation
+
+- [Repository and full README](https://github.com/jmrplens/libgen-mcp)
+- [Documentation, install guides & configuration reference](https://jmrp.io/docs/libgen-mcp) (also in [Español](https://jmrplens.github.io/libgen-mcp/es/))
+- [Releases and signed binaries](https://github.com/jmrplens/libgen-mcp/releases)
+
+---
+
+Maintained by [José M. Requena Plens](https://jmrp.io/) ·
+[Project page](https://jmrp.io/projects/) ·
+Hosted instance: [mcp.jmrp.io/libgen](https://mcp.jmrp.io/libgen) (POST-only; a GET returns 405 by design)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,3 +224,16 @@ jobs:
         run: |
           cosign sign --yes \
             docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
+      # Docker Hub does not take a description from the image, so a repository
+      # published only by `docker push` shows an empty page — which is what this
+      # one did for its first 1,400 pulls. Publishing it from here keeps the page
+      # and the README from drifting apart.
+      - name: Publish Docker Hub description
+        if: steps.dockerhub-login.outputs.skip == 'false'
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          short-description: "MCP server to search and read Library Genesis and open-access sources. By jmrp.io"
+          readme-filepath: ./README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,11 +224,16 @@ jobs:
         run: |
           cosign sign --yes \
             docker.io/${{ env.DOCKERHUB_IMAGE }}@${{ steps.docker-push.outputs.digest }}
-      # Docker Hub does not take a description from the image, so a repository
-      # published only by `docker push` shows an empty page — which is what this
-      # one did for its first 1,400 pulls. Publishing it from here keeps the page
-      # and the README from drifting apart.
-      - name: Publish Docker Hub description
+      # The Docker Hub repository descriptions are owned by this repo so they
+      # cannot drift (they had been empty since the repository was published,
+      # across thousands of pulls): the short description and the curated
+      # description file are re-pushed on every release, right after the
+      # image publish. The full README (~50KB) exceeds Docker Hub's 25,000
+      # character limit, so .github/dockerhub-description.md carries the
+      # Docker-relevant sections. DOCKERHUB_TOKEN must be a Docker Hub PAT
+      # with read/write/delete scope — the descriptions API rejects narrower
+      # ones.
+      - name: Update Docker Hub description
         if: steps.dockerhub-login.outputs.skip == 'false'
         uses: peter-evans/dockerhub-description@v5
         with:
@@ -236,4 +241,4 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ env.DOCKERHUB_IMAGE }}
           short-description: "MCP server to search and read Library Genesis and open-access sources. By jmrp.io"
-          readme-filepath: ./README.md
+          readme-filepath: ./.github/dockerhub-description.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,11 @@ jobs:
       # ones.
       - name: Update Docker Hub description
         if: steps.dockerhub-login.outputs.skip == 'false'
-        uses: peter-evans/dockerhub-description@v5
+        # Pinned to a commit SHA (unlike the org-owned actions above) because
+        # this is an individually-maintained action that receives
+        # DOCKERHUB_TOKEN — a mutable tag would let a compromised release
+        # exfiltrate it.
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -443,3 +443,9 @@ This tool accesses third-party mirrors of Library Genesis. You are responsible f
 ## License
 
 See [LICENSE](LICENSE). Released under the MIT License.
+
+---
+
+Maintained by [José M. Requena Plens](https://jmrp.io/) ·
+[Project page](https://jmrp.io/projects/) ·
+Hosted instance: [https://mcp.jmrp.io/libgen](https://mcp.jmrp.io/libgen) (POST-only; a GET returns 405 by design)

--- a/README.md
+++ b/README.md
@@ -448,4 +448,4 @@ See [LICENSE](LICENSE). Released under the MIT License.
 
 Maintained by [José M. Requena Plens](https://jmrp.io/) ·
 [Project page](https://jmrp.io/projects/) ·
-Hosted instance: [https://mcp.jmrp.io/libgen](https://mcp.jmrp.io/libgen) (POST-only; a GET returns 405 by design)
+Hosted instance: [mcp.jmrp.io/libgen](https://mcp.jmrp.io/libgen) (POST-only; a GET returns 405 by design)

--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "Books & Papers MCP Server",
   "description": "Federated search of books and papers, BibTeX/RIS citations, open-access retrieval and reading.",
   "version": "1.6.1",
-  "websiteUrl": "https://jmrplens.github.io/libgen-mcp/",
+  "websiteUrl": "https://jmrp.io/docs/libgen-mcp",
   "repository": {
     "url": "https://github.com/jmrplens/libgen-mcp",
     "source": "github",

--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "Books & Papers MCP Server",
   "description": "Federated search of books and papers, BibTeX/RIS citations, open-access retrieval and reading.",
   "version": "1.6.1",
-  "websiteUrl": "https://jmrp.io/docs/libgen-mcp",
+  "websiteUrl": "https://mcp.jmrp.io/",
   "repository": {
     "url": "https://github.com/jmrplens/libgen-mcp",
     "source": "github",


### PR DESCRIPTION
## Summary

The Docker Hub repository `jmrplens/libgen-mcp` has carried an **empty short description and an empty full description** since it was first published. Verified against the API on 2026-08-22:

```json
{ "description": "", "full_description_length": 0, "pull_count": 1447 }
```

1,447 pulls with no attribution and no link back to the project. Docker Hub takes neither description from the image, so a repository published by `docker push` alone shows a blank page — nothing was ever going to fill it in.

## What this does

A `peter-evans/dockerhub-description@v5` step at the end of the existing `docker` job in the release workflow, publishing:

- **short-description** — `MCP server to search and read Library Genesis and open-access sources. By jmrp.io` (81 chars, under Docker Hub's 100-char limit)
- **readme-filepath** — `./.github/dockerhub-description.md`, a curated file carrying the Docker-relevant material

**Why not the README.** Docker Hub caps the full description at 25,000 characters and this README is **50,606** — pointing the step at `./README.md` would have failed on the next release and left the page as empty as it is now. The curated file (4,265 chars) mirrors what the sibling `gitlab-mcp-server` publishes, so the two pages read as one project.

It hangs off the same `steps.dockerhub-login.outputs.skip` guard the image push already uses, so a fork without the credentials skips it exactly as it skips the push. No new secret is required: the step reuses `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`.

The README gains the maintainer block that the page will carry.

## server.json

`websiteUrl` moves to `https://mcp.jmrp.io/`, matching the sibling repository.

One correction worth recording: the schema note behind the original plan is wrong — the MCP registry schema (`2025-12-11`) has no `documentation` field, `websiteUrl` is its only URL field. But the entry also carries `repository.url`, so the documentation stays one hop away either way, and consistency across the two servers wins.

## Verification

Done:

- Docker Hub baseline confirmed empty via the API (above).
- `peter-evans/dockerhub-description@v5` confirmed as the latest release; it accepts a PAT with `read/write/delete` scope.
- Workflow YAML parses; short description measured at 81 chars, curated file at 4,265 (both under their limits).
- `https://jmrp.io/docs/libgen-mcp` → `301` → the documentation, so the link inside the curated file resolves.
- GitHub repo homepage already updated to the canonical URL.
- markdownlint, doc-links, md-tables and check-manifests all green.

Not yet done, and it cannot be from here: the description upload itself. The workflow only fires on a `v*` tag, and v1.6.1 has already shipped. See the note below.

## Before merging — please check the token scope

`DOCKERHUB_TOKEN` already exists and works for pushing images, but Docker Hub's description API needs a PAT with **`read/write/delete`** scope. A push-only token will pass the image step and fail this one. Worth confirming at https://app.docker.com/settings/personal-access-tokens before the next release.

To fill the page now rather than waiting for the next tag:

```bash
docker run --rm -v "$PWD:/repo" -e DOCKER_USER=jmrplens -e DOCKER_PASS='<PAT>' \
  chko/docker-pushrm --short "MCP server to search and read Library Genesis and open-access sources. By jmrp.io" \
  --file /repo/.github/dockerhub-description.md jmrplens/libgen-mcp
```

Then:

```bash
curl -s https://hub.docker.com/v2/repositories/jmrplens/libgen-mcp/ \
  | jq '{description, full_len: (.full_description|length), has_jmrp: (.full_description|contains("jmrp.io"))}'
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [ ] Tests added or updated for the change — n/a, no Go code changes
- [x] Docs updated if behavior changed

https://claude.ai/code/session_01HFRWhiJbZhqPTNpzVL7tqD

## Summary by Sourcery

Keep the Docker Hub repository page populated and aligned with the project by publishing curated documentation during releases.

Enhancements:
- Add a curated Docker Hub description covering the image’s usage, capabilities, documentation, and responsible-use guidance.
- Add maintainer and project links to the main README.
- Align the server metadata website URL with the project’s canonical documentation site.

CI:
- Publish the short and full Docker Hub repository descriptions automatically during authenticated release image publishing.

Documentation:
- Provide Docker-specific usage and project information for the Docker Hub repository page.