### PR TITLE
build(icons): pin the icon renderer, and point llms.txt at the documentation domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,11 +154,33 @@ MIME allowlist does exactly that). To add one:
    at startup rather than shipping a broken icon.
 3. Run `make gen-icon-webp` and commit the generated `.webp` files.
 
-The generator needs `rsvg-convert` (librsvg) and `cwebp` (libwebp) on `PATH`
-(`brew install librsvg webp`). It is **maintainer-only and not a CI gate** — the
-assets are committed, so ordinary builds and CI never need those tools.
-`make check-icon-webp` verifies the committed assets still match `icons.go`; run
-it by hand after touching an icon, since nothing in CI will.
+The generator needs `cwebp` (libwebp) and `rsvg-convert` on `PATH`, and the
+**librsvg version is part of the requirement, not a detail**: the assets are
+compared byte for byte, and librsvg's stroke antialiasing changed between 2.54
+and 2.58. Debian 12's 2.54.7 disagrees with the committed assets on three of the
+nine icons — the three drawn with rounded caps and joins on diagonals — while
+2.58.0 (Ubuntu 24.04) and 2.60.0 (Debian 13) each reproduce all eighteen files
+exactly, across two different `cwebp` releases. `minLibrsvg` in
+`cmd/gen_icon_webp` holds that floor; the Makefile does not restate it.
+
+So `make gen-icon-webp` and `make check-icon-webp` do not assume the local
+librsvg is usable. They ask the tool (`--probe`), run natively when it can
+reproduce the bytes, and otherwise fall back to a pinned container
+(`ICON_IMAGE`, tagged from `go.mod` so it cannot drift behind the toolchain).
+Either way every machine emits identical assets, which is the point — pinning
+the renderer beats chasing each host's version.
+
+The guard covers **generating**, not just verifying: run under an old librsvg
+the generator would not fail, it would rewrite all eighteen files in its own
+dialect and the divergence would be committed. For the same reason, never
+"fix" a failing check by regenerating on a machine below the floor — that pins
+the assets to the one renderer that does not agree.
+
+It is **maintainer-only and not a CI gate** — the assets are committed, so
+ordinary builds never invoke it, and no workflow installs librsvg or cwebp,
+which is why `TestRun_CheckModeAcceptsCommittedAssets` skips in CI. It skips on
+a below-floor machine too, so `go test ./...` stays green there; the real
+verification is `make check-icon-webp`, by hand after touching an icon.
 
 **Look at the rendered result before committing.** A hand-written SVG path that
 parses is not necessarily a shape that reads at 16×16, and the tests can only

--- a/Makefile
+++ b/Makefile
@@ -202,20 +202,56 @@ gen-tool-schema: ## Regenerate site/src/data/tool-schema.json from the registere
 check-tool-schema: ## Fail if site/src/data/tool-schema.json is stale (CI mode)
 	go run ./cmd/gen_tool_schema/ --check
 
