### PR TITLE
feat(npm): publish the server on npm as @jmrp.io/libgen-mcp

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: release
-description: Cut a libgen-mcp release — bump VERSION, mirror it into the four JSON manifests, regenerate llms.txt, tag, and publish to LobeHub. Use when cutting or preparing a release, bumping the version, or publishing to the MCP registry or LobeHub Marketplace.
+description: Cut a libgen-mcp release — bump VERSION, mirror it into the version-bearing manifests, regenerate llms.txt, tag, and publish to npm and LobeHub. Use when cutting or preparing a release, bumping the version, or publishing to the MCP registry, npm or LobeHub Marketplace.
 ---
 
 # Cutting a libgen-mcp release
 
-The version lives in `VERSION` and is mirrored into four JSON manifests. To cut a
+The version lives in `VERSION` and is mirrored into five manifests. To cut a
 release:
 
 1. Bump `VERSION`.
 2. Update the version in `server.json` (both `.version` and the six release-asset
-   URLs), `mcpb/manifest.json`, `lhm.plugin.json` and `.plugin/plugin.json`.
-3. Run `make check-manifests`. It gates all four against `VERSION`, and CI runs
+   URLs), `mcpb/manifest.json`, `lhm.plugin.json` and `.plugin/plugin.json`, and
+   run `make sync-npm-version` for `npm/libgen-mcp/package.json` (it moves the
+   version and all six dependency pins together — never hand-edit it).
+3. Run `make check-manifests`. It gates all five against `VERSION`, and CI runs
    it in the `server.json` job. Add any new version-bearing manifest to
    `VERSION_MANIFESTS` in the `Makefile` — a file that is not listed there is not
    gated, and will silently ship the previous release's number.
@@ -24,9 +26,9 @@ release:
 The tag is enough for the version-bearing files the workflow owns: on release,
 `scripts/update-server-json-sha.sh` re-stamps `server.json`'s version, its
 per-package versions, its six asset identifiers and their `fileSha256` digests,
-then stamps the version into the other three manifests (`lhm.plugin.json`,
-`mcpb/manifest.json`, `.plugin/plugin.json`) — the same set `check-manifests`
-gates — and commits the result back to main. The manual
+then stamps the version into the other four manifests (`lhm.plugin.json`,
+`mcpb/manifest.json`, `.plugin/plugin.json`, `npm/libgen-mcp/package.json`) — the
+same set `check-manifests` gates — and commits the result back to main. The manual
 bump above exists so the pre-tag CI gates pass, not because the digests need to
 be right — they cannot be until the binaries exist.
 
@@ -41,6 +43,39 @@ yours already publishes the same template.
 
 The `server.json` CI job is named for a required status check in the branch
 ruleset, not for its scope — do not rename it without updating the ruleset too.
+
+## Publishing to npm
+
+npm is part of the tagged release and needs no manual step. After GoReleaser
+writes `dist/`, the release job validates the assembled packages
+(`make validate-npm-local NPM_BINARIES=dist`) and then publishes them with
+`scripts/publish-npm.sh` — the six per-platform packages first, the launcher
+last, so an install racing the publish never finds a launcher pinning packages
+the registry does not have yet.
+
+Authentication is npm's **OIDC trusted publisher**: no stored token, no
+`NODE_AUTH_TOKEN`, and no `--provenance` flag (trusted publishing attaches
+provenance itself). The workflow already grants `id-token: write` at the top
+level, and the publish step installs `npm@11.5.1` first because that is the floor
+version that performs the OIDC exchange. The trusted publisher configured on
+npmjs.com for each of the seven packages names the GitHub account `jmrplens`,
+repository `libgen-mcp`, workflow `release.yml`, and a **blank** environment —
+the release job declares no `environment:`.
+
+Two failure modes worth knowing:
+
+- **Re-running the release job is safe.** `publish-npm.sh` asks `npm view` first
+  and skips any version already on the registry, so a job retried after a later
+  step failed does not die on npm's 409.
+- **A brand-new package 404s on `install` for a few minutes** after its first
+  publish while the registry propagates. Verify with `npm view`, and re-check
+  before concluding the publish failed.
+
+`make publish-npm NPM_BINARIES=<dir>` is the manual fallback (it was the
+bootstrap path, since a package cannot have a trusted publisher until it exists).
+It takes auth from the environment and never sees a credential itself; if it is
+ever needed again, put the token in a temporary `.npmrc` **outside the repo**,
+point npm at it with `NPM_CONFIG_USERCONFIG`, and delete it immediately after.
 
 ## Publishing to the LobeHub Marketplace
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,44 @@ jobs:
           bash scripts/build-mcpb.sh "${VERSION}"
           gh release upload "v${VERSION}" dist/libgen-mcp.mcpb --clobber
 
+      # npm publish via OIDC trusted publisher — no stored token. dist/ already
+      # holds the release binaries under their published names here, the same
+      # spot the .mcpb step above reads from. The workflow's id-token: write
+      # permission lets npm mint the OIDC token; npm >= 11.5.1 performs the
+      # exchange, so setup-node's Node 22 is upgraded first. Provenance is
+      # attached automatically under trusted publishing (no --provenance flag),
+      # and publish-npm.sh skips any version already on the registry, so
+      # re-running this job is safe.
+      #
+      # Bootstrap: a package cannot have a trusted publisher configured until it
+      # exists, so the first release's seven packages are created by a one-time
+      # tokened publish; from the next tag on, this runs with no credential. The
+      # trusted publisher on npmjs.com must name this workflow file
+      # (release.yml); this job declares no `environment:`, so that field stays
+      # blank there.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          registry-url: https://registry.npmjs.org
+
+      # Validate the assembled packages before anything is published. A
+      # published npm version is permanent, so a broken tarball has to fail the
+      # release here rather than after it is irreversibly on the registry. This
+      # runs on the ephemeral runner, which is already disposable; the same
+      # check runs in Docker via `make validate-npm` on a developer's machine.
+      - name: Validate npm packages
+        run: make validate-npm-local NPM_BINARIES=dist VERSION="${GITHUB_REF#refs/tags/v}"
+
+      - name: Publish to npm
+        run: |
+          set -euo pipefail
+          # Pinned, not @latest: this CLI runs `npm publish` under the job's
+          # id-token: write, so a surprising or compromised `latest` could push
+          # altered packages. 11.5.1 is the floor npm trusted publishing
+          # requires; bump it deliberately.
+          npm install -g npm@11.5.1
+          bash scripts/publish-npm.sh dist "${GITHUB_REF#refs/tags/v}"
+
       - name: Pin server.json version and SHA256 hashes
         run: |
           set -euo pipefail
@@ -176,7 +214,7 @@ jobs:
           # Every manifest the script stamps, not just the two it stamped first;
           # `if` rather than `[ -f … ] &&`, whose non-zero status would abort the
           # step under `set -e` the day a manifest is renamed away.
-          for manifest in server.json lhm.plugin.json mcpb/manifest.json .plugin/plugin.json; do
+          for manifest in server.json lhm.plugin.json mcpb/manifest.json .plugin/plugin.json npm/libgen-mcp/package.json; do
             if [ -f "${manifest}" ]; then git add "${manifest}"; fi
           done
           if git diff --cached --quiet; then

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@
 /audit_surface_quality
 /gen_icon_webp
 /dist/
+
+# npm publish set: the six per-platform packages are generated from the release
+# binaries at publish time and each carries a ~20 MB executable. The launcher
+# under /npm/libgen-mcp/ IS committed; everything below is not.
+/npm/packages/
+/npm/**/node_modules/
+/npm/**/*.tgz
+
 coverage.out
 coverage.internal.out
 coverage.html

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,6 +13,9 @@ ignores:
   # regenerated and checked. It is a machine artifact, not prose.
   - cmd/eval/testdata/latest-run.md
   - "**/node_modules/**"
+  # Generated per-platform npm packages: each README is emitted by
+  # scripts/build-npm.mjs at publish time and never committed.
+  - "npm/packages/**"
   - "**/dist/**"
   - "**/.astro/**"
   - docs/superpowers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,7 +440,40 @@ Spanish entry in `scenariosES`, or the generator fails.
 Cutting a release is a multi-step sequence with two gates that catch different
 things and a registry rule that has already broken one publish. It lives in the
 `release` skill (`.claude/skills/release/SKILL.md`) — invoke it when bumping the
-version, tagging, or publishing to the MCP registry or LobeHub.
+version, tagging, or publishing to the MCP registry, npm or LobeHub.
+
+### The npm channel
+
+`npm/libgen-mcp/` is the **committed** launcher package (`@jmrp.io/libgen-mcp`):
+`package.json`, `cli.js` and a README, and nothing else. The six per-platform
+packages that carry the binaries are **generated** from the release assets by
+`scripts/build-npm.mjs` at publish time and are gitignored — `npm/packages/`
+never enters a commit.
+
+Three things about it are easy to get wrong:
+
+- **`cli.js` lives at the package root, not in `bin/`.** The repo's `.gitignore`
+  has a global `bin/` rule, so a launcher under `npm/libgen-mcp/bin/` would be
+  silently untracked and every published tarball would be missing its entry
+  point.
+- **The launcher must never write to stdout.** The server speaks MCP over stdio,
+  so a stray byte there is a corrupted JSON-RPC stream, not a cosmetic wart. It
+  spawns the binary with `stdio: "inherit"`, prints only to stderr, and mirrors
+  the child's exit code and terminating signal. `scripts/validate-npm.mjs` drives
+  a real `initialize` handshake and asserts every stdout line parses as JSON-RPC
+  2.0, so a regression fails `make validate-npm` rather than a user's client.
+- **The version is stamped, not hand-edited.** `build-npm.mjs --sync-only`
+  rewrites the version and all six `optionalDependencies` pins together, which is
+  why `scripts/update-server-json-sha.sh` calls it rather than editing the JSON:
+  a jq edit could move the version and leave the pins a release behind.
+  `npm/libgen-mcp/package.json` is in `VERSION_MANIFESTS`, so `make
+  check-manifests` fails a bump that skipped `make sync-npm-version`.
+
+The scope is the npm **organization** `jmrp.io`, so packages are
+`@jmrp.io/libgen-mcp*`. `npm whoami` returns `jmrpio` (the maintainer's personal
+profile) and `npm org ls jmrp.io` lists `jmrpio` as the owner **member** — neither
+is the scope, and reading either as one publishes to the wrong place. A granular
+token cannot unpublish, so a mis-scoped publish cannot be undone.
 
 ## Commit & PR Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@
         eval-only eval-pages check-eval-pages audit-tokens audit-surface-quality \
         validate-http-stateless \
         install-tools release-check check-manifests \
-        mcpb publish-lobehub sonar clean help \
+        mcpb gen-npm sync-npm-version validate-npm validate-npm-local \
+        publish-npm-dry publish-npm publish-lobehub sonar clean help \
         build-linux-amd64 build-linux-arm64 build-darwin-amd64 \
         build-darwin-arm64 build-windows-amd64 build-windows-arm64
 
@@ -290,8 +291,12 @@ release-check: ## Validate the GoReleaser config
 
 # Every JSON manifest that mirrors the VERSION file. A manifest listed here is
 # gated; one that is not silently ships the previous version's number, which is
-# how .plugin/plugin.json spent a release cycle claiming to be 1.2.0.
-VERSION_MANIFESTS := server.json mcpb/manifest.json lhm.plugin.json .plugin/plugin.json
+# how .plugin/plugin.json spent a release cycle claiming to be 1.2.0. The npm
+# launcher is in the set for the same reason: the release workflow re-stamps it
+# and commits it back, so a bump that skips `make sync-npm-version` would leave
+# main advertising the previous version on npm until the next tag.
+VERSION_MANIFESTS := server.json mcpb/manifest.json lhm.plugin.json .plugin/plugin.json \
+                     npm/libgen-mcp/package.json
 
 check-manifests: ## Verify every version-bearing manifest parses and matches the VERSION file
 	@VF=$$(tr -d '[:space:]' < VERSION); \
@@ -306,6 +311,55 @@ check-manifests: ## Verify every version-bearing manifest parses and matches the
 
 mcpb: ## Build the .mcpb Claude Desktop bundle (needs GoReleaser artifacts in dist/)
 	bash scripts/build-mcpb.sh $(VERSION)
