### PR TITLE
chore(readme): swap dead Smithery badge for MCP Toplist

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 
 [![Cursor Directory](https://img.shields.io/badge/Cursor-Directory-1f9cf0?style=flat&logo=cursor&logoColor=white)](https://cursor.directory/plugins/libgen-mcp)
 [![libgen-mcp MCP server](https://glama.ai/mcp/servers/jmrplens/libgen-mcp/badges/score.svg)](https://glama.ai/mcp/servers/jmrplens/libgen-mcp)
-[![smithery badge](https://smithery.ai/badge/jmrp/libgen-mcp)](https://smithery.ai/servers/jmrp/libgen-mcp)
 [![MCP Badge](https://lobehub.com/badge/mcp/jmrplens-libgen-mcp)](https://lobehub.com/mcp/jmrplens-libgen-mcp)
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.jmrplens%2Flibgen-mcp.svg)](https://mcptoplist.com/server/io.github.jmrplens%2Flibgen-mcp)
 [![Hosted endpoint](https://img.shields.io/badge/Hosted-mcp.jmrp.io%2Flibgen-6366f1?style=flat&logo=icloud&logoColor=white)](https://mcp.jmrp.io/)
 
 </p>


### PR DESCRIPTION
## Summary
- Smithery's README badge stopped rendering, so it's replaced with the MCP Toplist listing badge in the same marketplace badge row.

## Test plan
- [x] Visual check of the badge markdown/URLs

https://claude.ai/code/session_013aYyBY8W3acJfk8C4JkpEw

## Summary by Sourcery

Replace the dead Smithery README badge with an MCP Toplist listing badge.

Enhancements:
- Replace the non-rendering Smithery marketplace badge with an MCP Toplist badge in the README.

Documentation:
- Update the README marketplace badge links to point to MCP Toplist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the non-rendering Smithery README badge with the MCP Toplist badge to keep the marketplace badges row functional and accurate. Previously: Smithery badge failed to render; now: MCP Toplist badge renders and links to the project listing; no side effects beyond README display.

- Review: confirm the badge renders and links to https://mcptoplist.com/server/io.github.jmrplens%2Flibgen-mcp (image: https://mcptoplist.com/badge/io.github.jmrplens%2Flibgen-mcp.svg).
- No code/runtime changes; no rollout or migration actions.

<sup>Written for commit 9d1397600b4d4114994ae1606aba119dd5ecd6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