+# The WebP icon assets are compared byte for byte, which makes the renderer's
+# version part of the toolchain rather than an implementation detail: librsvg's
+# stroke antialiasing changed between 2.54 (Debian 12) and 2.58, and the two
+# disagree on three of the nine icons. So these targets do not assume the local
+# librsvg is usable — they ask the tool itself, via --probe, and fall back to a
+# pinned image when it is not, so every machine emits identical bytes.
+#
+# The threshold is deliberately NOT restated here; it lives beside the
+# comparison it governs, in cmd/gen_icon_webp (minLibrsvg).
+#
+# The tag follows go.mod so the image cannot drift behind the toolchain the
+# repository actually builds with. Override to move it: make ICON_IMAGE=...
+ICON_IMAGE ?= golang:$(shell sed -n 's/^go \([0-9]*\.[0-9]*\).*/\1/p' go.mod)-trixie
+
+# The one path restated from the Go side (outDir): the container writes as
+# root, so a non-root host would otherwise be left with root-owned assets.
+ICON_WEBP_DIR := internal/toolutil/icons/webp
+
+# run-icon-tool runs gen_icon_webp with $(1), locally when this machine can
+# reproduce the committed bytes and in $(ICON_IMAGE) when it cannot. The final
+# branch re-runs --probe for one reason only: to let it print its own diagnosis
+# rather than restating it in a second voice that could drift.
+define run-icon-tool
+@if go run ./cmd/gen_icon_webp/ --probe 2>/dev/null; then \
+	go run ./cmd/gen_icon_webp/ $(1); \
+elif command -v docker >/dev/null 2>&1; then \
+	echo "local librsvg cannot reproduce the committed assets; running in $(ICON_IMAGE)"; \
+	MODCACHE="$$(go env GOMODCACHE)"; MOUNT=""; \
+	[ -d "$$MODCACHE" ] && MOUNT="-v $$MODCACHE:/go/pkg/mod"; \
+	docker run --rm $$MOUNT -v "$(CURDIR)":/src -w /src -e DEBIAN_FRONTEND=noninteractive $(ICON_IMAGE) sh -c \
+		"apt-get update -qq >/dev/null && apt-get install -y -qq librsvg2-bin webp >/dev/null && go run ./cmd/gen_icon_webp/ $(1)" \
+		&& chown -R "$$(id -u):$$(id -g)" "$(ICON_WEBP_DIR)"; \
+else \
+	echo "make: no librsvg that can reproduce the committed assets, and no docker to fall back to" >&2; \
+	go run ./cmd/gen_icon_webp/ --probe; \
+fi
+endef
+
 ## gen-icon-webp: regenerate the light/dark WebP fallbacks for every icon in
-## internal/toolutil/icons.go. Maintainer-only: needs rsvg-convert (librsvg)
-## and cwebp (libwebp) on PATH — `brew install librsvg webp`, or the
-## equivalent apt/dnf packages. Deliberately NOT a CI gate: the generated
-## .webp files under internal/toolutil/icons/webp/ are committed, so ordinary
-## builds never invoke this and CI never needs those tools installed. Run it
-## after adding or editing an icon.
+## internal/toolutil/icons.go. Maintainer-only, and deliberately NOT a CI gate:
+## the generated .webp files under internal/toolutil/icons/webp/ are committed,
+## so ordinary builds never invoke this. Needs either a librsvg >= 2.58 and
+## cwebp on PATH, or docker. Run it after adding or editing an icon.
 gen-icon-webp:
-	go run ./cmd/gen_icon_webp/
+	$(call run-icon-tool,)
 
 ## check-icon-webp: verify the committed WebP icon assets still match
-## icons.go. Same external-tool requirement as gen-icon-webp.
+## icons.go. Same toolchain requirement as gen-icon-webp.
 check-icon-webp:
-	go run ./cmd/gen_icon_webp/ --check
+	$(call run-icon-tool,--check)
 
 eval-pages: ## Regenerate the evaluator results pages (pass DOC=path to also refresh the run table)
 	go run ./cmd/gen_eval_pages/ $(if $(DOC),--results-doc $(DOC))

--- a/cmd/gen_icon_webp/main.go
+++ b/cmd/gen_icon_webp/main.go
@@ -47,6 +47,12 @@ const (
 
 	colorLight = "#1A1A1A" // near-black, for Icon.Theme "light" (light background)
 	colorDark  = "#FAFAFA" // near-white, for Icon.Theme "dark" (dark background)
+
+	// The two external tools, named once. Each is looked up three times over
+	// (the PATH check, the version probe and the render itself), and they are
+	// resolved by exec.LookPath rather than invoked by bare name.
+	toolRsvg  = "rsvg-convert"
+	toolCwebp = "cwebp"
 )
 
 // iconSource is one svg<Name> constant extracted from icons.go.
