### PR TITLE
ci: run on every pull request, not only those based on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,18 @@
 # CI pipeline for libgen-mcp
 #
-# Runs on: pull requests to main, pushes to main
+# Runs on: every pull request whatever its base branch, pushes to main
 # Jobs: test (+coverage gate), build, golangci-lint, godoc, govulncheck, markdown,
 #       hadolint, docker build (PR + Docker changes only), docs-site (Astro lint + a11y-less checks)
 
 name: CI
 
 on:
+  # Deliberately unfiltered by base branch. A stacked pull request is based on
+  # the branch below it rather than on main, so a `branches: [main]` filter
+  # silently gives every layer but the bottom one no CI at all — the checks do
+  # not fail, they never run, which reads as "nothing to report". Pushes stay
+  # filtered: a branch that is not yet a pull request has nothing to gate.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,10 @@ name: CodeQL
 on:
   push:
     branches: [main]
+  # Unfiltered, for the same reason as ci.yml: a stacked pull request is based
+  # on the branch below it, and a base-branch filter would leave every layer
+  # above the bottom one unanalyzed.
   pull_request:
-    branches: [main]
   schedule:
     - cron: "26 14 * * 2"
 


### PR DESCRIPTION
## Summary

Both `ci.yml` and `codeql.yml` filtered their `pull_request` trigger to `branches: [main]`.
A stacked pull request is based on the branch below it, not on `main`, so every layer above
the bottom one matched neither trigger and got **no CI at all**.

That is worse than a failure, because it does not look like one: on stack #131, PR #129 shows
"2 pass, 2 skipping" — four bot checks and no pipeline — which reads as a clean run unless you
count the checks against a sibling PR's twenty-two.

Only the `pull_request` filter is dropped. `push` stays scoped to `main`: a branch that is not
yet a pull request has nothing to gate, and leaving it unfiltered would run the whole pipeline
twice for every branch that later opens one.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / maintenance
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] `make test` passes
- [x] `make lint` passes (golangci-lint + govulncheck)
- [ ] Tests added or updated for the change
- [x] Docs updated if behavior changed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs CI and CodeQL on every pull request, not just those based on `main`, so stacked PRs no longer silently skip all checks.

**CI trigger change**
- Removed the `branches: [main]` filter from the `pull_request` trigger in both `.github/workflows/ci.yml` and `.github/workflows/codeql.yml`.
- Stacked PRs are based on the branch below them, so the old filter gave every layer above the bottom one no pipeline at all — which reads as a clean run rather than a gap.
- Pushes stay scoped to `main`; a branch that is not yet a PR has nothing to gate, and unfiltered pushes would run the pipeline twice per branch.

<sup>Written for commit 6a85be197835e92b8f5205f719a2e54a43e3078f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmrplens/libgen-mcp/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Run pull request CI and CodeQL workflows for every base branch so stacked pull requests receive the expected checks.

Bug Fixes:
- Ensure CI and CodeQL checks run for pull requests targeting any base branch, including stacked pull requests.

CI:
- Remove the main-branch restriction from pull request triggers while retaining the main-branch restriction for push triggers.