### PR TITLE
test(server): serve a pre-bound listener instead of reserving a port

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -310,6 +311,28 @@ func newRegisteredServer(cfg *config.Config, httpAddr string) (*mcp.Server, erro
 // still streaming after httpShutdownTimeout are closed outright rather than
 // waited on.
 func serveHTTP(ctx context.Context, server *mcp.Server, httpAddr string, opts transport.Options) error {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", httpAddr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", httpAddr, err)
+	}
+	return serveHTTPOn(ctx, server, ln, opts)
+}
+
+// serveHTTPOn serves the MCP endpoint on a listener the caller has already
+// bound, and closes it on return.
+//
+// The split exists for the tests. Reserving a port by binding it, reading its
+// address and closing it before handing the address on leaves a window in which
+// anything else on the machine can take that port — and with the package's HTTP
+// tests running in parallel, the window is entered often enough to matter: a
+// health probe can even reach a different test's server. Handing over a live
+// listener removes the window by construction rather than narrowing it.
+//
+// Production still calls serveHTTP, which binds and delegates here, so the
+// address a deployment configures is bound exactly as before.
+func serveHTTPOn(ctx context.Context, server *mcp.Server, ln net.Listener, opts transport.Options) error {
+	httpAddr := ln.Addr().String()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return server }, transport.StreamableHTTP(opts))
 	log.Printf("libgen-mcp %s (commit %s) listening on %s (streamable HTTP, stateless=%t, json-response=%t)",
 		buildversion.Current(), commit, httpAddr, opts.Stateless, opts.JSONResponse)
@@ -328,13 +351,12 @@ func serveHTTP(ctx context.Context, server *mcp.Server, httpAddr string, opts tr
 	}
 
 	srv := &http.Server{
-		Addr:              httpAddr,
 		Handler:           newHTTPHandler(mcpHandler, cardJSON),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- srv.ListenAndServe() }()
+	go func() { serveErr <- srv.Serve(ln) }()
 
 	select {
 	case err := <-serveErr:

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -282,17 +282,20 @@ func TestRunManagerError(t *testing.T) {
 // request so the per-request server-getter closure runs, then cancels for a
 // graceful shutdown.
 func TestServeHTTPServesRequests(t *testing.T) {
+	// The listener is handed to serveHTTPOn still bound. Reserving the port and
+	// closing it here would leave a window for anything else on the machine —
+	// including another test in this package — to take it before serveHTTP
+	// rebinds.
 	var lc net.ListenConfig
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("reserve port: %v", err)
 	}
 	addr := ln.Addr().String()
-	_ = ln.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
-	go func() { done <- serveHTTP(ctx, newTestServer(), addr, transport.DefaultOptions()) }()
+	go func() { done <- serveHTTPOn(ctx, newTestServer(), ln, transport.DefaultOptions()) }()
 
 	base := "http://" + addr
 	waitForHealth(t, base)
@@ -331,13 +334,16 @@ func TestServeHTTPServesRequests(t *testing.T) {
 // deadline. serveHTTP must still come back clean, having cut the stream, rather
 // than reporting the deadline as a failure and leaving the listener held.
 func TestServeHTTPClosesStreamsThatOutlastShutdown(t *testing.T) {
+	// The listener is handed to serveHTTPOn still bound. Reserving the port and
+	// closing it here would leave a window for anything else on the machine —
+	// including another test in this package — to take it before serveHTTP
+	// rebinds.
 	var lc net.ListenConfig
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("reserve port: %v", err)
 	}
 	addr := ln.Addr().String()
-	_ = ln.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -345,7 +351,7 @@ func TestServeHTTPClosesStreamsThatOutlastShutdown(t *testing.T) {
 	// default answers GET with 405 and closes every POST stream on reply.
 	opts := transport.DefaultOptions()
 	opts.Stateless = false
-	go func() { done <- serveHTTP(ctx, newTestServer(), addr, opts) }()
+	go func() { done <- serveHTTPOn(ctx, newTestServer(), ln, opts) }()
 
 	base := "http://" + addr
 	waitForHealth(t, base)


### PR DESCRIPTION
## Summary

Two HTTP tests in `cmd/server` reserved a port the way it is usually done and the
way that is usually wrong: bind an ephemeral port, read its address, close it,
then hand the address to `serveHTTP` so it can bind again.

Between the close and the rebind, anything on the machine can take that port —
including the other test in this package, since they run in parallel. When that
happens the health probe reaches a different test's server and the failure looks
like anything except a port race.

`serveHTTPOn` takes a listener the caller has already bound and closes it on
return. `serveHTTP` binds and delegates to it, so a deployment binds the address
it configured exactly as before. The window is removed by construction rather
than narrowed.

Borrowed from jmrplens/gitlab-mcp-server#297, which fixed the same pattern.

### What from that PR does *not* apply here, and why

Both were checked rather than assumed:

- **Empty address falling through to `:http`.** No test in this package passes an
  empty address, so nothing reaches port 80.
- **Deferring the server card.** There it gated readiness for tens of seconds
  behind a ~850-tool catalog. Measured here against this four-tool surface:
  **3.3 ms**. Deferring it would add a `sync.OnceValues` and a lazily-populated
  endpoint to buy nothing.

The graceful shutdown budget is also left at 5s: nothing here has been observed
exceeding it, and `TestServeHTTPClosesStreamsThatOutlastShutdown` deliberately
runs it out, so raising it would only make that test slower.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / maintenance
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [ ] Docs updated if behavior changed

No documentation change: `serveHTTP` keeps its signature and its behaviour, and
`serveHTTPOn` is unexported.

Also verified with `make validate-http-stateless`, which drives a real server
over the wire — CLAUDE.md asks for it after touching the HTTP wiring in
`cmd/server` — and with `go test -race -count=2 ./cmd/server/`.

## Summary by Sourcery

Eliminate port-rebinding races in HTTP server tests by serving directly on pre-bound listeners.

Enhancements:
- Refactor HTTP serving to support handing an already-bound listener directly to the server, eliminating test port-rebinding races while preserving production behavior.

Tests:
- Update parallel HTTP server tests to pass live listeners directly and avoid reserving and reopening ephemeral ports.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Refactored HTTP server startup to accept a pre-bound net.Listener, preventing port race conditions in parallel tests.</li>
<li>Updated server startup logic to use srv.Serve(ln) instead of srv.ListenAndServe().</li>
<li>Updated SHA256 checksums for all platform-specific binaries in server.json.</li>
</ul></div>