+
+# ─── npm distribution ───────────────────────────────────────────────────────
+# The npm channel is a thin launcher package (@jmrp.io/libgen-mcp) plus six
+# per-platform packages, each carrying one release binary and gated by npm's
+# os/cpu fields so only the matching one is unpacked. Nothing runs at install
+# time, which is what keeps `npx`, `npm ci --ignore-scripts`, offline and
+# proxied installs working — a postinstall that downloads breaks all four, on
+# exactly the locked-down machines an MCP server gets dropped onto.
+#
+# NPM_BINARIES points at a directory holding the release assets under their
+# published names (libgen-mcp-linux-amd64, …) — `dist/` after GoReleaser, or a
+# directory of assets downloaded from a release.
+NPM_BINARIES ?=
+
+gen-npm: ## Assemble the npm distribution from release binaries (NPM_BINARIES=<dir>)
+	@command -v node >/dev/null || { echo "ERROR: Node.js is required"; exit 1; }
+	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
+	node scripts/build-npm.mjs --binaries "$(NPM_BINARIES)" --version "$(VERSION)"
+
+sync-npm-version: ## Stamp VERSION into npm/libgen-mcp/package.json and its six pins
+	@command -v node >/dev/null || { echo "ERROR: Node.js is required"; exit 1; }
+	node scripts/build-npm.mjs --sync-only --version "$(VERSION)"
+
+# Runs in a clean node:22 container so the check never installs anything on the
+# host: structural checks on all seven packages, plus a real install and MCP
+# handshake for the container's native platform (linux-x64).
+validate-npm: ## Build and validate the npm packages in Docker (NPM_BINARIES=<dir>)
+	@command -v docker >/dev/null || { echo "ERROR: Docker is required for isolated validation (or use validate-npm-local)"; exit 1; }
+	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
+	docker run --rm -v "$(CURDIR):/work" -v "$(abspath $(NPM_BINARIES)):/binaries:ro" -w /work node:22 sh -euc 'node scripts/build-npm.mjs --binaries /binaries --version $(VERSION) && node scripts/validate-npm.mjs --packages npm/packages --main npm/libgen-mcp --version $(VERSION)'
+
+# Same validation without Docker, for the ephemeral CI runner — already
+# disposable, and the release job has no Docker-in-Docker to spare.
+validate-npm-local: ## Same validation without Docker, for CI (NPM_BINARIES=<dir>)
+	@command -v node >/dev/null || { echo "ERROR: Node.js is required"; exit 1; }
+	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
+	node scripts/build-npm.mjs --binaries "$(NPM_BINARIES)" --version "$(VERSION)"
+	node scripts/validate-npm.mjs --packages npm/packages --main npm/libgen-mcp --version "$(VERSION)"
+
+publish-npm-dry: ## Assemble and pack the npm publish set without publishing (NPM_BINARIES=<dir>)
+	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
+	scripts/publish-npm.sh "$(NPM_BINARIES)" "$(VERSION)" --dry-run
+
+# Auth is left to the environment (`npm login`, or a temporary .npmrc for the
+# one-time bootstrap). From the first tag after bootstrap on, the release
+# workflow publishes over OIDC and this target is only a fallback.
+publish-npm: ## Publish the npm distribution: platform packages first, then the launcher
+	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
+	scripts/publish-npm.sh "$(NPM_BINARIES)" "$(VERSION)"
 
 ## publish-lobehub: publish the current version to the LobeHub Marketplace.
 ## Reads lhm.plugin.json (version kept in sync by scripts/update-server-json-sha.sh

--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,11 @@ sync-npm-version: ## Stamp VERSION into npm/libgen-mcp/package.json and its six 
 validate-npm: ## Build and validate the npm packages in Docker (NPM_BINARIES=<dir>)
 	@command -v docker >/dev/null || { echo "ERROR: Docker is required for isolated validation (or use validate-npm-local)"; exit 1; }
 	@test -n "$(NPM_BINARIES)" || { echo "ERROR: set NPM_BINARIES=<dir of release binaries>"; exit 1; }
