### PR TITLE
fix(lobehub): update the existing listing instead of publishing it anew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ publish-lobehub:
 	fi
 	@$(MAKE) --no-print-directory check-lhm-manifest
 	@VER=$$(tr -d '[:space:]' < VERSION); \
-	echo "Publishing jmrplens-libgen-mcp v$$VER to LobeHub..."; \
-	npx -y @lobehub/market-cli plugin publish --dir "$(CURDIR)"
+	echo "Updating jmrplens-libgen-mcp to v$$VER on LobeHub..."; \
+	npx -y @lobehub/market-cli plugin update --dir "$(CURDIR)"
 
 sonar: ## Run the SonarCloud scanner locally (needs sonar-scanner + SONAR_TOKEN)
 	@command -v sonar-scanner >/dev/null || { echo "sonar-scanner not installed"; exit 1; }


### PR DESCRIPTION
## Summary

`make publish-lobehub` could not publish. Two things had changed under it since
v1.5.1 was published on 2026-08-02, and the second only surfaced once the first
was fixed:

1. `lhm plugin publish` grew a positional repository argument, so the target
   died with `missing required argument 'gitUrl'` before reaching the network.
2. With that satisfied, the marketplace refused the call outright:

   ```
   Plugin "jmrplens-libgen-mcp" is already published;
   use lhm plugin update for version "1.6.6"
   ```

The CLI has split the two verbs: `publish` creates a listing from a repository,
`update` reads `lhm.plugin.json` and pushes a new version of one that already
exists. Ours has existed since well before v1.5.1, so the verb is `update` — and
it takes nothing but `--dir`, which is why the repository-URL derivation this
branch first added is gone again rather than kept.

## Verification

Run for real, not reasoned about: the listing moved **1.6.4 → 1.6.6**, and the
public API now reports `1.6.6` with 4 tools and 4 prompts, so the capability
badges resolve.

That jump is worth noting on its own: the listing was on **1.6.4**, so **v1.6.5
never reached LobeHub**. The manual step had been outstanding for more than one
release, which is the failure mode of a publish that lives outside the tagged
release and reports nothing when it does not happen.

## Notes

Authentication needed no browser in the end. The stored credential's access
token had expired, but it carries a refresh token and the CLI refreshed it on
its own (`✓ Authenticated as …`). Worth recording, because `lhm auth status`
reports a plainly expired token and reads as a dead end when it is not.

Two traps for whoever hits this next:

- `lh` and `lhm` are different products and **both** are installed here. `lh`
  (`@lobehub/cli`) manages the personal account — its `plugin` subcommands are
  install/uninstall/list — and has its own valid session in `~/.lobehub/`.
  Marketplace publishing is only `lhm` (`@lobehub/market-cli`), whose session
  lives in `~/.lobehub-market/`. `lh whoami` succeeding says nothing about
  whether `lhm` is authenticated.
- The credential arrived world-readable (0644) and is now 0600.

## Type of change

- [x] Bug fix
- [x] CI / tooling

## Checklist

- [ ] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [ ] Tests added or updated for the change
- [x] Docs updated if behavior changed

`make test` and tests are unticked because this changes one Makefile recipe and
nothing in Go; the repository has no harness for Makefile recipes, and the
recipe was instead verified by running it against the live marketplace.