@@ -213,7 +219,7 @@ func rasterize(svg, color string) ([]byte, error) {
 	colored := strings.ReplaceAll(svg, "currentColor", color)
 	ctx := context.Background()
 
-	rsvgPath, err := exec.LookPath("rsvg-convert")
+	rsvgPath, err := exec.LookPath(toolRsvg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +233,7 @@ func rasterize(svg, color string) ([]byte, error) {
 		return nil, fmt.Errorf("rsvg-convert: %w: %s", runErr, rsvgErr.String())
 	}
 
-	cwebpPath, err := exec.LookPath("cwebp")
+	cwebpPath, err := exec.LookPath(toolCwebp)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +383,7 @@ func olderThan(a, b [3]int) bool {
 
 // librsvgVersion reports the release of the rsvg-convert found on PATH.
 func librsvgVersion() ([3]int, error) {
-	path, err := exec.LookPath("rsvg-convert")
+	path, err := exec.LookPath(toolRsvg)
 	if err != nil {
 		return [3]int{}, err
 	}
@@ -397,7 +403,7 @@ func librsvgVersion() ([3]int, error) {
 // eighteen files in its own dialect and the divergence would be committed.
 // So generating is guarded as well as verifying.
 func requireRenderer() error {
-	if err := requireTools("rsvg-convert", "cwebp"); err != nil {
+	if err := requireTools(toolRsvg, toolCwebp); err != nil {
 		return err
 	}
 	v, err := librsvgVersion()

--- a/cmd/gen_icon_webp/main.go
+++ b/cmd/gen_icon_webp/main.go
@@ -9,7 +9,9 @@
 //	<name>-light.webp — near-black glyph (#1A1A1A), for Icon.Theme "light"
 //	<name>-dark.webp  — near-white glyph (#FAFAFA), for Icon.Theme "dark"
 //
-// It requires rsvg-convert (librsvg) and cwebp (libwebp) on PATH. This is a
+// It requires cwebp (libwebp) and a librsvg at least [minLibrsvg] on PATH,
+// because the assets are compared byte for byte and older renderers draw
+// them differently. This is a
 // maintainer-only, occasional regeneration step: the generated .webp files
 // are committed to the repository, so ordinary builds and CI never invoke
 // this tool. Run it after adding or editing an icon in icons.go.
@@ -31,6 +33,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -73,10 +76,14 @@ type rasterizer func(svg, color string) ([]byte, error)
 
 func main() {
 	check := flag.Bool("check", false, "verify the committed WebP assets match icons.go without writing them")
+	probe := flag.Bool("probe", false, "report whether the local toolchain can reproduce the committed assets, then exit")
 	flag.Parse()
 
-	if err := requireTools("rsvg-convert", "cwebp"); err != nil {
+	if err := requireRenderer(); err != nil {
 		fatal(err)
+	}
+	if *probe {
+		return
 	}
 	if err := run(*check, rasterize); err != nil {
 		fatal(err)
@@ -314,6 +321,96 @@ func iconFileName(s string) string {
 	}, s))
 }
 
+// minLibrsvg is the oldest librsvg release measured to rasterize icons.go
+// into the committed WebP bytes exactly.
+//
+// The renderer's stroke antialiasing changed between 2.54 and 2.58. Debian
+// 12's 2.54.7 and Ubuntu 22.04's 2.52.5 each disagree with the committed
+// assets on three of the nine icons — the three drawn with rounded caps and
+// joins on diagonals — while Ubuntu 24.04's 2.58.0 and Debian 13's 2.60.0
+// reproduce all eighteen files byte for byte, across two different cwebp
+// releases. So 2.58.0 is the lowest version measured to agree, not the
+// release the behavior changed in: 2.55 through 2.57 were never tested and
+// are refused rather than assumed.
+var minLibrsvg = [3]int{2, 58, 0}
+
+// librsvgVersionRE matches the release number in rsvg-convert's --version
+// banner ("rsvg-convert version 2.54.7"). The patch component is optional
+// because some distribution builds print only major.minor.
+var librsvgVersionRE = regexp.MustCompile(`(\d+)\.(\d+)(?:\.(\d+))?`)
+
+// parseLibrsvgVersion extracts the release triple from rsvg-convert's
+// --version output. An absent patch component reads as zero.
+func parseLibrsvgVersion(out string) ([3]int, error) {
+	m := librsvgVersionRE.FindStringSubmatch(out)
+	if m == nil {
+		return [3]int{}, fmt.Errorf("no version number in rsvg-convert output %q", strings.TrimSpace(out))
+	}
+	var v [3]int
+	for i := range v {
+		if m[i+1] == "" {
+			continue
+		}
+		n, err := strconv.Atoi(m[i+1])
+		if err != nil {
+			return [3]int{}, fmt.Errorf("parse librsvg version %q: %w", m[0], err)
+		}
+		v[i] = n
+	}
+	return v, nil
+}
+
+// formatVersion renders a release triple as "major.minor.patch".
+func formatVersion(v [3]int) string {
+	return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2])
+}
+
+// olderThan reports whether release a precedes release b.
+func olderThan(a, b [3]int) bool {
+	for i := range a {
+		if a[i] != b[i] {
+			return a[i] < b[i]
+		}
+	}
+	return false
+}
+
+// librsvgVersion reports the release of the rsvg-convert found on PATH.
+func librsvgVersion() ([3]int, error) {
+	path, err := exec.LookPath("rsvg-convert")
+	if err != nil {
+		return [3]int{}, err
+	}
+	out, err := exec.CommandContext(context.Background(), path, "--version").Output()
+	if err != nil {
+		return [3]int{}, fmt.Errorf("rsvg-convert --version: %w", err)
+	}
+	return parseLibrsvgVersion(string(out))
+}
+
+// requireRenderer reports whether this machine can reproduce the committed
+// assets: both tools on PATH, and librsvg at least [minLibrsvg].
+//
+// The version is part of the requirement because the assets are compared
+// byte for byte. An older librsvg does not merely fail --check with a
+// misleading "stale assets" report; run without --check it would rewrite all
+// eighteen files in its own dialect and the divergence would be committed.
+// So generating is guarded as well as verifying.
+func requireRenderer() error {
+	if err := requireTools("rsvg-convert", "cwebp"); err != nil {
+		return err
+	}
+	v, err := librsvgVersion()
+	if err != nil {
+		return err
+	}
+	if olderThan(v, minLibrsvg) {
+		return fmt.Errorf("librsvg %s renders these icons differently and cannot reproduce the committed assets (need >= %s); `make gen-icon-webp` and `make check-icon-webp` fall back to a pinned container when it is too old",
+			formatVersion(v), formatVersion(minLibrsvg))
+	}
+	return nil
+}
+
 // requireTools reports an actionable error naming every tool in names that
 // is missing from PATH, or nil if all are present.
 func requireTools(names ...string) error {
@@ -324,7 +421,7 @@ func requireTools(names ...string) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("required tool(s) not found on PATH: %s (install librsvg and libwebp, e.g. `brew install librsvg webp`)", strings.Join(missing, ", "))
+		return fmt.Errorf("required tool(s) not found on PATH: %s (install librsvg >= %s and libwebp — `apt install librsvg2-bin webp` or `brew install librsvg webp` — or run `make check-icon-webp`, which falls back to a pinned container)", strings.Join(missing, ", "), formatVersion(minLibrsvg))
 	}
 	return nil
 }

--- a/cmd/gen_icon_webp/main_test.go
+++ b/cmd/gen_icon_webp/main_test.go
@@ -519,15 +519,107 @@ func TestRasterize_InvalidSVGFailsAtRsvgConvert(t *testing.T) {
 // TestRun_CheckModeAcceptsCommittedAssets verifies the real, committed WebP
 // assets under internal/toolutil/icons/webp/ still match icons.go, using the
 // real rasterize (rsvg-convert + cwebp) rather than a fake. This is the same
-// gate `make check-icon-webp` and CI would run if those tools were
-// installed; it is skipped here because they are a maintainer-only,
-// non-CI dependency (see the package doc comment).
+// gate `make check-icon-webp` runs; it is skipped when the machine cannot
+// reproduce the committed bytes, which covers both a missing tool (the
+// maintainer-only, non-CI dependency described in the package doc) and a
+// librsvg older than minLibrsvg.
+//
+// The version half of that guard matters as much as the missing-tool half:
+// Debian 12 ships librsvg 2.54.7, which renders three of the nine icons
+// differently, and without the guard this test reports the committed assets
+// as stale on every such machine — a failure about the renderer disguised as
+// a failure about the assets.
 func TestRun_CheckModeAcceptsCommittedAssets(t *testing.T) {
-	if err := requireTools("rsvg-convert", "cwebp"); err != nil {
+	if err := requireRenderer(); err != nil {
 		t.Skip("skipping: " + err.Error())
 	}
 
 	if err := run(true, rasterize); err != nil {
 		t.Fatalf("run(true) error: %v", err)
+	}
+}
+
+// TestParseLibrsvgVersion covers the banner rsvg-convert actually prints, the
+// major.minor-only form some distribution builds print, and output carrying
+// no version at all.
+func TestParseLibrsvgVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want [3]int
+		bad  bool
+	}{
+		{name: "debian 12 banner", out: "rsvg-convert version 2.54.7\n", want: [3]int{2, 54, 7}},
+		{name: "debian 13 banner", out: "rsvg-convert version 2.60.0\n", want: [3]int{2, 60, 0}},
+		{name: "major minor only", out: "rsvg-convert version 2.58\n", want: [3]int{2, 58, 0}},
+		{name: "no version", out: "rsvg-convert: command not understood\n", bad: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLibrsvgVersion(tc.out)
+			if tc.bad {
+				if err == nil {
+					t.Fatalf("parseLibrsvgVersion(%q) error = nil, want an error", tc.out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseLibrsvgVersion(%q) error: %v", tc.out, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseLibrsvgVersion(%q) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOlderThan pins the comparison against the versions that decided
+// minLibrsvg, including that the floor itself is not older than itself.
+func TestOlderThan(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b [3]int
+		want bool
+	}{
+		{name: "ubuntu 22.04 below floor", a: [3]int{2, 52, 5}, b: minLibrsvg, want: true},
+		{name: "debian 12 below floor", a: [3]int{2, 54, 7}, b: minLibrsvg, want: true},
+		{name: "floor itself", a: minLibrsvg, b: minLibrsvg, want: false},
+		{name: "ubuntu 24.04 at floor", a: [3]int{2, 58, 0}, b: minLibrsvg, want: false},
+		{name: "debian 13 above floor", a: [3]int{2, 60, 0}, b: minLibrsvg, want: false},
+		{name: "patch decides", a: [3]int{2, 58, 0}, b: [3]int{2, 58, 1}, want: true},
+		{name: "major outranks minor", a: [3]int{3, 0, 0}, b: [3]int{2, 99, 99}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := olderThan(tc.a, tc.b); got != tc.want {
+				t.Errorf("olderThan(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFormatVersion checks the rendering used in requireRenderer's message,
+// which is the only place a user sees these triples.
+func TestFormatVersion(t *testing.T) {
+	if got, want := formatVersion([3]int{2, 58, 0}), "2.58.0"; got != want {
+		t.Errorf("formatVersion = %q, want %q", got, want)
+	}
+}
+
+// TestRequireRenderer_AgreesWithTheRealToolchain asserts requireRenderer's
+// verdict matches what the machine can actually do, rather than trusting it:
+// when it reports the toolchain usable, the committed assets must verify, and
+// when it refuses, the reason must name either a missing tool or the version.
+func TestRequireRenderer_AgreesWithTheRealToolchain(t *testing.T) {
+	err := requireRenderer()
+	if err == nil {
+		if runErr := run(true, rasterize); runErr != nil {
+			t.Fatalf("requireRenderer() = nil but run(true) failed: %v", runErr)
+		}
+		return
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "not found on PATH") && !strings.Contains(msg, "librsvg") {
+		t.Errorf("requireRenderer() error %q names neither a missing tool nor librsvg", msg)
 	}
 }

--- a/cmd/gen_llms/main.go
+++ b/cmd/gen_llms/main.go
@@ -49,8 +49,14 @@ const (
 	llmsFullFileName      = "llms-full.txt"
 	llmsSummaryItemFormat = "- %s: %s\n"
 	llmsBoldTitleFormat   = "**%s**\n\n"
-	docsSiteURL           = "https://jmrplens.github.io/libgen-mcp/"
-	repoBlobURL           = "https://github.com/jmrplens/libgen-mcp/blob/main/"
+	// The personal domain, not the Pages host it 301s to, matching the repo
+	// homepage, server.json and the rest of the repository markdown. These
+	// files are the surface a model is pointed at from outside the site, so
+	// they carry the durable address; the site's own canonical URLs and
+	// JSON-LD @ids stay on the deployment host, since a canonical that
+	// redirects away contradicts itself.
+	docsSiteURL = "https://jmrp.io/docs/libgen-mcp/"
+	repoBlobURL = "https://github.com/jmrplens/libgen-mcp/blob/main/"
 )
 
 func main() {

--- a/llms.txt
+++ b/llms.txt
@@ -77,33 +77,33 @@ Prompts (guided workflows a client can offer by name):
 
 ## Documentation
 
-- [Getting started](https://jmrplens.github.io/libgen-mcp/getting-started/): Installation and first-run guide
-- [Configuration](https://jmrplens.github.io/libgen-mcp/configuration/): Full environment-variable configuration reference
-- [Tools](https://jmrplens.github.io/libgen-mcp/tools/): Per-tool reference for search, get_details, download, read
-- [Architecture](https://jmrplens.github.io/libgen-mcp/architecture/): Internal architecture, mirror discovery and download sources
-- [Download sources](https://jmrplens.github.io/libgen-mcp/sources/): Per-source reference for every download source: corpus, resolve mechanics, measured traps, and keys
-- [How search works](https://jmrplens.github.io/libgen-mcp/how-search-works/): Catalog-first search, and when and how it escalates to the extra sources
-- [LLM eval results](https://jmrplens.github.io/libgen-mcp/eval-results/): Results of driving a real model over MCP against the live site, scenario by scenario
-- [Troubleshooting](https://jmrplens.github.io/libgen-mcp/troubleshooting/): Common setup and runtime issues
-- [Responsible use](https://jmrplens.github.io/libgen-mcp/responsible-use/): Why the open-access providers are tried first, and what the server refuses to serve
-- [Privacy policy](https://jmrplens.github.io/libgen-mcp/privacy/): No telemetry; requests go only to the Library Genesis mirrors and the search and download sources a call invokes
+- [Getting started](https://jmrp.io/docs/libgen-mcp/getting-started/): Installation and first-run guide
+- [Configuration](https://jmrp.io/docs/libgen-mcp/configuration/): Full environment-variable configuration reference
+- [Tools](https://jmrp.io/docs/libgen-mcp/tools/): Per-tool reference for search, get_details, download, read
+- [Architecture](https://jmrp.io/docs/libgen-mcp/architecture/): Internal architecture, mirror discovery and download sources
+- [Download sources](https://jmrp.io/docs/libgen-mcp/sources/): Per-source reference for every download source: corpus, resolve mechanics, measured traps, and keys
+- [How search works](https://jmrp.io/docs/libgen-mcp/how-search-works/): Catalog-first search, and when and how it escalates to the extra sources
+- [LLM eval results](https://jmrp.io/docs/libgen-mcp/eval-results/): Results of driving a real model over MCP against the live site, scenario by scenario
+- [Troubleshooting](https://jmrp.io/docs/libgen-mcp/troubleshooting/): Common setup and runtime issues
+- [Responsible use](https://jmrp.io/docs/libgen-mcp/responsible-use/): Why the open-access providers are tried first, and what the server refuses to serve
+- [Privacy policy](https://jmrp.io/docs/libgen-mcp/privacy/): No telemetry; requests go only to the Library Genesis mirrors and the search and download sources a call invokes
 - [Security policy](https://github.com/jmrplens/libgen-mcp/blob/main/SECURITY.md): Threat model and how to report a vulnerability privately
 - [Headless install](https://github.com/jmrplens/libgen-mcp/blob/main/llms-install.md): Machine-readable install guide for AI assistants
 
 ## Documentación (Español)
 
-- [Primeros pasos](https://jmrplens.github.io/libgen-mcp/es/getting-started/): Guía de instalación y primera ejecución
-- [Configuración](https://jmrplens.github.io/libgen-mcp/es/configuration/): Referencia completa de configuración por variables de entorno
-- [Herramientas](https://jmrplens.github.io/libgen-mcp/es/tools/): Referencia por herramienta de search, get_details, download, read
-- [Arquitectura](https://jmrplens.github.io/libgen-mcp/es/architecture/): Arquitectura interna, descubrimiento de mirrors y fuentes de descarga
-- [Fuentes de descarga](https://jmrplens.github.io/libgen-mcp/es/sources/): Referencia por fuente de cada fuente de descarga: corpus, mecánica de resolución, trampas medidas y claves
-- [Cómo funciona la búsqueda](https://jmrplens.github.io/libgen-mcp/es/how-search-works/): Búsqueda con el catálogo primero, y cuándo y cómo escala a las fuentes extra
-- [Resultados de la evaluación con LLM](https://jmrplens.github.io/libgen-mcp/es/eval-results/): Resultados de conducir un modelo real sobre MCP contra el sitio en vivo, escenario a escenario
-- [Solución de problemas](https://jmrplens.github.io/libgen-mcp/es/troubleshooting/): Problemas habituales de configuración y ejecución
-- [Uso responsable](https://jmrplens.github.io/libgen-mcp/es/responsible-use/): Por qué se prueban primero los proveedores de acceso abierto, y qué se niega a servir el servidor
-- [Política de privacidad](https://jmrplens.github.io/libgen-mcp/es/privacy/): Sin telemetría; las peticiones van solo a los mirrors de Library Genesis y a las fuentes que invoca cada llamada
+- [Primeros pasos](https://jmrp.io/docs/libgen-mcp/es/getting-started/): Guía de instalación y primera ejecución
+- [Configuración](https://jmrp.io/docs/libgen-mcp/es/configuration/): Referencia completa de configuración por variables de entorno
+- [Herramientas](https://jmrp.io/docs/libgen-mcp/es/tools/): Referencia por herramienta de search, get_details, download, read
+- [Arquitectura](https://jmrp.io/docs/libgen-mcp/es/architecture/): Arquitectura interna, descubrimiento de mirrors y fuentes de descarga
+- [Fuentes de descarga](https://jmrp.io/docs/libgen-mcp/es/sources/): Referencia por fuente de cada fuente de descarga: corpus, mecánica de resolución, trampas medidas y claves
+- [Cómo funciona la búsqueda](https://jmrp.io/docs/libgen-mcp/es/how-search-works/): Búsqueda con el catálogo primero, y cuándo y cómo escala a las fuentes extra
+- [Resultados de la evaluación con LLM](https://jmrp.io/docs/libgen-mcp/es/eval-results/): Resultados de conducir un modelo real sobre MCP contra el sitio en vivo, escenario a escenario
+- [Solución de problemas](https://jmrp.io/docs/libgen-mcp/es/troubleshooting/): Problemas habituales de configuración y ejecución
+- [Uso responsable](https://jmrp.io/docs/libgen-mcp/es/responsible-use/): Por qué se prueban primero los proveedores de acceso abierto, y qué se niega a servir el servidor
+- [Política de privacidad](https://jmrp.io/docs/libgen-mcp/es/privacy/): Sin telemetría; las peticiones van solo a los mirrors de Library Genesis y a las fuentes que invoca cada llamada
 
 ## Optional
 
-- [Full LLM reference](https://jmrplens.github.io/libgen-mcp/llms-full.txt): Generated companion reference with full tool schemas
-- [Documentation site](https://jmrplens.github.io/libgen-mcp/): Rendered documentation site
+- [Full LLM reference](https://jmrp.io/docs/libgen-mcp/llms-full.txt): Generated companion reference with full tool schemas
+- [Documentation site](https://jmrp.io/docs/libgen-mcp/): Rendered documentation site


### PR DESCRIPTION
## Summary

Two independent changes to how this repository addresses things: which renderer
produces the icon assets, and which host the generated LLM index points at.

### The icon gate

The WebP icon assets are compared byte for byte, which quietly makes librsvg's
version part of the toolchain rather than an implementation detail. Measured
with the real pipeline:

| distro | librsvg | cwebp | reproduces the committed assets |
| --- | --- | --- | --- |
| Ubuntu 22.04 | 2.52.5 | 1.2.2 | 0/6 |
| Debian 12 | 2.54.7 | 1.2.4 | 0/6 |
| Ubuntu 24.04 | 2.58.0 | 1.3.2 | 6/6 |
| Debian 13 | 2.60.0 | 1.5.0 | 6/6 |

Two different librsvg releases *and* two different cwebp releases agree; the
outlier is specifically Debian 12's 2.54.7, and only on the three icons drawn
with rounded caps and joins on diagonals.

On such a machine the check failed with the wrong diagnosis — "icon webp assets
are stale or missing", naming three assets that were correct. The underlying
difference is **two pixels of 256** (six on `read`), which is how badly a byte
comparison overstates an antialiasing change.

So the tool now knows what it needs: `minLibrsvg` holds the floor, `--probe`
reports whether this machine meets it, and the Makefile targets run natively
when it does and in a pinned image when it does not — tagged from `go.mod` so it
cannot drift behind the toolchain. Every machine emits identical bytes.

The guard covers **generating**, not only verifying. Run under 2.54.7 the
generator would not have failed; it would have rewritten all eighteen files in
its own dialect. Committing that would pin the assets to the one renderer
measured *not* to agree, breaking every machine that currently agrees — so the
tempting fix for a red check is precisely the wrong one.

`TestRun_CheckModeAcceptsCommittedAssets` now skips on a below-floor renderer
exactly as it already did on a missing tool, so `go test ./...` is green on
Debian 12 instead of red about the assets when the subject is the renderer.

### The documentation URL

`llms.txt`'s twenty-two links addressed the Pages host while the repository
markdown, the repo homepage and `server.json` all use `jmrp.io/docs/libgen-mcp`.
These files are the surface a model is handed from outside the site, so they
carry the durable address. The redirect preserves nested routes and files,
verified against the generated set: `/architecture/`, `/es/architecture/`,
`/configuration/` and `/llms-full.txt` each resolve 200 through it.

The site's own canonicals, sitemap and JSON-LD `@id`s stay on the deployment
host. That asymmetry is deliberate: a canonical that redirects away contradicts
itself, while an external pointer that outlives a change of host is what a
durable address is for.

## Verification

All three Makefile branches were exercised rather than reasoned about:

- **native** — `make check-icon-webp` inside Debian 13: runs directly, passes.
- **container fallback** — same target on this Debian 12 host: falls back, passes
  in 54s.
- **neither** — a container with no librsvg and no docker: fails with the
  tool's own diagnosis rather than a second, driftable copy of it.

`make gen-icon-webp` was then run for real through the container: it rewrote all
eighteen files and produced **zero diff**, which is the direct evidence that the
pinned image reproduces the committed assets.

## Type of change

- [x] Bug fix
- [x] Refactor / maintenance
- [x] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [x] Docs updated if behavior changed

`make test` passes on this machine for the first time: the icon test now skips
with a reason instead of failing. `go test -race ./...`, `make cover-check`, the
godoc audit, `markdownlint-cli2`, all six `make check-*` gates,
`make audit-surface-quality` and the site's ten-step chain are green.

## Summary by Sourcery

Ensure WebP icon assets are generated consistently across environments and expose durable documentation URLs in the generated LLM index.

Bug Fixes:
- Prevent icon generation and verification from using librsvg versions that produce incompatible WebP assets.
- Point generated LLM documentation links at the durable documentation domain.

Enhancements:
- Add renderer compatibility probing and version validation for icon tooling.
- Make icon generation and checks fall back to a Go-toolchain-pinned container when the local renderer is unsuitable.
- Allow committed-asset checks to skip with a diagnostic when required tools or renderer versions are unavailable.

Build:
- Update Makefile icon targets to select a compatible native or containerized rendering environment.

Documentation:
- Document the librsvg version requirement, container fallback, and safe icon regeneration workflow.

Tests:
- Add coverage for librsvg version parsing, version comparisons, renderer compatibility, and real-toolchain asset verification.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Implemented a robust toolchain check for WebP icon generation, requiring librsvg >= 2.58.0 to ensure byte-for-byte consistency across environments.</li>
<li>Added a fallback mechanism in the Makefile using a pinned Docker container when the local environment's librsvg version is insufficient.</li>
<li>Updated the icon generation tool to include a --probe mode for diagnosing toolchain compatibility.</li>
<li>Updated the documentation site URL in the LLM generator to use the canonical domain.</li>
<li>Added comprehensive unit tests for version parsing and toolchain compatibility checks.</li>
</ul></div>