-	docker run --rm -v "$(CURDIR):/work" -v "$(abspath $(NPM_BINARIES)):/binaries:ro" -w /work node:22 sh -euc 'node scripts/build-npm.mjs --binaries /binaries --version $(VERSION) && node scripts/validate-npm.mjs --packages npm/packages --main npm/libgen-mcp --version $(VERSION)'
+	@# --user with a writable HOME: the container writes npm/packages/ and rewrites
+	@# npm/libgen-mcp/package.json through the bind mount, so running as root would
+	@# leave a tracked manifest root-owned on the host. HOME must move with the uid
+	@# or npm has nowhere to put its cache.
+	docker run --rm --user "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/work" -v "$(abspath $(NPM_BINARIES)):/binaries:ro" -w /work node:22 sh -euc 'node scripts/build-npm.mjs --binaries /binaries --version $(VERSION) && node scripts/validate-npm.mjs --packages npm/packages --main npm/libgen-mcp --version $(VERSION)'
 
 # Same validation without Docker, for the ephemeral CI runner — already
 # disposable, and the release job has no Docker-in-Docker to spare.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
 
 [![GitHub Release](https://img.shields.io/github/v/release/jmrplens/libgen-mcp?style=flat&logo=github&label=Release)](https://github.com/jmrplens/libgen-mcp/releases/latest)
+[![npm](https://img.shields.io/npm/v/%40jmrp.io%2Flibgen-mcp?style=flat&logo=npm&label=npm)](https://www.npmjs.com/package/@jmrp.io/libgen-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux%20%7C%20macOS-amd64%20%26%20arm64-lightgrey?style=flat&logo=windows-terminal&logoColor=white)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_libgen-mcp2&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_libgen-mcp2)
@@ -37,9 +38,29 @@ You talk to your AI assistant; it does the searching and fetching. You don't nee
 
 ## Quick start
 
-The lowest-friction path is **Docker — no install, no Go, nothing to manage**. Pick your client below and paste the snippet; each one runs the published image `ghcr.io/jmrplens/libgen-mcp:latest` (auto-pulled on first run — you only need [Docker](https://www.docker.com/) installed). Prefer a native binary? See [Install a native binary](#install-a-native-binary).
+The lowest-friction paths are **`npx` and Docker — no install, no Go, nothing to manage**. If you already have Node, [`npx @jmrp.io/libgen-mcp`](#run-it-with-npx-no-install) is a single command. Otherwise pick your client below and paste the snippet; each one runs the published image `ghcr.io/jmrplens/libgen-mcp:latest` (auto-pulled on first run — you only need [Docker](https://www.docker.com/) installed). Prefer a native binary? See [Install a native binary](#install-a-native-binary).
 
 Then just ask your assistant: _"Search for the Rust book."_
+
+### Run it with `npx` (no install)
+
+The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). The package is a thin launcher over the same prebuilt binaries the releases page serves: npm downloads only the one matching your OS and CPU, nothing is compiled, and no script runs at install time.
+
+```bash
+npx @jmrp.io/libgen-mcp              # run it, no install
+npm install -g @jmrp.io/libgen-mcp   # or install it globally
+pnpm add -g @jmrp.io/libgen-mcp      # …with pnpm
+```
+
+Most MCP clients can launch it this way directly:
+
+```json
+{
+  "mcpServers": {
+    "libgen": { "command": "npx", "args": ["-y", "@jmrp.io/libgen-mcp"] }
+  }
+}
+```
 
 ### Try it without installing anything
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ You talk to your AI assistant; it does the searching and fetching. You don't nee
 
 ## Quick start
 
-The lowest-friction paths are **`npx` and Docker — no install, no Go, nothing to manage**. If you already have Node, [`npx @jmrp.io/libgen-mcp`](#run-it-with-npx-no-install) is a single command. Otherwise pick your client below and paste the snippet; each one runs the published image `ghcr.io/jmrplens/libgen-mcp:latest` (auto-pulled on first run — you only need [Docker](https://www.docker.com/) installed). Prefer a native binary? See [Install a native binary](#install-a-native-binary).
+The lowest-friction paths are **`npx` and Docker — no install, no Go, nothing to manage**. If you already have Node 18 or newer, [`npx @jmrp.io/libgen-mcp`](#run-it-with-npx-no-install) is a single command. Otherwise pick your client below and paste the snippet; each one runs the published image `ghcr.io/jmrplens/libgen-mcp:latest` (auto-pulled on first run — you only need [Docker](https://www.docker.com/) installed). Prefer a native binary? See [Install a native binary](#install-a-native-binary).
 
 Then just ask your assistant: _"Search for the Rust book."_
 
 ### Run it with `npx` (no install)
 
-The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). The package is a thin launcher over the same prebuilt binaries the releases page serves: npm downloads only the one matching your OS and CPU, nothing is compiled, and no script runs at install time.
+The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp) and needs Node 18 or newer. The package is a thin launcher over the same prebuilt binaries the releases page serves: npm downloads only the platform package matching your OS and CPU, nothing is compiled, and no script runs at install time.
 
 ```bash
 npx @jmrp.io/libgen-mcp              # run it, no install

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ open-access and Sci-Hub sources by DOI.
 
 | Page                                    | What it covers                                                                                                                           |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| [Getting started](getting-started.md)   | Install (release binary, Docker, or `go install`), wire the server into an MCP client, and run your first search.                        |
+| [Getting started](getting-started.md)   | Install (npm/npx, release binary, Docker, or `go install`), wire the server into an MCP client, and run your first search.               |
 | [Configuration](configuration.md)       | Every environment variable, with its default, valid range, and meaning.                                                                  |
 | [Tools](tools.md)                       | The `search`, `get_details`, `download`, and `read` tools — inputs, outputs, and error behavior.                                         |
 | [Architecture](architecture.md)         | The HTTP client (mirror discovery, failover, retry/cooldown), the download pipeline, and the multi-source chain.                         |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,21 +5,25 @@ running your first search.
 
 ## Install
 
-`libgen-mcp` installs four ways. If you already have Node, **npm/npx** is the
-shortest path — one command, nothing to place on your `PATH`. Otherwise the
+`libgen-mcp` installs four ways. If you already have Node 18 or newer,
+**npm/npx** is the shortest path — one command, nothing to download by hand.
+Otherwise the
 **prebuilt binary** is a single static executable with nothing else to install:
 no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as
 alternatives if they fit your setup better.
 
-### 1. npm / npx (shortest path if you have Node)
+### 1. npm / npx (shortest path if you have Node 18 or newer)
 
 The server is published to npm as
 [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp).
-That package is a thin launcher over the same prebuilt binaries the releases
-page serves: the binary rides inside a per-platform package that npm installs
-only when its `os`/`cpu` match, so nothing is compiled and no script runs at
-install time — which is what keeps `npx`, `npm ci --ignore-scripts`, offline and
-proxied installs working.
+It needs Node 18 or newer. The package is a thin launcher over the same
+prebuilt binaries the releases page serves: the binary rides inside a
+per-platform package that npm installs only when its `os`/`cpu` match, so
+nothing is compiled and no script runs at install time. Because the binary
+travels inside the package npm downloads anyway, `npx` and
+`npm ci --ignore-scripts` both work, and so does an install served from a
+private registry mirror — or from the local cache with `--offline`, once the
+tarballs are in it.
 
 ```bash
 npx @jmrp.io/libgen-mcp              # run it, no install
@@ -37,6 +41,11 @@ nothing to install or keep updated by hand:
   }
 }
 ```
+
+A global install puts `libgen-mcp` in your package manager's global binary
+directory. If the command is not found afterwards, that directory is not on your
+`PATH` — `npm config get prefix` shows npm's (the binaries are in its `bin`
+subdirectory), and pnpm's is set up by `pnpm setup`.
 
 Prebuilt binaries exist for Linux, macOS and Windows on x64 and arm64. On any
 other platform the launcher exits with a message pointing at the release

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,12 +5,44 @@ running your first search.
 
 ## Install
 
-The recommended way to install `libgen-mcp` is the **prebuilt binary**: a single
-static executable with nothing else to install — no Go toolchain, no Docker, no
-runtime. Docker and `go install` are offered as alternatives if they fit your
-setup better.
+`libgen-mcp` installs four ways. If you already have Node, **npm/npx** is the
+shortest path — one command, nothing to place on your `PATH`. Otherwise the
+**prebuilt binary** is a single static executable with nothing else to install:
+no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as
+alternatives if they fit your setup better.
 
-### 1. Release binary (recommended)
+### 1. npm / npx (shortest path if you have Node)
+
+The server is published to npm as
+[`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp).
+That package is a thin launcher over the same prebuilt binaries the releases
+page serves: the binary rides inside a per-platform package that npm installs
+only when its `os`/`cpu` match, so nothing is compiled and no script runs at
+install time — which is what keeps `npx`, `npm ci --ignore-scripts`, offline and
+proxied installs working.
+
+```bash
+npx @jmrp.io/libgen-mcp              # run it, no install
+npm install -g @jmrp.io/libgen-mcp   # or install it globally
+pnpm add -g @jmrp.io/libgen-mcp      # …with pnpm
+```
+
+Most MCP clients can launch it through `npx` directly, which means there is
+nothing to install or keep updated by hand:
+
+```json
+{
+  "mcpServers": {
+    "libgen": { "command": "npx", "args": ["-y", "@jmrp.io/libgen-mcp"] }
+  }
+}
+```
+
+Prebuilt binaries exist for Linux, macOS and Windows on x64 and arm64. On any
+other platform the launcher exits with a message pointing at the release
+binaries and the option to build from source.
+
+### 2. Release binary
 
 Download a prebuilt binary for your platform from the
 [GitHub releases](https://github.com/jmrplens/libgen-mcp/releases) page. Assets are named
@@ -29,7 +61,7 @@ The binary is fully static (built with `CGO_ENABLED=0`), so it depends on nothin
 the host and runs straight away. Each release also ships a `checksums.txt`; verify your
 download against it before running.
 
-### 2. Docker
+### 3. Docker
 
 Prefer containers, or want a zero-install command your client pulls on first run? A
 multi-arch image is published to the GitHub Container Registry:
@@ -61,7 +93,7 @@ docker run --rm -p 8080:8080 \
   ghcr.io/jmrplens/libgen-mcp:latest --http 0.0.0.0:8080
 ```
 
-### 3. `go install` (from source)
+### 4. `go install` (from source)
 
 If you already have Go 1.27 or newer and prefer building from source:
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -52,7 +52,7 @@ claude mcp add libgen -- npx -y @jmrp.io/libgen-mcp
 A global install works too, and puts `libgen-mcp` on the `PATH`:
 
 ```bash
-npm install -g @jmrp.io/libgen-mcp
+npm install -g @jmrp.io/libgen-mcp   # or: pnpm add -g @jmrp.io/libgen-mcp
 ```
 
 ### Method B: Native binary (no dependencies at all)

--- a/llms-install.md
+++ b/llms-install.md
@@ -22,10 +22,43 @@ there is nothing to authenticate — skip straight to installation.
 
 ## Step 1 — Choose an install method
 
-### Method A: Native binary (recommended — no dependencies)
+### Method A: npm / npx (shortest path when Node is present)
+
+If `node --version` reports v18 or newer, this is the least work: the package
+carries the same prebuilt binaries as Method B, and npm installs only the one
+matching the user's OS and CPU. Nothing is compiled and no script runs at
+install time.
+
+```json
+{
+  "mcpServers": {
+    "libgen": {
+      "command": "npx",
+      "args": ["-y", "@jmrp.io/libgen-mcp"]
+    }
+  }
+}
+```
+
+For VS Code / GitHub Copilot, use the `servers` key with an explicit
+`"type": "stdio"` and the same `command`/`args`.
+
+**Claude Code CLI one-liner**:
+
+```bash
+claude mcp add libgen -- npx -y @jmrp.io/libgen-mcp
+```
+
+A global install works too, and puts `libgen-mcp` on the `PATH`:
+
+```bash
+npm install -g @jmrp.io/libgen-mcp
+```
+
+### Method B: Native binary (no dependencies at all)
 
 A single static executable: no Docker, no Go, nothing else to install. If you
-cannot determine the user's OS and architecture, use Docker (Method B) instead.
+cannot determine the user's OS and architecture, use Docker (Method C) instead.
 
 1. Download the binary for the user's platform from the latest release at
    `https://github.com/jmrplens/libgen-mcp/releases/latest`. Asset names:
@@ -61,7 +94,7 @@ For VS Code / GitHub Copilot, use the `servers` key with an explicit
 claude mcp add libgen -- /usr/local/bin/libgen-mcp
 ```
 
-### Method B: Docker (no download; pulls on first run)
+### Method C: Docker (no download; pulls on first run)
 
 Requires Docker installed and running. Verify with `docker --version`. The image
 is pulled automatically on first run.
@@ -137,14 +170,14 @@ Full reference: <https://jmrp.io/docs/libgen-mcp/configuration/>
 
 ## Troubleshooting
 
-- **Docker: `docker: command not found`** — use Method A (native binary), the
-  recommended default anyway.
+- **Docker: `docker: command not found`** — use Method A (npm/npx) if Node is
+  installed, or Method B (native binary), which needs nothing at all.
 - **No search results / parse errors** — a mirror may be down or have changed
   layout. Mirrors fail over automatically; retry, or pin a known-good one with
   `LIBGEN_MIRROR`. Set `LIBGEN_MCP_LOG_LEVEL=debug` to trace per-mirror attempts.
 - **Downloads not appearing on the host (Docker)** — files land inside the
   container by default; mount a volume and set `LIBGEN_MCP_DOWNLOAD_DIR` (see the
-  note under Method A).
+  note under Method C).
 - **Article DOI lookups rate-limited** — set `LIBGEN_MCP_UNPAYWALL_EMAIL` to the
   user's own address to be a good API citizen.
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -27,7 +27,7 @@ there is nothing to authenticate — skip straight to installation.
 If `node --version` reports v18 or newer, this is the least work: the package
 carries the same prebuilt binaries as Method B, and npm installs only the one
 matching the user's OS and CPU. Nothing is compiled and no script runs at
-install time.
+install time. Below v18, use Method B.
 
 ```json
 {
@@ -49,11 +49,16 @@ For VS Code / GitHub Copilot, use the `servers` key with an explicit
 claude mcp add libgen -- npx -y @jmrp.io/libgen-mcp
 ```
 
-A global install works too, and puts `libgen-mcp` on the `PATH`:
+A global install works too:
 
 ```bash
 npm install -g @jmrp.io/libgen-mcp   # or: pnpm add -g @jmrp.io/libgen-mcp
 ```
+
+It places `libgen-mcp` in the package manager's global binary directory, which
+is only callable by name if that directory is on the user's `PATH`
+(`npm config get prefix` for npm, `pnpm setup` for pnpm). If it is not, use the
+`npx` form above or an absolute `command` path.
 
 ### Method B: Native binary (no dependencies at all)
 

--- a/npm/libgen-mcp/README.md
+++ b/npm/libgen-mcp/README.md
@@ -6,10 +6,11 @@ and standards across the [Library Genesis](https://en.wikipedia.org/wiki/Library
 catalog and a long list of open-access sources. It runs as a local binary over
 stdio (default) or HTTP, and needs **no account, API key or token**.
 
-This package is a thin launcher. The actual server is a prebuilt Go binary that
-ships inside a per-platform package; npm installs only the one matching your
-operating system and CPU, so there is nothing to compile and nothing is
-downloaded at install time.
+This package is a thin launcher and needs Node 18 or newer. The actual server is
+a prebuilt Go binary that ships inside a per-platform package, listed here as an
+optional dependency; npm resolves only the one whose `os` and `cpu` match your
+machine and downloads it with the launcher. Nothing is compiled, and no install
+script runs and fetches anything else — the binary is already in the package.
 
 ## Run without installing
 
@@ -33,9 +34,13 @@ Most MCP clients are configured to launch the server this way. For example:
 ## Install
 
 ```bash
-npm install -g @jmrp.io/libgen-mcp
+npm install -g @jmrp.io/libgen-mcp   # or: pnpm add -g @jmrp.io/libgen-mcp
 libgen-mcp --help
 ```
+
+This puts `libgen-mcp` in your package manager's global binary directory. If the
+command is not found afterwards, that directory is not on your `PATH` —
+`npm config get prefix` shows npm's, and pnpm's is set up by `pnpm setup`.
 
 ## Tools
 

--- a/npm/libgen-mcp/README.md
+++ b/npm/libgen-mcp/README.md
@@ -1,0 +1,72 @@
+# @jmrp.io/libgen-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that lets an
+AI assistant search, cite, download and read books, papers, comics, magazines
+and standards across the [Library Genesis](https://en.wikipedia.org/wiki/Library_Genesis)
+catalog and a long list of open-access sources. It runs as a local binary over
+stdio (default) or HTTP, and needs **no account, API key or token**.
+
+This package is a thin launcher. The actual server is a prebuilt Go binary that
+ships inside a per-platform package; npm installs only the one matching your
+operating system and CPU, so there is nothing to compile and nothing is
+downloaded at install time.
+
+## Run without installing
+
+```bash
+npx @jmrp.io/libgen-mcp
+```
+
+Most MCP clients are configured to launch the server this way. For example:
+
+```json
+{
+  "mcpServers": {
+    "libgen": {
+      "command": "npx",
+      "args": ["-y", "@jmrp.io/libgen-mcp"]
+    }
+  }
+}
+```
+
+## Install
+
+```bash
+npm install -g @jmrp.io/libgen-mcp
+libgen-mcp --help
+```
+
+## Tools
+
+- `search` — search the Library Genesis catalog, escalating to Anna's Archive
+  and the open-access providers (arXiv, Crossref, OpenLibrary, Project
+  Gutenberg, dblp, PubMed, ERIC) when the catalog comes up empty.
+- `get_details` — full metadata for a record by md5, edition/file id or DOI,
+  with an optional BibTeX/RIS citation export.
+- `download` — resolve and download a book (by md5) or article (by DOI) through
+  an ordered source chain with transparent failover.
+- `read` — extract text, search within, and outline a downloaded PDF/EPUB/TXT.
+
+Four prompts (`acquire_book`, `research_topic`, `get_paper`,
+`download_troubleshoot`) turn common requests into ready-to-run tool plans.
+
+## Configuration
+
+Everything works with zero configuration. Optional `LIBGEN_MCP_*` environment
+variables and command-line flags — download directory, HTTP mode, extra search
+sources, opt-in keys — are documented in the
+[configuration reference](https://jmrp.io/docs/libgen-mcp/configuration/).
+
+## Supported platforms
+
+Linux, macOS and Windows, on x64 and arm64. On any other platform the launcher
+exits with a message pointing to the
+[release binaries](https://github.com/jmrplens/libgen-mcp/releases) and the
+option to build from source.
+
+## Links
+
+- Documentation: <https://jmrp.io/docs/libgen-mcp>
+- Source and issues: <https://github.com/jmrplens/libgen-mcp>
+- License: MIT

--- a/npm/libgen-mcp/cli.js
+++ b/npm/libgen-mcp/cli.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// cli.js resolves the prebuilt libgen-mcp binary for the current platform and
+// hands control to it. The binary ships inside a per-platform optional
+// dependency (see the package's optionalDependencies); npm installs only the
+// one whose os/cpu match, and this launcher execs it.
+//
+// It is a thin shim on purpose. The server speaks MCP over stdio, so stdio is
+// inherited untouched and this file never writes to stdout — a stray byte there
+// would corrupt the JSON-RPC stream. argv is forwarded verbatim, the
+// environment is passed through unmodified (every LIBGEN_MCP_* variable is the
+// server's to read), and the child's exit code and terminating signal are
+// mirrored so `npx` callers and process supervisors see the real outcome.
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const os = require("node:os");
+
+// platformKey maps Node's platform/arch names to the per-platform package
+// suffix. The suffixes follow Node's vocabulary (win32, x64), not Go's
+// (windows, amd64); the release generator translates when it builds each
+// package, so the two never have to agree at runtime.
+function platformKey() {
+  const supported = {
+    "linux-x64": true,
+    "linux-arm64": true,
+    "darwin-x64": true,
+    "darwin-arm64": true,
+    "win32-x64": true,
+    "win32-arm64": true,
+  };
+  const key = `${process.platform}-${process.arch}`;
+  return supported[key] ? key : null;
+}
+
+function binaryName() {
+  return process.platform === "win32" ? "libgen-mcp.exe" : "libgen-mcp";
+}
+
+// resolveBinary finds the binary inside the matching per-platform package.
+// require.resolve walks the same node_modules the launcher was loaded from, so
+// it finds the dependency whether the install is flat, nested, hoisted, or run
+// through npx's throwaway prefix.
+function resolveBinary(key) {
+  const pkg = `@jmrp.io/libgen-mcp-${key}`;
+  try {
+    return require.resolve(`${pkg}/${binaryName()}`);
+  } catch {
+    return null;
+  }
+}
+
+function fail(message) {
+  process.stderr.write(`libgen-mcp: ${message}\n`);
+  process.exit(1);
+}
+
+const key = platformKey();
+if (!key) {
+  fail(
+    `unsupported platform ${process.platform}/${process.arch}. ` +
+      "Prebuilt binaries exist for linux, macOS and Windows on x64 and arm64; " +
+      "for anything else, build from source or use a released binary directly " +
+      "(https://github.com/jmrplens/libgen-mcp/releases).",
+  );
+}
+
+const binary = resolveBinary(key);
+if (!binary) {
+  // The platform is supported but its package is absent. The usual cause is an
+  // install that skipped optional dependencies (npm install --no-optional, or
+  // a lockfile pinned on a different OS), not a broken release.
+  fail(
+    `the @jmrp.io/libgen-mcp-${key} package is not installed. ` +
+      "It is an optional dependency that carries the binary for this platform; " +
+      "reinstall without --no-optional, or delete node_modules and the lockfile " +
+      "and install again.",
+  );
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  fail(`failed to start the binary: ${result.error.message}`);
+}
+// A child killed by a signal reports null status and a signal name. Re-raise it
+// so the launcher dies the same way rather than masking a SIGINT as exit 0.
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+  // If the re-raise did not terminate us (signal ignored, or no default
+  // disposition), exit with the conventional 128+signal code so the caller
+  // still sees the child's terminating signal rather than a bare failure.
+  const signum = os.constants.signals[result.signal];
+  process.exit(signum ? 128 + signum : 1);
+}
+process.exit(result.status === null ? 1 : result.status);

--- a/npm/libgen-mcp/cli.js
+++ b/npm/libgen-mcp/cli.js
@@ -49,47 +49,60 @@ function resolveBinary(key) {
   }
 }
 
+// fail reports a diagnostic and marks the run failed. It sets `exitCode` rather
+// than calling process.exit(), which would drop a stderr write that has not
+// flushed yet — writes to a pipe are asynchronous, and the message explaining
+// why the launcher gave up is the one least worth losing. Callers return
+// immediately after; the process then exits on its own once stderr has drained.
 function fail(message) {
   process.stderr.write(`libgen-mcp: ${message}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 }
 
-const key = platformKey();
-if (!key) {
-  fail(
-    `unsupported platform ${process.platform}/${process.arch}. ` +
-      "Prebuilt binaries exist for linux, macOS and Windows on x64 and arm64; " +
-      "for anything else, build from source or use a released binary directly " +
-      "(https://github.com/jmrplens/libgen-mcp/releases).",
-  );
+function main() {
+  const key = platformKey();
+  if (!key) {
+    fail(
+      `unsupported platform ${process.platform}/${process.arch}. ` +
+        "Prebuilt binaries exist for linux, macOS and Windows on x64 and arm64; " +
+        "for anything else, build from source or use a released binary directly " +
+        "(https://github.com/jmrplens/libgen-mcp/releases).",
+    );
+    return;
+  }
+
+  const binary = resolveBinary(key);
+  if (!binary) {
+    // The platform is supported but its package is absent. The usual cause is
+    // an install that skipped optional dependencies (npm install --no-optional,
+    // or a lockfile pinned on a different OS), not a broken release.
+    fail(
+      `the @jmrp.io/libgen-mcp-${key} package is not installed. ` +
+        "It is an optional dependency that carries the binary for this platform; " +
+        "reinstall without --no-optional, or delete node_modules and the lockfile " +
+        "and install again.",
+    );
+    return;
+  }
+
+  const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
+
+  if (result.error) {
+    fail(`failed to start the binary: ${result.error.message}`);
+    return;
+  }
+  // A child killed by a signal reports null status and a signal name. Re-raise
+  // it so the launcher dies the same way rather than masking a SIGINT as exit 0.
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    // If the re-raise did not terminate us (signal ignored, or no default
+    // disposition), fall back to the conventional 128+signal code so the caller
+    // still sees the child's terminating signal rather than a bare failure.
+    const signum = os.constants.signals[result.signal];
+    process.exitCode = signum ? 128 + signum : 1;
+    return;
+  }
+  process.exitCode = result.status === null ? 1 : result.status;
 }
 
-const binary = resolveBinary(key);
-if (!binary) {
-  // The platform is supported but its package is absent. The usual cause is an
-  // install that skipped optional dependencies (npm install --no-optional, or
-  // a lockfile pinned on a different OS), not a broken release.
-  fail(
-    `the @jmrp.io/libgen-mcp-${key} package is not installed. ` +
-      "It is an optional dependency that carries the binary for this platform; " +
-      "reinstall without --no-optional, or delete node_modules and the lockfile " +
-      "and install again.",
-  );
-}
-
-const result = spawnSync(binary, process.argv.slice(2), { stdio: "inherit" });
-
-if (result.error) {
-  fail(`failed to start the binary: ${result.error.message}`);
-}
-// A child killed by a signal reports null status and a signal name. Re-raise it
-// so the launcher dies the same way rather than masking a SIGINT as exit 0.
-if (result.signal) {
-  process.kill(process.pid, result.signal);
-  // If the re-raise did not terminate us (signal ignored, or no default
-  // disposition), exit with the conventional 128+signal code so the caller
-  // still sees the child's terminating signal rather than a bare failure.
-  const signum = os.constants.signals[result.signal];
-  process.exit(signum ? 128 + signum : 1);
-}
-process.exit(result.status === null ? 1 : result.status);
+main();

--- a/npm/libgen-mcp/package.json
+++ b/npm/libgen-mcp/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@jmrp.io/libgen-mcp",
+  "version": "1.7.2",
+  "description": "Model Context Protocol (MCP) server for federated search, citation and reading of books and papers across Library Genesis and open-access sources. Runs as a local binary over stdio or HTTP.",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "libgen",
+    "library-genesis",
+    "open-access",
+    "arxiv",
+    "crossref",
+    "doi",
+    "ai",
+    "llm",
+    "claude",
+    "stdio",
+    "cli"
+  ],
+  "homepage": "https://jmrp.io/docs/libgen-mcp",
+  "bugs": "https://github.com/jmrplens/libgen-mcp/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jmrplens/libgen-mcp.git",
+    "directory": "npm/libgen-mcp"
+  },
+  "license": "MIT",
+  "author": "José M. Requena Plens",
+  "type": "commonjs",
+  "bin": {
+    "libgen-mcp": "cli.js"
+  },
+  "files": [
+    "cli.js",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "@jmrp.io/libgen-mcp-linux-x64": "1.7.2",
+    "@jmrp.io/libgen-mcp-linux-arm64": "1.7.2",
+    "@jmrp.io/libgen-mcp-darwin-x64": "1.7.2",
+    "@jmrp.io/libgen-mcp-darwin-arm64": "1.7.2",
+    "@jmrp.io/libgen-mcp-win32-x64": "1.7.2",
+    "@jmrp.io/libgen-mcp-win32-arm64": "1.7.2"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/build-npm.mjs
+++ b/scripts/build-npm.mjs
@@ -1,0 +1,149 @@
+// build-npm.mjs assembles the npm publish set from the release binaries.
+//
+// The npm distribution is one thin launcher package plus one package per
+// platform that carries the matching prebuilt binary (the esbuild/biome model:
+// npm installs only the package whose os/cpu fit, and no code runs at install
+// time). This script is the single place the two vocabularies meet — Node's
+// platform/arch names on the npm side, Go's GOOS/GOARCH on the asset side — so
+// nothing downstream has to translate.
+//
+// Usage:
+//   node scripts/build-npm.mjs --binaries <dir> --version <x.y.z> [--out <dir>]
+//   node scripts/build-npm.mjs --sync-only --version <x.y.z>
+//
+// <dir> holds the release assets under their published names
+// (libgen-mcp-linux-amd64, …). Output is one directory per package under
+// <out> (default npm/packages), plus the main package's version and dependency
+// pins rewritten in place under npm/libgen-mcp.
+//
+// --sync-only rewrites just the committed main package.json (version and the
+// optionalDependency pins) and builds nothing. It needs no binaries, so the
+// release version-stamp step can keep the checked-in file honest between
+// releases without staging a whole distribution.
+
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// PLATFORMS is the whole distribution matrix. `key` is the npm suffix and the
+// runtime lookup the launcher performs; `os`/`cpu` gate the install; `asset` is
+// the release filename the binary is copied from. Keep this in lockstep with
+// the launcher's supported set and the main package's optionalDependencies.
+const PLATFORMS = [
+  { key: "linux-x64", os: "linux", cpu: "x64", asset: "libgen-mcp-linux-amd64", exe: false },
+  { key: "linux-arm64", os: "linux", cpu: "arm64", asset: "libgen-mcp-linux-arm64", exe: false },
+  { key: "darwin-x64", os: "darwin", cpu: "x64", asset: "libgen-mcp-darwin-amd64", exe: false },
+  { key: "darwin-arm64", os: "darwin", cpu: "arm64", asset: "libgen-mcp-darwin-arm64", exe: false },
+  { key: "win32-x64", os: "win32", cpu: "x64", asset: "libgen-mcp-windows-amd64.exe", exe: true },
+  { key: "win32-arm64", os: "win32", cpu: "arm64", asset: "libgen-mcp-windows-arm64.exe", exe: true },
+];
+
+function parseArgs(argv) {
+  const out = { binaries: null, version: null, out: join(repoRoot, "npm", "packages"), syncOnly: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--binaries") out.binaries = argv[++i];
+    else if (arg === "--version") out.version = argv[++i];
+    else if (arg === "--out") out.out = argv[++i];
+    else if (arg === "--sync-only") out.syncOnly = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!out.version) throw new Error("--version <x.y.z> is required");
+  // Anchored at both ends: an unanchored test accepts "1.7.2invalid" and stamps
+  // it into every manifest, which npm then rejects far from the cause.
+  if (!/^\d+\.\d+\.\d+$/.test(out.version)) throw new Error(`--version must be semver, got ${out.version}`);
+  if (!out.syncOnly && !out.binaries) throw new Error("--binaries <dir> is required (or pass --sync-only)");
+  return out;
+}
+
+const mainRepository = {
+  type: "git",
+  url: "git+https://github.com/jmrplens/libgen-mcp.git",
+};
+
+// writePlatformPackage emits one per-platform package: the binary renamed to a
+// stable name the launcher resolves, made executable so the bit survives into
+// the tarball, and a package.json whose os/cpu confine the install to the
+// platform it serves.
+function writePlatformPackage(plat, version, binariesDir, outDir) {
+  const dir = join(outDir, plat.key);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+
+  const binaryName = plat.exe ? "libgen-mcp.exe" : "libgen-mcp";
+  const src = join(binariesDir, plat.asset);
+  const dst = join(dir, binaryName);
+  copyFileSync(src, dst);
+  // Explicit 0o755 after the copy: npm records the file mode in the tarball, so
+  // a binary packed without the executable bit installs un-runnable on the
+  // consumer's machine — and the source asset's mode depends on how it was
+  // downloaded.
+  chmodSync(dst, 0o755);
+
+  const pkg = {
+    name: `@jmrp.io/libgen-mcp-${plat.key}`,
+    version,
+    description: `libgen-mcp prebuilt binary for ${plat.os} ${plat.cpu}. Installed automatically as an optional dependency of @jmrp.io/libgen-mcp.`,
+    license: "MIT",
+    author: "José M. Requena Plens",
+    homepage: "https://jmrp.io/docs/libgen-mcp",
+    repository: mainRepository,
+    os: [plat.os],
+    cpu: [plat.cpu],
+    files: [binaryName],
+    preferUnplugged: true,
+  };
+  writeFileSync(join(dir, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+  writeFileSync(
+    join(dir, "README.md"),
+    `# @jmrp.io/libgen-mcp-${plat.key}\n\n` +
+      `The ${plat.os}/${plat.cpu} binary for ` +
+      `[@jmrp.io/libgen-mcp](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). ` +
+      "You do not install this directly; it comes in as an optional dependency of the main package.\n",
+  );
+  return { name: pkg.name, dir };
+}
+
+// syncMainPackage rewrites the launcher package's own version and pins every
+// optional dependency to the same version, so the whole set moves as one and a
+// consumer never resolves a launcher against a mismatched binary package.
+function syncMainPackage(version) {
+  const dir = join(repoRoot, "npm", "libgen-mcp");
+  const path = join(dir, "package.json");
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  pkg.version = version;
+  pkg.optionalDependencies = Object.fromEntries(
+    PLATFORMS.map((p) => [`@jmrp.io/libgen-mcp-${p.key}`, version]),
+  );
+  writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+  return { name: pkg.name, dir };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.syncOnly) {
+    const mainPackage = syncMainPackage(args.version);
+    process.stdout.write(`npm main package synced to v${args.version} (${mainPackage.name})\n`);
+    return;
+  }
+
+  mkdirSync(args.out, { recursive: true });
+
+  const platformPackages = PLATFORMS.map((p) =>
+    writePlatformPackage(p, args.version, args.binaries, args.out),
+  );
+  const mainPackage = syncMainPackage(args.version);
+
+  // Publish order matters: the platform packages must exist on the registry
+  // before the launcher that lists them, or an install racing the publish
+  // resolves optional dependencies that are not there yet.
+  process.stdout.write(`npm distribution assembled for v${args.version}\n\n`);
+  process.stdout.write("Publish in this order (platform packages first):\n");
+  for (const p of platformPackages) process.stdout.write(`  ${p.dir}\n`);
+  process.stdout.write(`  ${mainPackage.dir}   (${mainPackage.name})\n`);
+}
+
+main();

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -47,11 +47,30 @@ publish() {
   # OIDC exchange, or a maintainer's `npm login` / .npmrc for the bootstrap — so
   # this script never sees a credential.
   #
+  # The output is captured so a rejection can be classified rather than just
+  # propagated. The `npm view` check above is an optimisation, not the guarantee:
+  # a version published moments ago can still be missing from the read path while
+  # the write path already rejects it, and that window is exactly when a retried
+  # release job runs. Treating npm's own duplicate-version answer as success is
+  # what closes it — the version we wanted on the registry is on the registry.
+  log="$(mktemp)"
   # $DRY_RUN is empty or "--dry-run" and must word-split, not stay one argument.
   # The directive below must be bare: ShellCheck rejects a `disable=` line that
   # carries a trailing explanation and then skips the whole file.
   # shellcheck disable=SC2086
-  npm publish "$dir" --access public $DRY_RUN
+  if npm publish "$dir" --access public $DRY_RUN >"$log" 2>&1; then
+    cat "$log"
+    rm -f "$log"
+    return 0
+  fi
+  cat "$log"
+  if grep -qE 'EPUBLISHCONFLICT|cannot publish over the previously published versions' "$log"; then
+    echo "Skipping $name@$VERSION — the registry already has it."
+    rm -f "$log"
+    return 0
+  fi
+  rm -f "$log"
+  return 1
 }
 
 for key in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64 win32-arm64; do

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# publish-npm.sh assembles and publishes the npm distribution for one release:
+# the six per-platform binary packages first, then the launcher that depends on
+# them. The order is load-bearing — a consumer installing between the two
+# publishes must not find the launcher referencing platform packages that are
+# not on the registry yet.
+#
+# Usage:
+#   scripts/publish-npm.sh <binaries-dir> <version> [--dry-run]
+#
+# <binaries-dir> holds the release assets under their published names. Auth is
+# whatever `npm` already has: the OIDC trusted publisher in CI (no stored
+# credential) or an interactive `npm login` locally. Under trusted publishing
+# npm attaches build provenance automatically; --dry-run packs and validates
+# without publishing anything.
+set -euo pipefail
+
+BINARIES_DIR="${1:?Usage: $0 <binaries-dir> <version> [--dry-run]}"
+VERSION="${2:?Usage: $0 <binaries-dir> <version> [--dry-run]}"
+DRY_RUN=""
+if [ "${3:-}" = "--dry-run" ]; then
+  DRY_RUN="--dry-run"
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/npm/packages"
+
+echo "Assembling npm distribution for v$VERSION"
+node "$ROOT/scripts/build-npm.mjs" --binaries "$BINARIES_DIR" --version "$VERSION" --out "$OUT"
+
+publish() {
+  dir="$1"
+  name="$(node -p "require('$dir/package.json').name")"
+  # Skip a version already on the registry so re-running a release job (which
+  # happens — a later step can fail and get retried) does not die on npm's 409
+  # for the packages that already went out. `npm view` prints the version when
+  # it exists and errors (nothing on stdout) when it does not.
+  if [ -z "$DRY_RUN" ] && [ "$(npm view "$name@$VERSION" version 2>/dev/null || true)" = "$VERSION" ]; then
+    echo "Skipping $name@$VERSION — already published."
+    return 0
+  fi
+  echo "Publishing $name@$VERSION…"
+  # No --provenance flag on purpose. In CI this publishes through npm's OIDC
+  # trusted publisher, which generates and attaches provenance automatically;
+  # the local bootstrap publish (token auth, no OIDC) simply has none. Auth is
+  # left to the environment — the workflow's setup-node registry config for the
+  # OIDC exchange, or a maintainer's `npm login` / .npmrc for the bootstrap — so
+  # this script never sees a credential.
+  #
+  # $DRY_RUN is empty or "--dry-run" and must word-split, not stay one argument.
+  # The directive below must be bare: ShellCheck rejects a `disable=` line that
+  # carries a trailing explanation and then skips the whole file.
+  # shellcheck disable=SC2086
+  npm publish "$dir" --access public $DRY_RUN
+}
+
+for key in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64 win32-arm64; do
+  publish "$OUT/$key"
+done
+
+# The launcher last, once every platform package it pins is live.
+publish "$ROOT/npm/libgen-mcp"
+
+echo "npm publish complete for v$VERSION"

--- a/scripts/update-server-json-sha.sh
+++ b/scripts/update-server-json-sha.sh
@@ -82,3 +82,17 @@ for manifest in lhm.plugin.json mcpb/manifest.json .plugin/plugin.json; do
     echo "NOTE: $manifest not found, skipping"
   fi
 done
+
+# 6. Update the npm launcher package version and its optionalDependency pins.
+#
+# The generator owns the whole mapping — the version and all six pins move
+# together — so this stays a single call rather than a jq edit that could stamp
+# the version while leaving the dependency specs a release behind. The
+# per-platform packages are built from the release binaries at publish time,
+# not stamped here.
+NPM_MAIN="npm/libgen-mcp/package.json"
+if [[ -f "$NPM_MAIN" ]] && command -v node >/dev/null 2>&1; then
+  node scripts/build-npm.mjs --sync-only --version "$VERSION"
+else
+  echo "NOTE: $NPM_MAIN not found or node unavailable, skipping npm manifest update"
+fi

--- a/scripts/validate-npm.mjs
+++ b/scripts/validate-npm.mjs
@@ -1,0 +1,236 @@
+// validate-npm.mjs checks the assembled npm distribution before it is
+// published. A published npm version is permanent — the registry refuses to
+// replace it — so a broken tarball caught here is cheap and caught after
+// publish is not.
+//
+// Two tiers of check:
+//   1. Structural, for all seven packages. What actually ships in each tarball:
+//      the exact file set, the executable bit on the binary, the binary's magic
+//      number for the platform it claims, a size floor, and the package.json
+//      os/cpu/name/version. This runs anywhere; it does not execute anything.
+//   2. Runtime, for the one platform the validating host can run (linux-x64
+//      inside the node:22 container `make validate-npm` uses). It installs the
+//      launcher plus that platform package from their tarballs into a throwaway
+//      project, confirms npm resolved only the matching package, then drives an
+//      MCP initialize handshake over stdio and asserts stdout carries pure
+//      JSON-RPC — the property a stray print would silently break.
+//
+// Usage: node scripts/validate-npm.mjs --packages <dir> --main <dir> --version <x.y.z>
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Magic numbers by target OS: ELF for linux, Mach-O 64-bit LE for darwin, PE/MZ
+// for windows. A binary whose first bytes do not match is one built for the
+// wrong platform or a truncated download, which os/cpu gating would not catch.
+const MAGIC = {
+  linux: [[0x7f, 0x45, 0x4c, 0x46]], // \x7fELF
+  darwin: [
+    [0xcf, 0xfa, 0xed, 0xfe], // Mach-O 64-bit thin, little-endian
+    [0xca, 0xfe, 0xba, 0xbe], // Mach-O universal ("fat")
+  ],
+  win32: [[0x4d, 0x5a]], // MZ
+};
+const MIN_BINARY_BYTES = 5_000_000;
+
+const PLATFORMS = [
+  { key: "linux-x64", os: "linux", cpu: "x64", exe: false },
+  { key: "linux-arm64", os: "linux", cpu: "arm64", exe: false },
+  { key: "darwin-x64", os: "darwin", cpu: "x64", exe: false },
+  { key: "darwin-arm64", os: "darwin", cpu: "arm64", exe: false },
+  { key: "win32-x64", os: "win32", cpu: "x64", exe: true },
+  { key: "win32-arm64", os: "win32", cpu: "arm64", exe: true },
+];
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--packages") out.packages = argv[++i];
+    else if (argv[i] === "--main") out.main = argv[++i];
+    else if (argv[i] === "--version") out.version = argv[++i];
+    else throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  for (const k of ["packages", "main", "version"]) {
+    if (!out[k]) throw new Error(`--${k} is required`);
+  }
+  return out;
+}
+
+const failures = [];
+function check(cond, msg) {
+  if (!cond) failures.push(msg);
+  return cond;
+}
+
+// packAndList packs a package to tgz and returns { tgz, entries } where each
+// entry is { mode, size, name } parsed from `tar -tzv`. Packing (not reading
+// the source dir) is the point: it validates the artifact that ships.
+function packAndList(dir, destDir) {
+  const out = execFileSync("npm", ["pack", "--pack-destination", destDir, "--silent"], {
+    cwd: dir,
+    encoding: "utf8",
+  }).trim();
+  const tgz = join(destDir, out.split("\n").pop().trim());
+  const listing = execFileSync("tar", ["-tzvf", tgz], { encoding: "utf8" });
+  const entries = listing
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const parts = line.split(/\s+/);
+      // e.g. "-rwxr-xr-x 0/0  18874368 2026-... package/libgen-mcp"
+      return { mode: parts[0], size: Number(parts[2]), name: parts[parts.length - 1] };
+    });
+  return { tgz, entries };
+}
+
+function firstBytes(tgz, entryName, n) {
+  const buf = execFileSync("tar", ["-xzOf", tgz, entryName], { maxBuffer: 1 << 30 });
+  return Array.from(buf.subarray(0, n));
+}
+
+function validatePlatform(plat, packagesDir, version, workDir) {
+  const label = `@jmrp.io/libgen-mcp-${plat.key}`;
+  const dir = join(packagesDir, plat.key);
+  const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+
+  check(pkg.name === label, `${plat.key}: name is ${pkg.name}, want ${label}`);
+  check(pkg.version === version, `${plat.key}: version ${pkg.version}, want ${version}`);
+  check(JSON.stringify(pkg.os) === JSON.stringify([plat.os]), `${plat.key}: os ${JSON.stringify(pkg.os)}, want [${plat.os}]`);
+  check(JSON.stringify(pkg.cpu) === JSON.stringify([plat.cpu]), `${plat.key}: cpu ${JSON.stringify(pkg.cpu)}, want [${plat.cpu}]`);
+
+  const binaryName = plat.exe ? "libgen-mcp.exe" : "libgen-mcp";
+  const { tgz, entries } = packAndList(dir, workDir);
+  const shipped = entries.map((e) => e.name.replace(/^package\//, "")).filter((n) => n && !n.endsWith("/"));
+  const want = new Set([binaryName, "package.json", "README.md"]);
+  check(
+    shipped.length === want.size && shipped.every((n) => want.has(n)),
+    `${plat.key}: tarball ships ${JSON.stringify(shipped)}, want ${JSON.stringify([...want])}`,
+  );
+
+  const binEntry = entries.find((e) => e.name.endsWith("/" + binaryName));
+  if (check(binEntry, `${plat.key}: binary ${binaryName} not in tarball`)) {
+    check(binEntry.mode.includes("x"), `${plat.key}: binary is not executable in the tarball (mode ${binEntry.mode})`);
+    check(binEntry.size >= MIN_BINARY_BYTES, `${plat.key}: binary is ${binEntry.size} bytes, below the ${MIN_BINARY_BYTES} floor`);
+    const magic = firstBytes(tgz, `package/${binaryName}`, 4);
+    const ok = MAGIC[plat.os].some((sig) => sig.every((b, i) => magic[i] === b));
+    check(ok, `${plat.key}: binary magic ${magic.map((b) => b.toString(16)).join(" ")} is not ${plat.os}`);
+  }
+}
+
+function validateMain(mainDir, version, workDir) {
+  const pkg = JSON.parse(readFileSync(join(mainDir, "package.json"), "utf8"));
+  check(pkg.name === "@jmrp.io/libgen-mcp", `main: name is ${pkg.name}`);
+  check(pkg.version === version, `main: version ${pkg.version}, want ${version}`);
+  check(pkg.bin && pkg.bin["libgen-mcp"] === "cli.js", `main: bin does not point at cli.js`);
+  for (const plat of PLATFORMS) {
+    const dep = `@jmrp.io/libgen-mcp-${plat.key}`;
+    check(pkg.optionalDependencies?.[dep] === version, `main: optionalDependency ${dep} pinned to ${pkg.optionalDependencies?.[dep]}, want ${version}`);
+  }
+  const { entries } = packAndList(mainDir, workDir);
+  const shipped = entries.map((e) => e.name.replace(/^package\//, "")).filter((n) => n && !n.endsWith("/"));
+  const want = new Set(["cli.js", "package.json", "README.md"]);
+  check(
+    shipped.length === want.size && shipped.every((n) => want.has(n)),
+    `main: tarball ships ${JSON.stringify(shipped)}, want ${JSON.stringify([...want])}`,
+  );
+}
+
+// runtimeCheck installs the launcher plus the host-native platform package from
+// their tarballs and drives an MCP handshake, asserting stdout is pure
+// JSON-RPC. Returns the platform key it exercised, or null if none matched.
+async function runtimeCheck(packagesDir, mainDir, version, workDir) {
+  const key = `${process.platform}-${process.arch}`;
+  const plat = PLATFORMS.find((p) => p.key === key);
+  if (!plat) {
+    process.stdout.write(`  runtime: host is ${key}, no matching package to execute — structural checks only\n`);
+    return null;
+  }
+
+  const platTgz = packAndList(join(packagesDir, plat.key), workDir).tgz;
+  const mainTgz = packAndList(mainDir, workDir).tgz;
+
+  const proj = mkdtempSync(join(workDir, "proj-"));
+  writeFileSync(join(proj, "package.json"), JSON.stringify({ name: "v", version: "1.0.0", private: true }));
+  execFileSync("npm", ["install", "--no-audit", "--no-fund", platTgz, mainTgz], { cwd: proj, stdio: "pipe" });
+
+  const installed = readdirSync(join(proj, "node_modules", "@jmrp.io"));
+  check(
+    installed.includes("libgen-mcp") && installed.includes(`libgen-mcp-${plat.key}`),
+    `runtime: node_modules/@jmrp.io holds ${JSON.stringify(installed)}`,
+  );
+  check(
+    !installed.some((n) => n.startsWith("libgen-mcp-") && n !== `libgen-mcp-${plat.key}`),
+    `runtime: a non-host platform package was installed: ${JSON.stringify(installed)}`,
+  );
+
+  const before = failures.length;
+  const bin = join(proj, "node_modules", ".bin", "libgen-mcp");
+  const seen = await handshake(bin);
+  check(seen === version, `runtime: handshake serverInfo.version ${seen}, want ${version}`);
+  const ok = failures.length === before ? " ✓" : "";
+  process.stdout.write(`  runtime: installed + MCP handshake on ${plat.key}, stdout pure JSON-RPC${ok}\n`);
+  return plat.key;
+}
+
+// handshake spawns the launcher, sends an initialize request, and verifies every
+// non-empty stdout line is JSON-RPC 2.0. Returns the negotiated server version.
+function handshake(bin) {
+  return new Promise((resolve) => {
+    const child = spawn(bin, []);
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", () => {}); // logs live on stderr; not our concern here
+    const init = {
+      jsonrpc: "2.0", id: 1, method: "initialize",
+      params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "validate", version: "1" } },
+    };
+    child.stdin.write(JSON.stringify(init) + "\n");
+    setTimeout(() => {
+      child.kill();
+      let version = null;
+      for (const line of out.split("\n")) {
+        const s = line.trim();
+        if (!s) continue;
+        let msg;
+        try {
+          msg = JSON.parse(s);
+        } catch {
+          failures.push(`runtime: non-JSON on stdout would corrupt the MCP stream: ${JSON.stringify(s.slice(0, 100))}`);
+          continue;
+        }
+        if (msg.jsonrpc !== "2.0") failures.push(`runtime: stdout line is not JSON-RPC 2.0: ${JSON.stringify(s.slice(0, 100))}`);
+        if (msg.id === 1 && msg.result) version = msg.result.serverInfo?.version ?? null;
+      }
+      if (!version) failures.push("runtime: no initialize result on stdout");
+      resolve(version);
+    }, 4000);
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const workDir = mkdtempSync(join(tmpdir(), "validate-npm-"));
+  process.stdout.write(`Validating npm distribution v${args.version}\n`);
+  try {
+    for (const plat of PLATFORMS) validatePlatform(plat, args.packages, args.version, workDir);
+    validateMain(args.main, args.version, workDir);
+    process.stdout.write(`  structural: 7 packages checked (files, exec bit, magic, os/cpu, pins)${failures.length ? "" : " ✓"}\n`);
+    await runtimeCheck(args.packages, args.main, args.version, workDir);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+
+  if (failures.length) {
+    process.stdout.write(`\nFAILED (${failures.length}):\n`);
+    for (const f of failures) process.stdout.write(`  ✗ ${f}\n`);
+    process.exit(1);
+  }
+  process.stdout.write("\nnpm distribution valid ✓\n");
+}
+
+main().catch((e) => {
+  process.stderr.write(`validate-npm: ${e.stack || e}\n`);
+  process.exit(1);
+});

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -34,7 +34,7 @@ head:
             "@type": "HowToStep",
             "position": 1,
             "name": "Instala el servidor",
-            "text": "Descarga el binario estático precompilado para tu plataforma desde la página de releases de GitHub, márcalo como ejecutable y ponlo en tu PATH. Es un único ejecutable completamente estático sin nada más que instalar. Como alternativa, descarga la imagen Docker multiarquitectura ghcr.io/jmrplens/libgen-mcp:latest, o compila desde el código con go install si tienes Go 1.27 o superior.",
+            "text": "Si tienes Node 18 o posterior, ejecuta npx @jmrp.io/libgen-mcp, o instálalo globalmente con npm install -g @jmrp.io/libgen-mcp. Si no, descarga el binario estático precompilado para tu plataforma desde la página de releases de GitHub, márcalo como ejecutable y ponlo en tu PATH: es un único ejecutable completamente estático sin nada más que instalar. También puedes descargar la imagen Docker multiarquitectura ghcr.io/jmrplens/libgen-mcp:latest, o compilar desde el código con go install si tienes Go 1.27 o superior.",
             "url": "https://jmrplens.github.io/libgen-mcp/es/getting-started/#instalación"
           },
           {
@@ -76,7 +76,7 @@ head:
             "name": "¿Cómo instalo libgen-mcp?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "La instalación recomendada es el binario precompilado: descarga el archivo para tu plataforma desde la página de releases de GitHub (los archivos se llaman libgen-mcp-<os>-<arch>, cubriendo Linux, macOS y Windows en amd64 y arm64), hazlo ejecutable y colócalo en tu PATH. Es un único ejecutable totalmente estático sin nada más que instalar. Como alternativas puedes usar la imagen de Docker multi-arch ghcr.io/jmrplens/libgen-mcp:latest o, si ya tienes Go 1.27 o posterior, compilar desde el código fuente con go install github.com/jmrplens/libgen-mcp/cmd/server@latest."
+              "text": "Si tienes Node 18 o posterior, el camino más corto es npm: ejecuta npx @jmrp.io/libgen-mcp, o instálalo globalmente con npm install -g @jmrp.io/libgen-mcp. Si no, usa el binario precompilado: descarga el archivo para tu plataforma desde la página de releases de GitHub (los archivos se llaman libgen-mcp-<os>-<arch>, cubriendo Linux, macOS y Windows en amd64 y arm64), hazlo ejecutable y colócalo en tu PATH. Es un único ejecutable totalmente estático sin nada más que instalar. Como alternativas puedes usar la imagen de Docker multi-arch ghcr.io/jmrplens/libgen-mcp:latest o, si ya tienes Go 1.27 o posterior, compilar desde el código fuente con go install github.com/jmrplens/libgen-mcp/cmd/server@latest."
             }
           },
           {
@@ -84,7 +84,7 @@ head:
             "name": "¿Qué método de instalación debería usar?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Usa el binario precompilado en la mayoría de los casos: es un único ejecutable estático que no necesita toolchain de Go, ni Docker, ni runtime. Elige Docker si prefieres contenedores o un comando sin instalación que tu cliente descarga en el primer arranque. Elige go install solo si ya tienes Go 1.27 o posterior y quieres compilar desde el código fuente. En Claude Desktop, la extensión .mcpb de un clic del último release es la opción más sencilla."
+              "text": "Usa npm si ya hay Node en la máquina: npx @jmrp.io/libgen-mcp no necesita paso de instalación y mantiene el servidor al día por sí solo. Si no, usa el binario precompilado: es un único ejecutable estático que no necesita toolchain de Go, ni Docker, ni runtime. Elige Docker si prefieres contenedores o un comando sin instalación que tu cliente descarga en el primer arranque. Elige go install solo si ya tienes Go 1.27 o posterior y quieres compilar desde el código fuente. En Claude Desktop, la extensión .mcpb de un clic del último release es la opción más sencilla."
             }
           },
           {
@@ -112,15 +112,50 @@ import LegalNotice from "../../../components/docs/LegalNotice.astro";
 
 import { Tabs, TabItem, LinkCard, Aside } from "@astrojs/starlight/components";
 
-`libgen-mcp` se instala de tres formas: un binario estático precompilado desde la página de releases de GitHub, una imagen Docker (`ghcr.io/jmrplens/libgen-mcp`) o `go install`. No necesita cuenta, clave de API ni token. En cuanto queda registrado en un cliente MCP — Claude Code, Claude Desktop, Cursor o VS Code — sus cuatro herramientas (`search`, `get_details`, `download`, `read`) están disponibles de inmediato.
+`libgen-mcp` se instala de cuatro formas: desde npm como [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp), como binario estático precompilado desde la página de releases de GitHub, como imagen Docker (`ghcr.io/jmrplens/libgen-mcp`) o con `go install`. No necesita cuenta, clave de API ni token. En cuanto queda registrado en un cliente MCP — Claude Code, Claude Desktop, Cursor o VS Code — sus cuatro herramientas (`search`, `get_details`, `download`, `read`) están disponibles de inmediato.
 
 ## Instalación
 
-La instalación recomendada es el **binario precompilado**: un único ejecutable estático sin nada más que instalar — sin toolchain de Go, sin Docker, sin runtime. Docker y `go install` se ofrecen como alternativas.
+Si ya tienes Node, **npm** es el camino más corto — un solo comando, y tu cliente MCP puede lanzar el servidor con `npx` sin instalar nada. Si no, el **binario precompilado** es un único ejecutable estático sin nada más que instalar: sin toolchain de Go, sin Docker, sin runtime. Docker y `go install` se ofrecen como alternativas.
 
 <Tabs>
-	<TabItem label="Binario (recomendado)">
-		Descarga un binario precompilado para tu plataforma desde la página de [releases de GitHub](https://github.com/jmrplens/libgen-mcp/releases). Los archivos se llaman `libgen-mcp-<os>-<arch>` (por ejemplo `libgen-mcp-linux-amd64` o `libgen-mcp-darwin-arm64`), cubriendo Linux, macOS y Windows en amd64 y arm64.
+	<TabItem label="npm / npx">
+		El servidor se publica en npm como [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). Ese paquete es un lanzador ligero sobre los mismos binarios precompilados que sirve la página de releases: el ejecutable viaja dentro de un paquete por plataforma que npm desempaqueta solo cuando coinciden su `os` y su `cpu`, así que no se compila nada y no se ejecuta ningún script en la instalación — que es lo que mantiene funcionando `npx`, `npm ci --ignore-scripts` y las instalaciones sin red o tras un proxy.
+
+    	<Tabs syncKey="pkg">
+    		<TabItem label="npx">
+    			```bash
+    			npx @jmrp.io/libgen-mcp
+    			```
+
+    			No se instala nada de forma permanente. La mayoría de clientes MCP pueden lanzar el servidor así, que es la configuración con menos fricción posible:
+
+    			```json
+    			{
+    			  "mcpServers": {
+    			    "libgen": { "command": "npx", "args": ["-y", "@jmrp.io/libgen-mcp"] }
+    			  }
+    			}
+    			```
+    		</TabItem>
+    		<TabItem label="npm">
+    			```bash
+    			npm install -g @jmrp.io/libgen-mcp
+    			libgen-mcp --help
+    			```
+    		</TabItem>
+    		<TabItem label="pnpm">
+    			```bash
+    			pnpm add -g @jmrp.io/libgen-mcp
+    			libgen-mcp --help
+    			```
+    		</TabItem>
+    	</Tabs>
+
+    	Hay binarios precompilados para Linux, macOS y Windows en x64 y arm64. En cualquier otra plataforma el lanzador termina con un mensaje que apunta a los binarios del release y a la opción de compilar desde el código.
+    </TabItem>
+    <TabItem label="Binario">
+    	Descarga un binario precompilado para tu plataforma desde la página de [releases de GitHub](https://github.com/jmrplens/libgen-mcp/releases). Los archivos se llaman `libgen-mcp-<os>-<arch>` (por ejemplo `libgen-mcp-linux-amd64` o `libgen-mcp-darwin-arm64`), cubriendo Linux, macOS y Windows en amd64 y arm64.
 
     	```bash
     	# Ejemplo: Linux amd64
@@ -389,11 +424,11 @@ Consulta [Herramientas](/libgen-mcp/es/tools/#prompts) para ver la tabla complet
 
 ### ¿Cómo instalo libgen-mcp?
 
-La instalación recomendada es el binario precompilado: descarga el archivo para tu plataforma desde la página de [releases de GitHub](https://github.com/jmrplens/libgen-mcp/releases) (los archivos se llaman `libgen-mcp-<os>-<arch>`, cubriendo Linux, macOS y Windows en amd64 y arm64), hazlo ejecutable y colócalo en tu `PATH`. Es un único ejecutable totalmente estático sin nada más que instalar. Como alternativas puedes usar la imagen de Docker multi-arch `ghcr.io/jmrplens/libgen-mcp:latest` o, si ya tienes Go 1.27 o posterior, compilar desde el código fuente con `go install github.com/jmrplens/libgen-mcp/cmd/server@latest`.
+Si tienes Node 18 o posterior, el camino más corto es npm: ejecuta `npx @jmrp.io/libgen-mcp`, o instálalo globalmente con `npm install -g @jmrp.io/libgen-mcp`. Si no, usa el binario precompilado: descarga el archivo para tu plataforma desde la página de [releases de GitHub](https://github.com/jmrplens/libgen-mcp/releases) (los archivos se llaman `libgen-mcp-<os>-<arch>`, cubriendo Linux, macOS y Windows en amd64 y arm64), hazlo ejecutable y colócalo en tu `PATH`. Es un único ejecutable totalmente estático sin nada más que instalar. Como alternativas puedes usar la imagen de Docker multi-arch `ghcr.io/jmrplens/libgen-mcp:latest` o, si ya tienes Go 1.27 o posterior, compilar desde el código fuente con `go install github.com/jmrplens/libgen-mcp/cmd/server@latest`.
 
 ### ¿Qué método de instalación debería usar?
 
-Usa el binario precompilado en la mayoría de los casos: es un único ejecutable estático que no necesita toolchain de Go, ni Docker, ni runtime. Elige Docker si prefieres contenedores o un comando sin instalación que tu cliente descarga en el primer arranque. Elige `go install` solo si ya tienes Go 1.27 o posterior y quieres compilar desde el código fuente. En Claude Desktop, la extensión `.mcpb` de un clic del último release es la opción más sencilla.
+Usa npm si ya hay Node en la máquina: `npx @jmrp.io/libgen-mcp` no necesita paso de instalación y mantiene el servidor al día por sí solo. Si no, usa el binario precompilado: es un único ejecutable estático que no necesita toolchain de Go, ni Docker, ni runtime. Elige Docker si prefieres contenedores o un comando sin instalación que tu cliente descarga en el primer arranque. Elige `go install` solo si ya tienes Go 1.27 o posterior y quieres compilar desde el código fuente. En Claude Desktop, la extensión `.mcpb` de un clic del último release es la opción más sencilla.
 
 ### ¿Cómo conecto libgen-mcp a Claude o VS Code?
 

--- a/site/src/content/docs/es/getting-started.mdx
+++ b/site/src/content/docs/es/getting-started.mdx
@@ -116,11 +116,11 @@ import { Tabs, TabItem, LinkCard, Aside } from "@astrojs/starlight/components";
 
 ## Instalación
 
-Si ya tienes Node, **npm** es el camino más corto — un solo comando, y tu cliente MCP puede lanzar el servidor con `npx` sin instalar nada. Si no, el **binario precompilado** es un único ejecutable estático sin nada más que instalar: sin toolchain de Go, sin Docker, sin runtime. Docker y `go install` se ofrecen como alternativas.
+Si ya tienes Node 18 o posterior, **npm** es el camino más corto — un solo comando, y tu cliente MCP puede lanzar el servidor con `npx` sin instalar nada. Si no, el **binario precompilado** es un único ejecutable estático sin nada más que instalar: sin toolchain de Go, sin Docker, sin runtime. Docker y `go install` se ofrecen como alternativas.
 
 <Tabs>
 	<TabItem label="npm / npx">
-		El servidor se publica en npm como [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). Ese paquete es un lanzador ligero sobre los mismos binarios precompilados que sirve la página de releases: el ejecutable viaja dentro de un paquete por plataforma que npm desempaqueta solo cuando coinciden su `os` y su `cpu`, así que no se compila nada y no se ejecuta ningún script en la instalación — que es lo que mantiene funcionando `npx`, `npm ci --ignore-scripts` y las instalaciones sin red o tras un proxy.
+		El servidor se publica en npm como [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). Necesita Node 18 o posterior. El paquete es un lanzador ligero sobre los mismos binarios precompilados que sirve la página de releases: el ejecutable viaja dentro de un paquete por plataforma que npm desempaqueta solo cuando coinciden su `os` y su `cpu`, así que no se compila nada y no se ejecuta ningún script en la instalación. Como el ejecutable viaja dentro del paquete que npm descarga de todas formas, `npx` y `npm ci --ignore-scripts` funcionan igual, y también una instalación servida desde un mirror privado del registro — o desde la caché local con `--offline`, una vez que los tarballs están en ella.
 
     	<Tabs syncKey="pkg">
     		<TabItem label="npx">
@@ -151,6 +151,8 @@ Si ya tienes Node, **npm** es el camino más corto — un solo comando, y tu cli
     			```
     		</TabItem>
     	</Tabs>
+
+    	Una instalación global deja `libgen-mcp` en el directorio de binarios globales de tu gestor de paquetes. Si después el comando no aparece, ese directorio no está en tu `PATH` — `npm config get prefix` muestra el de npm, y el de pnpm lo configura `pnpm setup`.
 
     	Hay binarios precompilados para Linux, macOS y Windows en x64 y arm64. En cualquier otra plataforma el lanzador termina con un mensaje que apunta a los binarios del release y a la opción de compilar desde el código.
     </TabItem>

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -34,7 +34,7 @@ head:
             "@type": "HowToStep",
             "position": 1,
             "name": "Install the server",
-            "text": "Download the prebuilt static binary for your platform from the GitHub releases page, mark it executable and put it on your PATH. It is a single fully static executable with nothing else to install. Alternatively pull the multi-arch Docker image ghcr.io/jmrplens/libgen-mcp:latest, or build from source with go install if you have Go 1.27 or newer.",
+            "text": "If you have Node 18 or newer, run npx @jmrp.io/libgen-mcp, or install it globally with npm install -g @jmrp.io/libgen-mcp. Otherwise download the prebuilt static binary for your platform from the GitHub releases page, mark it executable and put it on your PATH: it is a single fully static executable with nothing else to install. You can also pull the multi-arch Docker image ghcr.io/jmrplens/libgen-mcp:latest, or build from source with go install if you have Go 1.27 or newer.",
             "url": "https://jmrplens.github.io/libgen-mcp/getting-started/#install"
           },
           {
@@ -76,7 +76,7 @@ head:
             "name": "How do I install libgen-mcp?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "The recommended install is the prebuilt binary: download the asset for your platform from the GitHub releases page (named libgen-mcp-<os>-<arch>, covering Linux, macOS, and Windows on amd64 and arm64), mark it executable, and put it on your PATH. It is a single fully static executable with nothing else to install. As alternatives, you can pull the multi-arch Docker image ghcr.io/jmrplens/libgen-mcp:latest, or build from source with go install github.com/jmrplens/libgen-mcp/cmd/server@latest if you have Go 1.27 or newer."
+              "text": "If you have Node 18 or newer, the shortest path is npm: run npx @jmrp.io/libgen-mcp, or install it globally with npm install -g @jmrp.io/libgen-mcp. Otherwise use the prebuilt binary: download the asset for your platform from the GitHub releases page (named libgen-mcp-<os>-<arch>, covering Linux, macOS, and Windows on amd64 and arm64), mark it executable, and put it on your PATH. It is a single fully static executable with nothing else to install. As alternatives, you can pull the multi-arch Docker image ghcr.io/jmrplens/libgen-mcp:latest, or build from source with go install github.com/jmrplens/libgen-mcp/cmd/server@latest if you have Go 1.27 or newer."
             }
           },
           {
@@ -84,7 +84,7 @@ head:
             "name": "Which install method should I use for libgen-mcp?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Use the prebuilt binary for most setups: it is a single static executable that needs no Go toolchain, no Docker, and no runtime. Choose Docker if you prefer containers or want a zero-install command your client pulls on first run. Choose go install only if you already have Go 1.27 or newer and want to build from source. On Claude Desktop, the one-click .mcpb extension from the latest release is the easiest option."
+              "text": "Use npm if Node is already on the machine: npx @jmrp.io/libgen-mcp needs no install step and keeps the server current on its own. Use the prebuilt binary otherwise: it is a single static executable that needs no Go toolchain, no Docker, and no runtime. Choose Docker if you prefer containers or want a zero-install command your client pulls on first run. Choose go install only if you already have Go 1.27 or newer and want to build from source. On Claude Desktop, the one-click .mcpb extension from the latest release is the easiest option."
             }
           },
           {
@@ -112,15 +112,50 @@ import LegalNotice from "../../components/docs/LegalNotice.astro";
 
 import { Tabs, TabItem, LinkCard, Aside } from "@astrojs/starlight/components";
 
-`libgen-mcp` installs three ways: a prebuilt static binary from the GitHub releases page, a Docker image (`ghcr.io/jmrplens/libgen-mcp`), or `go install`. It needs no account, API key or token. Once it is registered with an MCP client — Claude Code, Claude Desktop, Cursor or VS Code — its four tools (`search`, `get_details`, `download`, `read`) are available immediately.
+`libgen-mcp` installs four ways: from npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp), as a prebuilt static binary from the GitHub releases page, as a Docker image (`ghcr.io/jmrplens/libgen-mcp`), or with `go install`. It needs no account, API key or token. Once it is registered with an MCP client — Claude Code, Claude Desktop, Cursor or VS Code — its four tools (`search`, `get_details`, `download`, `read`) are available immediately.
 
 ## Install
 
-The recommended install is the **prebuilt binary**: a single static executable with nothing else to install — no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as alternatives.
+If you already have Node, **npm** is the shortest path — one command, and your MCP client can launch the server through `npx` without installing anything. Otherwise the **prebuilt binary** is a single static executable with nothing else to install: no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as alternatives.
 
 <Tabs>
-	<TabItem label="Binary (recommended)">
-		Download a prebuilt binary for your platform from the [GitHub releases](https://github.com/jmrplens/libgen-mcp/releases) page. Assets are named `libgen-mcp-<os>-<arch>` (for example `libgen-mcp-linux-amd64` or `libgen-mcp-darwin-arm64`), covering Linux, macOS, and Windows on both amd64 and arm64.
+	<TabItem label="npm / npx">
+		The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). That package is a thin launcher over the same prebuilt binaries the releases page serves: the executable rides inside a per-platform package that npm unpacks only when its `os` and `cpu` match, so nothing is compiled and no script runs at install time — which is what keeps `npx`, `npm ci --ignore-scripts`, offline and proxied installs working.
+
+    	<Tabs syncKey="pkg">
+    		<TabItem label="npx">
+    			```bash
+    			npx @jmrp.io/libgen-mcp
+    			```
+
+    			Nothing is installed permanently. Most MCP clients can launch the server this way, which is the lowest-friction configuration there is:
+
+    			```json
+    			{
+    			  "mcpServers": {
+    			    "libgen": { "command": "npx", "args": ["-y", "@jmrp.io/libgen-mcp"] }
+    			  }
+    			}
+    			```
+    		</TabItem>
+    		<TabItem label="npm">
+    			```bash
+    			npm install -g @jmrp.io/libgen-mcp
+    			libgen-mcp --help
+    			```
+    		</TabItem>
+    		<TabItem label="pnpm">
+    			```bash
+    			pnpm add -g @jmrp.io/libgen-mcp
+    			libgen-mcp --help
+    			```
+    		</TabItem>
+    	</Tabs>
+
+    	Prebuilt binaries exist for Linux, macOS and Windows on x64 and arm64. On any other platform the launcher exits with a message pointing at the release binaries and the option to build from source.
+    </TabItem>
+    <TabItem label="Binary">
+    	Download a prebuilt binary for your platform from the [GitHub releases](https://github.com/jmrplens/libgen-mcp/releases) page. Assets are named `libgen-mcp-<os>-<arch>` (for example `libgen-mcp-linux-amd64` or `libgen-mcp-darwin-arm64`), covering Linux, macOS, and Windows on both amd64 and arm64.
 
     	```bash
     	# Example: Linux amd64
@@ -385,11 +420,11 @@ See [Tools](/libgen-mcp/tools/#prompts) for each prompt's full argument table an
 
 ### How do I install libgen-mcp?
 
-The recommended install is the prebuilt binary: download the asset for your platform from the [GitHub releases](https://github.com/jmrplens/libgen-mcp/releases) page (named `libgen-mcp-<os>-<arch>`, covering Linux, macOS, and Windows on amd64 and arm64), mark it executable, and put it on your `PATH`. It is a single fully static executable with nothing else to install. As alternatives, you can pull the multi-arch Docker image `ghcr.io/jmrplens/libgen-mcp:latest`, or build from source with `go install github.com/jmrplens/libgen-mcp/cmd/server@latest` if you have Go 1.27 or newer.
+If you have Node 18 or newer, the shortest path is npm: run `npx @jmrp.io/libgen-mcp`, or install it globally with `npm install -g @jmrp.io/libgen-mcp`. Otherwise use the prebuilt binary: download the asset for your platform from the [GitHub releases](https://github.com/jmrplens/libgen-mcp/releases) page (named `libgen-mcp-<os>-<arch>`, covering Linux, macOS, and Windows on amd64 and arm64), mark it executable, and put it on your `PATH`. It is a single fully static executable with nothing else to install. As alternatives, you can pull the multi-arch Docker image `ghcr.io/jmrplens/libgen-mcp:latest`, or build from source with `go install github.com/jmrplens/libgen-mcp/cmd/server@latest` if you have Go 1.27 or newer.
 
 ### Which install method should I use for libgen-mcp?
 
-Use the prebuilt binary for most setups: it is a single static executable that needs no Go toolchain, no Docker, and no runtime. Choose Docker if you prefer containers or want a zero-install command your client pulls on first run. Choose `go install` only if you already have Go 1.27 or newer and want to build from source. On Claude Desktop, the one-click `.mcpb` extension from the latest release is the easiest option.
+Use npm if Node is already on the machine: `npx @jmrp.io/libgen-mcp` needs no install step and keeps the server current on its own. Use the prebuilt binary otherwise: it is a single static executable that needs no Go toolchain, no Docker, and no runtime. Choose Docker if you prefer containers or want a zero-install command your client pulls on first run. Choose `go install` only if you already have Go 1.27 or newer and want to build from source. On Claude Desktop, the one-click `.mcpb` extension from the latest release is the easiest option.
 
 ### How do I connect libgen-mcp to Claude or VS Code?
 

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -116,11 +116,11 @@ import { Tabs, TabItem, LinkCard, Aside } from "@astrojs/starlight/components";
 
 ## Install
 
-If you already have Node, **npm** is the shortest path — one command, and your MCP client can launch the server through `npx` without installing anything. Otherwise the **prebuilt binary** is a single static executable with nothing else to install: no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as alternatives.
+If you already have Node 18 or newer, **npm** is the shortest path — one command, and your MCP client can launch the server through `npx` without installing anything. Otherwise the **prebuilt binary** is a single static executable with nothing else to install: no Go toolchain, no Docker, no runtime. Docker and `go install` are offered as alternatives.
 
 <Tabs>
 	<TabItem label="npm / npx">
-		The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). That package is a thin launcher over the same prebuilt binaries the releases page serves: the executable rides inside a per-platform package that npm unpacks only when its `os` and `cpu` match, so nothing is compiled and no script runs at install time — which is what keeps `npx`, `npm ci --ignore-scripts`, offline and proxied installs working.
+		The server is published to npm as [`@jmrp.io/libgen-mcp`](https://www.npmjs.com/package/@jmrp.io/libgen-mcp). It needs Node 18 or newer. The package is a thin launcher over the same prebuilt binaries the releases page serves: the executable rides inside a per-platform package that npm unpacks only when its `os` and `cpu` match, so nothing is compiled and no script runs at install time. Because the executable travels inside the package npm downloads anyway, `npx` and `npm ci --ignore-scripts` both work, and so does an install served from a private registry mirror — or from the local cache with `--offline`, once the tarballs are in it.
 
     	<Tabs syncKey="pkg">
     		<TabItem label="npx">
@@ -151,6 +151,8 @@ If you already have Node, **npm** is the shortest path — one command, and your
     			```
     		</TabItem>
     	</Tabs>
+
+    	A global install puts `libgen-mcp` in your package manager's global binary directory. If the command is not found afterwards, that directory is not on your `PATH` — `npm config get prefix` shows npm's, and pnpm's is set up by `pnpm setup`.
 
     	Prebuilt binaries exist for Linux, macOS and Windows on x64 and arm64. On any other platform the launcher exits with a message pointing at the release binaries and the option to build from source.
     </TabItem>

--- a/site/src/lib/page-markdown.mjs
+++ b/site/src/lib/page-markdown.mjs
@@ -234,11 +234,24 @@ export function toMarkdown(source, labels, schema, chain) {
 	// A tab set has no Markdown equivalent, so each tab becomes a labelled
 	// section. Dropping the labels would silently merge alternatives that are
 	// meant to be read one instead of the other.
-	text = text.replace(/<\/?Tabs[^>]*>/g, "");
-	text = text.replace(
-		/<TabItem([^>]*)>([\s\S]*?)<\/TabItem>/g,
-		(_, tag, body) => `#### ${attr(tag, "label") ?? ""}\n${body.trim()}\n`,
-	);
+	//
+	// Tab sets nest — getting-started offers an npx/npm/pnpm choice inside its
+	// npm install method — so the innermost pair is rendered first and each pass
+	// works one level outwards. A single non-greedy pass would instead pair an
+	// outer <TabItem> with an inner </TabItem>, leaving the outer close tag in
+	// the output and shipping JSX in the Markdown copy. Every pass removes at
+	// least one tag, so the loop terminates.
+	// The indentation is taken with the tag: a nested <Tabs> is indented, and
+	// leaving its whitespace behind would emit a line of blanks that the
+	// blank-line collapse below cannot see.
+	text = text.replace(/[ \t]*<\/?Tabs[^>]*>/g, "");
+	const tabItem = "<TabItem([^>]*)>((?:(?!<TabItem)[\\s\\S])*?)</TabItem>";
+	while (new RegExp(tabItem).test(text)) {
+		text = text.replace(
+			new RegExp(tabItem, "g"),
+			(_, tag, body) => `#### ${attr(tag, "label") ?? ""}\n${body.trim()}\n`,
+		);
+	}
 
 	text = text.replace(/<LinkCard([^>]*)\/>/g, (_, tag) => {
 		const title = attr(tag, "title") ?? "";


### PR DESCRIPTION
## Summary

Adds npm as a distribution channel: the same released binaries, one more front
door — and the lowest-friction one for MCP clients, which mostly launch servers
with `npx`.

The shape is a thin launcher package (`@jmrp.io/libgen-mcp`) that depends on six
per-platform packages, each carrying one prebuilt binary and gated by npm's
`os`/`cpu` fields, so npm unpacks only the one that fits the machine. This is the
esbuild/biome model, and I picked it over a `postinstall` that downloads on
purpose: the binary riding inside the tarball is what keeps `npx`,
`npm ci --ignore-scripts`, offline and proxied installs working — a postinstall
download breaks all four, on exactly the locked-down machines an MCP server tends
to get dropped onto.

`npm/libgen-mcp/` (launcher, `cli.js`, README) is committed. The six per-platform
packages are generated from the release assets by `scripts/build-npm.mjs` at
publish time and are gitignored — they carry a ~15 MB executable each. `cli.js`
sits at the package **root** rather than in a `bin/` subdirectory because the
repo's global `bin/` ignore rule would silence it there and every published
tarball would ship without its entry point.

### The launcher keeps stdout pure

The server speaks MCP over stdio, so any stray byte on stdout corrupts the
JSON-RPC stream — for a stdio server that is a crash, not a warning. The launcher
resolves the platform binary via `require.resolve`, spawns it with
`stdio: "inherit"`, forwards argv verbatim, writes only to stderr, and mirrors the
child's exit code and terminating signal (re-raising the signal, and falling
through to `128 + signum` rather than a bare `exit 1`). It passes the environment
through untouched, so it needs to know none of the `LIBGEN_MCP_*` variables.

### Validation before anything is published

A published npm version is permanent, so `scripts/validate-npm.mjs` runs two
tiers and gates the publish:

- **Structural, all seven packages** — pack each tarball and check the exact file
  set, the binary's executable bit *inside the tarball*, its platform magic number
  (ELF / Mach-O / `MZ`), a size floor, the `os`/`cpu`/`name`/`version`, the
  launcher's `bin`, and that all six `optionalDependencies` are pinned to the
  version.
- **Runtime, the host-native platform** — install the launcher plus that platform
  package from their tarballs into a throwaway project, confirm npm resolved
  **only** the matching package, then drive a real MCP `initialize` handshake and
  assert every stdout line parses as JSON-RPC 2.0.

`make validate-npm` runs it in a clean `node:22` container so a developer's
machine is never touched; `make validate-npm-local` is the same check without
Docker, for the ephemeral CI runner.

I mutation-tested the validator rather than trusting a green run: stripping the
executable bit, corrupting a binary's magic number, unpinning one
`optionalDependency`, and adding a `console.log` to the launcher each produce the
expected failure.

### Release wiring

`release.yml` gains `setup-node`, a `Validate npm packages` step and a
`Publish to npm` step, between the `.mcpb` upload and the `server.json` pin.
Authentication is npm's **OIDC trusted publisher** — no stored token, no
`NODE_AUTH_TOKEN`, and no `--provenance` flag, since trusted publishing attaches
provenance itself. `npm@11.5.1` is pinned rather than `@latest` because that CLI
runs `npm publish` under the job's `id-token: write`. `publish-npm.sh` publishes
the platform packages first and the launcher last (an install racing the publish
must not find a launcher pinning packages the registry does not have yet) and
skips any version already on the registry, so re-running the job is safe.

`scripts/update-server-json-sha.sh` now stamps the launcher's version and all six
pins together — one generator call rather than a `jq` edit that could move the
version and leave the pins a release behind — the commit-back step stages
`npm/libgen-mcp/package.json`, and it is in `VERSION_MANIFESTS` so
`make check-manifests` fails a bump that skipped `make sync-npm-version`.

### Bootstrap

A package cannot have a trusted publisher configured until it exists, so all
seven were created with a one-time tokened publish and are live at 1.7.2. I
verified all three install paths against the real registry, each in an isolated
sandbox: `npx @jmrp.io/libgen-mcp`, `npm install -g` and `pnpm add -g` all
resolve **only** the host-native platform package and answer `initialize` with
pure JSON-RPC on stdout.

Still to do outside this PR: configure the trusted publisher on npmjs.com for
each of the seven packages (GitHub account `jmrplens`, repo `libgen-mcp`,
workflow `release.yml`, blank environment — the release job declares none), then
revoke the bootstrap token.

### Docs

npm version badge and an `npx`-first block in the README, an npm/npx section in
`docs/getting-started.md`, a new install method in `llms-install.md`, and the same
section in both locales of the site behind a Starlight `<Tabs>` set. The site's
Markdown mirror (`page-markdown.mjs`) learned to render **nested** tab sets on the
way — a single non-greedy pass paired an outer `<TabItem>` with an inner
`</TabItem>` and shipped raw JSX, which its own guard caught.

## Type of change

- [x] New feature
- [x] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [x] Tests added or updated for the change
- [x] Docs updated if behavior changed

## Summary by Sourcery

Publish libgen-mcp through npm with platform-specific binaries, release automation, validation, and user-facing installation guidance.

New Features:
- Add the @jmrp.io/libgen-mcp npm distribution with platform-specific binary packages for npx, npm, and pnpm installation.

Enhancements:
- Preserve pure MCP JSON-RPC stdio and child process exit behavior through the npm launcher.
- Add structural and host-native runtime validation for npm packages before publication.
- Keep npm package versions and platform dependency pins synchronized with releases and make retries safe.

Build:
- Add Makefile targets and scripts to assemble, validate, and publish the npm package set.

CI:
- Integrate npm package validation and OIDC-based npm publishing into the release workflow.

Documentation:
- Document npm and npx installation across the README, getting-started guides, LLM installation instructions, and both localized site versions.
- Update the site Markdown renderer to support nested tab components.

Tests:
- Add comprehensive npm tarball and runtime handshake validation, including platform selection and stdout JSON-RPC checks.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Added npm publishing support for libgen-mcp using OIDC trusted publisher.</li>
<li>Updated release workflow to include npm package validation and publishing.</li>
<li>Updated documentation to recommend npm as the primary installation method.</li>
<li>Refactored Markdown processing in the site generator to support nested tab components.</li>
<li>Added scripts to manage npm versioning and validation.</li>
</ul></div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds npm as a distribution channel: a thin launcher (`@jmrp.io/libgen-mcp`) plus six per-platform packages that each carry a prebuilt binary, letting MCP clients launch the server with `npx` (or install it via `npm`/`pnpm`) instead of downloading a binary or running Docker. The launcher inherits stdio and never writes to stdout, so the JSON-RPC stream stays pure.

**Validation**
- The release job validates all seven tarballs before publishing, since a published npm version is permanent.
- Structural checks verify the file set, the binary's executable bit inside the tarball, its platform magic number, a size floor, and the `os`/`cpu`/version pins.
- A runtime check installs the host-native pair from tarballs, confirms only the matching platform package resolves, and drives a real MCP `initialize` handshake asserting stdout parses as JSON-RPC 2.0.

**Release wiring**
- The workflow authenticates through npm's OIDC trusted publisher — no stored token — with `npm@11.5.1` pinned because that CLI version performs the OIDC exchange.
- `publish-npm.sh` publishes the six platform packages before the launcher and tolerates duplicates (skipping versions already on the registry and treating npm's own duplicate-version rejection as success), so re-running the job is safe.
- The launcher flushes its stderr diagnostics before exiting, so a startup failure message is never lost.
- `scripts/update-server-json-sha.sh` stamps the launcher version and all six dependency pins together, and the launcher is now gated by `make check-manifests`.
- Docs cover the npm/npx path (with pnpm as an equivalent install path) in the README, getting-started, `llms-install.md`, and both site locales; the site's Markdown mirror now renders nested tab sets.
- The seven packages are live at 1.7.2 from a one-time tokened publish; configure the trusted publisher on npmjs.com and revoke the bootstrap token outside this PR.

<sup>Written for commit ba3fb372f072de97e5895ffa944f3fc31ee4581d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added npm distribution with `npx` and global installation support.
  - Added platform-specific packages for supported operating systems and architectures.
  - Added npm publishing and release automation.

- **Documentation**
  - Updated installation guides and site content to prioritize npm/npx.
  - Added package documentation, configuration examples, supported-platform details, and troubleshooting guidance.

- **Bug Fixes**
  - Improved documentation tab rendering to prevent malformed Markdown from nested tabs.
  - Added comprehensive validation for package contents, platform selection, executable behavior, and MCP communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->